### PR TITLE
Compile, test and deploy BES using standard configuration

### DIFF
--- a/besd.in
+++ b/besd.in
@@ -12,6 +12,8 @@
 # Path to the besctl script. Note: If the BES is installed using a prefix
 # that is not set in the besctl script, add '-i <bes_prefix>' to the value
 # of besctl here. This should only be needed in unusual situations.
+prefix=@prefix@
+exec_prefix=@exec_prefix@
 besctl=@bindir@/besctl
 prog=besd
 RETVAL=0

--- a/configure_standard.ac
+++ b/configure_standard.ac
@@ -10,6 +10,8 @@ AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS([config.h])
 
 AM_CONDITIONAL([DAP_MODULES], [false])
+AM_CONDITIONAL([WITH_DEPENDENCIES], [false])
+AM_CONDITIONAL([BUILD_GDAL], [false])
 
 PACKAGE_MAJOR_VERSION=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)$@\1@'`
 PACKAGE_MINOR_VERSION=`echo $PACKAGE_VERSION | sed 's@^\([[0-9]]\)*\.\([[0-9]]*\)\.\([[0-9]]*\)$@\2@'`
@@ -295,7 +297,6 @@ AC_CONFIG_FILES([Makefile
 		 dapreader/Makefile
 		 dapreader/tests/Makefile
 		 dapreader/tests/atlocal
-		 dapreader/tests/package.m4
 
 		 dap/Makefile
 		 dap/unit-tests/Makefile
@@ -304,14 +305,9 @@ AC_CONFIG_FILES([Makefile
 		 functions/Makefile
 		 functions/tests/Makefile
 		 functions/tests/atlocal
- 		 functions/tests/package.m4
-		 functions/unit-tests/Makefile])
+		 functions/unit-tests/Makefile
+		 functions/swath2grid/Makefile])
 		 
-if test -n "$GDAL_FOUND"
-then
-    AC_CONFIG_FILES([functions/swath2grid/Makefile])
-fi
-
 AC_CONFIG_FILES([cmdln/testsuite/generate_data_baseline.sh], [chmod +x cmdln/testsuite/generate_data_baseline.sh])
 AC_CONFIG_FILES([cmdln/testsuite/generate_metadata_baseline.sh], [chmod +x cmdln/testsuite/generate_metadata_baseline.sh])
 

--- a/dapreader/Makefile.am
+++ b/dapreader/Makefile.am
@@ -39,7 +39,7 @@ $(top_builddir)/dispatch/libbes_dispatch.la
 libdapreader_module_la_SOURCES = $(BES_SRCS) $(BES_HDRS)
 libdapreader_module_la_CPPFLAGS = $(DAP_CFLAGS) $(AM_CPPFLAGS)
 libdapreader_module_la_LDFLAGS = -avoid-version -module 
-libdapreader_module_la_LIBADD = $(DAP_CLIENT_LIBS) -ltest-types 
+libdapreader_module_la_LIBADD = $(DAP_SERVER_LIBS) $(DAP_CLIENT_LIBS) -ltest-types 
 
 EXTRA_PROGRAMS = 
 


### PR DESCRIPTION
Attempting to build a standard configuration of the BES using just the
modules that I need and without all of the dependencies that I don't
need. So using the configure_standard.ac configuration file.

The besd.in file which builds the besd initialization script that goes
into /etc/init.d was not setting up the prefix variables correctly so
the bes was not launching using that script.

configure_standard.ac seemed to have not been updated with the other
configuration file as it appears to be working.

dapreader Makefile.am was missing the inclusion of the dap server libs
to resolve the Ancillary methods used, specificall reading a das
ancillary file.