### PR TITLE
Logrotate

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,7 @@ aclocaldir=$(datadir)/aclocal
 dist_aclocal_DATA = conf/bes.m4
 
 EXTRA_DIST = apache hello_world doxy.conf.in bes.spec \
-OSX_Resources bes-config-pkgconfig
+OSX_Resources bes-config-pkgconfig besd.logrotate
 
 server-tests:
 	cd cmdln && make server-tests

--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,10 @@ bin_SCRIPTS = bes-config bes-config-pkgconfig
 # with-out a second underscore.
 init_ddir = $(sysconfdir)/rc.d/init.d
 init_d_SCRIPTS = besd
+
+logrotate_ddir = $(sysconfdir)/logrotate.d
+logrotate_d_DATA = besd.logrotate
+
 CLEANFILES = $(init_d_SCRIPTS)
 
 pkgconfigdir=$(libdir)/pkgconfig

--- a/bes.spec
+++ b/bes.spec
@@ -151,20 +151,10 @@ exit 0
 
 %config(noreplace) %{_sysconfdir}/bes/bes.conf
 %config(noreplace) %{_sysconfdir}/bes/modules/*.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/functions.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/csv.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/dap-server.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/dapreader.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/ff.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/fojson.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/fonc.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/gateway.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/h4.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/h5.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/nc.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/ncml.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/w10n.conf
-# %config(noreplace) %{_sysconfdir}/bes/modules/xml_data_handler.conf
+
+# Added 10/25/16 jhrg. See below for the installation of the logrotate file.
+%dir %{_sysconfdir}/logrotate.d
+%config(noreplace) %{_sysconfdir}/logrotate.d/besd.logrotate
 
 %dir %{_datadir}/bes/
 %{_datadir}/bes/*.html

--- a/bes.spec.all_static
+++ b/bes.spec.all_static
@@ -160,6 +160,10 @@ exit 0
 %config(noreplace) %{_sysconfdir}/bes/bes.conf
 %config(noreplace) %{_sysconfdir}/bes/modules/*.conf
 
+# Added 10/25/16 jhrg. See below for the installation of the logrotate file.
+%dir %{_sysconfdir}/logrotate.d
+%config(noreplace) %{_sysconfdir}/logrotate.d/besd.logrotate
+
 %dir %{_datadir}/bes/
 %{_datadir}/bes/*.html
 %{_datadir}/bes/*.txt

--- a/bes.spec.nasa
+++ b/bes.spec.nasa
@@ -155,6 +155,10 @@ exit 0
 %config(noreplace) %{_sysconfdir}/bes/bes.conf
 %config(noreplace) %{_sysconfdir}/bes/modules/*.conf
 
+# Added 10/25/16 jhrg. See below for the installation of the logrotate file.
+%dir %{_sysconfdir}/logrotate.d
+%config(noreplace) %{_sysconfdir}/logrotate.d/besd.logrotate
+
 %dir %{_datadir}/bes/
 %{_datadir}/bes/*.html
 %{_datadir}/bes/*.txt

--- a/besd.logrotate
+++ b/besd.logrotate
@@ -1,0 +1,9 @@
+/var/log/bes/*log {
+    missingok
+    notifempty
+    sharedscripts
+    delaycompress
+    postrotate
+        /sbin/service besd restart > /dev/null 2>/dev/null || true
+    endscript
+}


### PR DESCRIPTION
This branch, tested on CentOS 6, adds a logrotate control file so the bes.log file in /var/log/bes will be rotated like all other unix logs. The file is copied into /etc/logrotate.d when the RPM is installed.
