### PR TITLE
Function promoter

### DIFF
--- a/README
+++ b/README
@@ -5,11 +5,11 @@ Updated for version 3.16.
 
 See the INSTALL file for build instructions, including special
 instructions for building from a (git) cloned repo. This code can
-build one of two disticnt ways and that requires a tiny bit setup.
+build one of two distinct ways and that requires a tiny bit setup.
 
 For more information on Hyrax and the BES, please visit our documentation
 wiki at docs.opendap.org. This will include the latest install and build
-instructions, the latest configuration inforamtion, tutorials, how to
+instructions, the latest configuration information, tutorials, how to
 develop new modules for the BES, and more.
 
 This version has significant performance improvements for aggregations,

--- a/dap/BESDapResponseBuilder.cc
+++ b/dap/BESDapResponseBuilder.cc
@@ -816,6 +816,20 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS &dds, Const
         if (with_mime_headers)
             set_mime_binary(data_stream, dods_data, x_plain, last_modified_time(d_dataset), dds.get_dap_version());
 
+
+        if(fdds->num_var()==1){
+            BaseType *bt = fdds->get_var_index(0);
+            libdap::Constructor *collection = dynamic_cast<libdap::Constructor *>(bt);
+            if(collection){
+                libdap::Collection::Vars_iter vi;
+                for(vi=collection->var_begin(); vi!=collection->var_end(); vi++){
+                    BaseType resultBT =
+                }
+            }
+        }
+
+
+
 #if FUNCTION_CACHING
         // This means: if we are not supposed to store the result, then serialize it.
         if (!store_dap2_result(data_stream, dds, eval)) {

--- a/dap/BESDapResponseBuilder.cc
+++ b/dap/BESDapResponseBuilder.cc
@@ -526,7 +526,7 @@ static DDS *promote_function_output_structure(DDS *fdds)
     // Look in the top level of the DDS for a promotable member - i.e. a member
     // variable that is a collection and whose name ends with "_unwrap"
     bool found_promotable_member = false;
-    for (DDS::Vars_citer di = fdds->var_begin(), de = fdds->var_end(); di != de; ++di) {
+    for (DDS::Vars_citer di = fdds->var_begin(), de = fdds->var_end(); di != de && !found_promotable_member; ++di) {
         Structure *collection = dynamic_cast<Structure *>(*di);
         if (collection && ends_with(collection->name(), "_unwrap")) {
             found_promotable_member = true;

--- a/dap/BESDapResponseBuilder.h
+++ b/dap/BESDapResponseBuilder.h
@@ -69,9 +69,6 @@ protected:
 	 */
 	std::string d_store_result;
 
-
-	// BESDapResponseCache *d_response_cache;
-
 	void initialize();
 	bool store_dap2_result(ostream &out, libdap::DDS &dds, libdap::ConstraintEvaluator &eval);
 
@@ -124,13 +121,6 @@ public:
 
 	virtual void split_ce(libdap::ConstraintEvaluator &eval, const std::string &expr = "");
 
-#if 0
-	// I dumped this because it's pattern of use was super confiusing. Holding a pointer to a singleton cache that is responsible
-	// for destructing itself and then trying to delete the referenced object was breaking many things in a subtle and hard
-	// to discern manner.
-	virtual BESDapResponseCache *responseCache();
-#endif
-
 	virtual void send_das(std::ostream &out, libdap::DAS &das, bool with_mime_headers = true) const;
 	virtual void send_das(std::ostream &out, libdap::DDS &dds, libdap::ConstraintEvaluator &eval, bool constrained =
 			false, bool with_mime_headers = true);
@@ -156,7 +146,7 @@ public:
 	virtual void serialize_dap4_data(std::ostream &out, libdap::DMR &dmr, bool with_mime_headers = true);
 	virtual bool store_dap4_result(ostream &out, libdap::DMR &dmr);
 
-    virtual void promoteFunctionOutputStructure(libdap::DDS **dds);
+    //virtual void promote_function_output_structure(libdap::DDS **dds);
 };
 
 #endif // _response_builder_h

--- a/dap/BESDapResponseBuilder.h
+++ b/dap/BESDapResponseBuilder.h
@@ -155,6 +155,8 @@ public:
 
 	virtual void serialize_dap4_data(std::ostream &out, libdap::DMR &dmr, bool with_mime_headers = true);
 	virtual bool store_dap4_result(ostream &out, libdap::DMR &dmr);
+
+    virtual void promoteFunctionOutputStructure(libdap::DDS **dds);
 };
 
 #endif // _response_builder_h

--- a/functions/TabularSequence.cc
+++ b/functions/TabularSequence.cc
@@ -28,7 +28,7 @@
 #include <string>
 #include <sstream>
 
-#define DODS_DEBUG
+//#define DODS_DEBUG
 
 #include <BaseType.h>
 #include <Byte.h>

--- a/functions/TabularSequence.h
+++ b/functions/TabularSequence.h
@@ -63,9 +63,29 @@ protected:
     void load_prototypes_with_values(libdap::BaseTypeRow &btr, bool safe = true);
 
 public:
+    /** The Sequence constructor requires only the name of the variable
+        to be created.  The name may be omitted, which will create a
+        nameless variable.  This may be adequate for some applications.
+
+        @param n A string containing the name of the variable to be
+        created.
+
+        @brief The Sequence constructor. */
     TabularSequence(const string &n) : Sequence(n) { }
+
+    /** The Sequence server-side constructor requires the name of the variable
+        to be created and the dataset name from which this variable is being
+        created.
+
+        @param n A string containing the name of the variable to be
+        created.
+        @param d A string containing the name of the dataset from which this
+        variable is being created.
+
+        @brief The Sequence server-side constructor. */
     TabularSequence(const string &n, const string &d) : Sequence(n, d) { }
 
+    /** @brief The Sequence copy constructor. */
     TabularSequence(const TabularSequence &rhs) : Sequence(rhs) { }
 
     virtual ~TabularSequence() { }

--- a/functions/tests/Makefile.am
+++ b/functions/tests/Makefile.am
@@ -55,17 +55,12 @@ $(TESTSUITE): $(TESTSUITE).at $(srcdir)/handler_tests_macros.m4 $(srcdir)/packag
 
 check-local: atconfig atlocal $(TESTSUITE)
 	@echo "Run tests with an empty cache"
-	-$(SHELL) '$(TESTSUITE)' $(TESTSUITEFLAGS)
-	-rm -f dap_cache
+	$(SHELL) '$(TESTSUITE)' $(TESTSUITEFLAGS)
+	-rm -rf dap_cache/*
 	
-# When caching is working again for function results, add this back into the 
-# target's actions. jhrg 10/20/15
-# 	@echo "Run tests with a full cache"
-#	-$(SHELL) '$(TESTSUITE)' $(TESTSUITEFLAGS)
-
 clean-local:
 	test ! -f '$(TESTSUITE)' || $(SHELL) '$(TESTSUITE)' --clean
-	-rm -f dap_cache
+	-rm -rf dap_cache/*
 	-rm -f $(TESTSUITE) $(srcdir)/package.m4 
 
 AUTOTEST = $(AUTOM4TE) --language=autotest


### PR DESCRIPTION
This branch holds a fix (hack really) that Nathan and I made to the bes/dap code so that when functions package up multiple BaseType*s they will appear in the result DDS as BaseType*s at the top level, not wrapped in a Structure. This means that more clients will be able to work with the results of server functions. We adopted the convention that the returned Structure would only be flattened if it's name ends with _unwrap. Yeah, it's a hack. The alternative is ugly.

This does not address a similar issue with DAP4 - now might be the time to do that...