### PR TITLE
Dispatch test fix

### DIFF
--- a/dispatch/BESContainerStorageVolatile.cc
+++ b/dispatch/BESContainerStorageVolatile.cc
@@ -44,6 +44,10 @@
  *
  * Creates an instances of BESContainerStorageVolatile with the given name.
  *
+ * @note This constructor will fail with an Internal Fatal Error if the BES
+ * Keys file cannot be read. That is, the if the singleton TheBESKeys cannot
+ * be initialized, the access to the BES keys will throw a BESInternalFatalError.
+ *
  * @param n name of this persistent store
  * @see BESContainer
  */
@@ -258,7 +262,7 @@ bool BESContainerStorageVolatile::isData(const string &inQuestion, list<string> 
 
 /** @brief show information for each container in this persistent store
  *
- * For each container in this persistent store, add infomation about each of
+ * For each container in this persistent store, add information about each of
  * those containers. The information added to the information object
  * includes a line for each container within this persistent store which 
  * includes the symbolic name, the real name, and the data type, 

--- a/dispatch/BESFSFile.cc
+++ b/dispatch/BESFSFile.cc
@@ -40,194 +40,159 @@
 
 #include "BESFSFile.h"
 
-BESFSFile::BESFSFile(const string &fullPath)
-        : _dirName(""),
-        _fileName(""),
-        _baseName(""),
-        _extension("")
+BESFSFile::BESFSFile(const string &fullPath) :
+    _dirName(""), _fileName(""), _baseName(""), _extension("")
 {
-    breakApart(fullPath) ;
+    breakApart(fullPath);
 }
 
-BESFSFile::BESFSFile(const string &dirName, const string &fileName)
-        : _dirName(dirName),
-        _fileName(fileName),
-        _baseName(""),
-        _extension("")
+BESFSFile::BESFSFile(const string &dirName, const string &fileName) :
+    _dirName(dirName), _fileName(fileName), _baseName(""), _extension("")
 {
-    breakExtension() ;
+    breakExtension();
 }
 
-BESFSFile::BESFSFile(const BESFSFile &copyFrom)
-        : _dirName(copyFrom._dirName),
-        _fileName(copyFrom._fileName),
-        _baseName(copyFrom._baseName),
-        _extension(copyFrom._extension)
-{}
+BESFSFile::BESFSFile(const BESFSFile &copyFrom) :
+    _dirName(copyFrom._dirName), _fileName(copyFrom._fileName), _baseName(copyFrom._baseName), _extension(
+        copyFrom._extension)
+{
+}
 
 BESFSFile::~BESFSFile()
-{}
-
-string
-BESFSFile::getDirName()
 {
-    return _dirName ;
 }
 
-string
-BESFSFile::getFileName()
+string BESFSFile::getDirName()
 {
-    return _fileName ;
+    return _dirName;
 }
 
-string
-BESFSFile::getBaseName()
+string BESFSFile::getFileName()
 {
-    return _baseName ;
+    return _fileName;
 }
 
-string
-BESFSFile::getExtension()
+string BESFSFile::getBaseName()
 {
-    return _extension ;
+    return _baseName;
 }
 
-string
-BESFSFile::getFullPath()
+string BESFSFile::getExtension()
 {
-    return _dirName + "/" + _fileName ;
+    return _extension;
 }
 
-void
-BESFSFile::breakApart(const string &fullPath)
+string BESFSFile::getFullPath()
 {
-    string::size_type pos = fullPath.rfind("/") ;
+    return _dirName + "/" + _fileName;
+}
+
+void BESFSFile::breakApart(const string &fullPath)
+{
+    string::size_type pos = fullPath.rfind("/");
     if (pos != string::npos) {
-        _dirName = fullPath.substr(0, pos) ;
-        _fileName = fullPath.substr(pos + 1, fullPath.length() - pos) ;
+        _dirName = fullPath.substr(0, pos);
+        _fileName = fullPath.substr(pos + 1, fullPath.length() - pos);
     }
     else {
-        _dirName = "./" ;
-        _fileName = fullPath ;
+        _dirName = "./";
+        _fileName = fullPath;
     }
 
-    breakExtension() ;
+    breakExtension();
 }
 
-void
-BESFSFile::breakExtension()
+void BESFSFile::breakExtension()
 {
-    string::size_type pos = _fileName.rfind(".") ;
+    string::size_type pos = _fileName.rfind(".");
     if (pos != string::npos) {
-        _baseName = _fileName.substr(0, pos) ;
-        _extension = _fileName.substr(pos + 1, _fileName.length() - pos) ;
+        _baseName = _fileName.substr(0, pos);
+        _extension = _fileName.substr(pos + 1, _fileName.length() - pos);
     }
     else {
-        _baseName = _fileName ;
+        _baseName = _fileName;
     }
 }
 
-bool
-BESFSFile::exists( string &reason )
+bool BESFSFile::exists(string &reason)
 {
-    bool ret = false ;
-    if( !access( getFullPath().c_str(), F_OK ) )
-    {
-	ret = true ;
+    bool ret = false;
+    if (!access(getFullPath().c_str(), F_OK)) {
+        ret = true;
     }
-    else
-    {
-	char *err = strerror( errno ) ;
-	if( err )
-	{
-	    reason += err ;
-	}
-	else
-	{
-	    reason += "Unknown error" ;
-	}
+    else {
+        char *err = strerror(errno);
+        if (err) {
+            reason += err;
+        }
+        else {
+            reason += "Unknown error";
+        }
     }
-    return ret ;
+    return ret;
 }
 
-bool
-BESFSFile::isReadable( string &reason )
+bool BESFSFile::isReadable(string &reason)
 {
-    bool ret = false ;
-    if( !access( getFullPath().c_str(), R_OK ) )
-    {
-	ret = true ;
+    bool ret = false;
+    if (!access(getFullPath().c_str(), R_OK)) {
+        ret = true;
     }
-    else
-    {
-	char *err = strerror( errno ) ;
-	if( err )
-	{
-	    reason += err ;
-	}
-	else
-	{
-	    reason += "Unknown error" ;
-	}
+    else {
+        char *err = strerror(errno);
+        if (err) {
+            reason += err;
+        }
+        else {
+            reason += "Unknown error";
+        }
     }
-    return ret ;
+    return ret;
 }
 
-bool
-BESFSFile::isWritable( string &reason )
+bool BESFSFile::isWritable(string &reason)
 {
-    bool ret = false ;
-    if( !access( getFullPath().c_str(), W_OK ) )
-    {
-	ret = true ;
+    bool ret = false;
+    if (!access(getFullPath().c_str(), W_OK)) {
+        ret = true;
     }
-    else
-    {
-	char *err = strerror( errno ) ;
-	if( err )
-	{
-	    reason += err ;
-	}
-	else
-	{
-	    reason += "Unknown error" ;
-	}
+    else {
+        char *err = strerror(errno);
+        if (err) {
+            reason += err;
+        }
+        else {
+            reason += "Unknown error";
+        }
     }
-    return ret ;
+    return ret;
 }
 
-bool
-BESFSFile::isExecutable( string &reason )
+bool BESFSFile::isExecutable(string &reason)
 {
-    bool ret = false ;
-    if( !access( getFullPath().c_str(), X_OK ) )
-    {
-	ret = true ;
+    bool ret = false;
+    if (!access(getFullPath().c_str(), X_OK)) {
+        ret = true;
     }
-    else
-    {
-	char *err = strerror( errno ) ;
-	if( err )
-	{
-	    reason += err ;
-	}
-	else
-	{
-	    reason += "Unknown error" ;
-	}
+    else {
+        char *err = strerror(errno);
+        if (err) {
+            reason += err;
+        }
+        else {
+            reason += "Unknown error";
+        }
     }
-    return ret ;
+    return ret;
 }
 
-bool
-BESFSFile::hasDotDot()
+bool BESFSFile::hasDotDot()
 {
-    bool ret = false ;
-    string fp = getFullPath() ;
-    if( fp.find( ".." ) != string::npos )
-    {
-	ret = true ;
+    bool ret = false;
+    string fp = getFullPath();
+    if (fp.find("..") != string::npos) {
+        ret = true;
     }
-    return ret ;
+    return ret;
 }
 

--- a/dispatch/BESKeys.cc
+++ b/dispatch/BESKeys.cc
@@ -32,16 +32,6 @@
 
 #include "config.h"
 
-#if 0
-#ifdef __cplusplus
-extern "C"
-{
-#include <sys/types.h>
-//#include "regex.h"
-}
-#endif
-#endif
-
 #include <cerrno>
 #include <cstring>
 
@@ -79,7 +69,7 @@ vector<string> BESKeys::KeyList;
 BESKeys::BESKeys(const string &keys_file_name) :
     _keys_file(0), _keys_file_name(keys_file_name), _the_keys(0), _own_keys(true)
 {
-    _the_keys = new map<string, vector<string> > ;
+    _the_keys = new map<string, vector<string> >;
     initialize_keys();
 }
 
@@ -99,9 +89,8 @@ BESKeys::~BESKeys()
 void BESKeys::initialize_keys()
 {
     _keys_file = new ifstream(_keys_file_name.c_str());
-    //int myerrno = errno;
-    if (!(*_keys_file))
-    {
+
+    if (!(*_keys_file)) {
         char path[500];
         getcwd(path, sizeof(path));
         string s = string("BES: fatal, cannot open BES configuration file ") + _keys_file_name + ": ";
@@ -111,39 +100,35 @@ void BESKeys::initialize_keys()
         else
             s += "Unknown error";
 
-        s += (string) ".\n" + "The current working directory is " + path + "\n";
+        s += (string) ".\n" + "The current working directory is " + path;
         throw BESInternalFatalError(s, __FILE__, __LINE__);
     }
 
-    try
-    {
+    try {
         load_keys();
     }
-    catch (BESError &e)
-    {
+    catch (BESError &e) {
         // be sure we're throwing a fatal error, since the BES can't run
         // within the configuration file
         clean();
         throw BESInternalFatalError(e.get_message(), e.get_file(), e.get_line());
     }
-    catch (...)
-    {
+    catch (...) {
         clean();
-        string s = (string) "Undefined exception while trying to load keys " + "from bes configuration file " + _keys_file_name;
+        string s = (string) "Undefined exception while trying to load keys from bes configuration file "
+            + _keys_file_name;
         throw BESInternalFatalError(s, __FILE__, __LINE__);
     }
 }
 
 void BESKeys::clean()
 {
-    if (_keys_file)
-    {
+    if (_keys_file) {
         _keys_file->close();
         delete _keys_file;
     }
 
-    if (_the_keys && _own_keys)
-    {
+    if (_the_keys && _own_keys) {
         delete _the_keys;
     }
 }
@@ -159,71 +144,34 @@ bool BESKeys::LoadedKeys(const string &key_file)
 {
     vector<string>::const_iterator i = BESKeys::KeyList.begin();
     vector<string>::const_iterator e = BESKeys::KeyList.end();
-    for (; i != e; i++)
-    {
-        if ((*i) == key_file)
-        {
+    for (; i != e; i++) {
+        if ((*i) == key_file) {
             return true;
         }
     }
+
     return false;
 }
 
 void BESKeys::load_keys()
 {
-#if 0 // Replaced this use of character buffer code with the string based version below. ndp 09/09/2015
-	char buffer[255];
-    string key, value;
-    while (!(*_keys_file).eof())
-    {
-        if ((*_keys_file).getline(buffer, 255))
-        {
-            bool addto = false;
-            if (break_pair(buffer, key, value, addto))
-            {
-                if (key == BES_INCLUDE_KEY)
-                {
-                    // I added this call to set_key() because we need access
-                    // to the child config files for the admin interface.
-                    // jhrg 5/27/11
-                    // Force 'addto' to true; we need all of the include values.
-                    // jhrg 6/21/11
-                    set_key(key, value, true);
-                    load_include_files(value);
-                }
-                else
-                {
-                    set_key(key, value, addto);
-                }
-            }
-        }
-    }
-#endif
-
-
     string key, value, line;
-    while(!_keys_file->eof() )
-    {
+    while (!_keys_file->eof()) {
         bool addto = false;
-        getline( *_keys_file, line );
-        if (break_pair(line.c_str(), key, value, addto))
-        {
-            if (key == BES_INCLUDE_KEY)
-            {
+        getline(*_keys_file, line);
+        if (break_pair(line.c_str(), key, value, addto)) {
+            if (key == BES_INCLUDE_KEY) {
                 // We make this call to set_key() and force 'addto' to
-            	// be true because we need access to the child configuration
-            	// files and their values for the admin interface.
+                // be true because we need access to the child configuration
+                // files and their values for the admin interface.
                 set_key(key, value, true);
                 load_include_files(value);
             }
-            else
-            {
+            else {
                 set_key(key, value, addto);
             }
         }
-
     }
-
 }
 
 // The string contained in the character buffer b should be of the
@@ -238,39 +186,33 @@ inline bool BESKeys::break_pair(const char* b, string& key, string &value, bool 
 {
     addto = false;
     // Ignore comments and lines with only spaces
-    if (b && (b[0] != '#') && (!only_blanks(b)))
-    {
+    if (b && (b[0] != '#') && (!only_blanks(b))) {
         register size_t l = strlen(b);
-        if (l > 1)
-        {
+        if (l > 1) {
             int pos = 0;
             bool done = false;
-            for (register size_t j = 0; j < l && !done; j++)
-            {
-                if (b[j] == '=')
-                {
+            for (register size_t j = 0; j < l && !done; j++) {
+                if (b[j] == '=') {
                     if (!addto)
                         pos = j;
-                    else
-                    {
-                        if (pos != static_cast<int> (j - 1))
-                        {
+                    else {
+                        if (pos != static_cast<int>(j - 1)) {
                             string s = string("BES: Invalid entry ") + b + " in configuration file " + _keys_file_name
-                                    + " '+' character found in variable name" + " or attempting '+=' with space" + " between the characters.\n";
+                                + " '+' character found in variable name" + " or attempting '+=' with space"
+                                + " between the characters.\n";
                             throw BESInternalFatalError(s, __FILE__, __LINE__);
                         }
                     }
                     done = true;
                 }
-                else if (b[j] == '+')
-                {
+                else if (b[j] == '+') {
                     addto = true;
                     pos = j;
                 }
             }
-            if (!done)
-            {
-                string s = string("BES: Invalid entry ") + b + " in configuration file " + _keys_file_name + ": " + " '=' character not found.\n";
+            if (!done) {
+                string s = string("BES: Invalid entry ") + b + " in configuration file " + _keys_file_name + ": "
+                    + " '=' character not found.\n";
                 throw BESInternalFatalError(s, __FILE__, __LINE__);
             }
 
@@ -308,12 +250,10 @@ void BESKeys::load_include_files(const string &files)
 
     // If the files specified begin with a /, then use that directory
     // instead of the current keys file directory.
-    if (!files.empty() && files[0] == '/')
-    {
+    if (!files.empty() && files[0] == '/') {
         newdir = allfiles.getDirName();
     }
-    else
-    {
+    else {
         // determine the directory of the current keys file. All included
         // files will be relative to this file.
         BESFSFile currfile(_keys_file_name);
@@ -321,18 +261,14 @@ void BESKeys::load_include_files(const string &files)
 
         string alldir = allfiles.getDirName();
 
-        if ((currdir == "./" || currdir == ".") && (alldir == "./" || alldir == "."))
-        {
+        if ((currdir == "./" || currdir == ".") && (alldir == "./" || alldir == ".")) {
             newdir = "./";
         }
-        else
-        {
-            if (alldir == "./" || alldir == ".")
-            {
+        else {
+            if (alldir == "./" || alldir == ".") {
                 newdir = currdir;
             }
-            else
-            {
+            else {
                 newdir = currdir + "/" + alldir;
             }
         }
@@ -343,8 +279,7 @@ void BESKeys::load_include_files(const string &files)
     BESFSDir fsd(newdir, allfiles.getFileName());
     BESFSDir::fileIterator i = fsd.beginOfFileList();
     BESFSDir::fileIterator e = fsd.endOfFileList();
-    for (; i != e; i++)
-    {
+    for (; i != e; i++) {
         load_include_file((*i).getFullPath());
     }
 }
@@ -360,8 +295,7 @@ void BESKeys::load_include_file(const string &file)
     // make sure the file exists and is readable
     // throws exception if unable to read
     // not loaded if has already be started to be loaded
-    if (!BESKeys::LoadedKeys(file))
-    {
+    if (!BESKeys::LoadedKeys(file)) {
         BESKeys::KeyList.push_back(file);
         BESKeys tmp(file, _the_keys);
     }
@@ -374,43 +308,6 @@ bool BESKeys::only_blanks(const char *line)
         return false;
     else
         return true;
-
-#if 0
-    int val;
-    regex_t rx;
-    string expr = "[^[:space:]]";
-    val = regcomp(&rx, expr.c_str(), REG_ICASE);
-
-    if (val != 0)
-    {
-        string s = (string) "Regular expression " + expr + " did not compile correctly " + " in configuration file " + _keys_file_name;
-        throw BESInternalFatalError(s, __FILE__, __LINE__);
-    }
-    val = regexec(&rx, line, 0, 0, REG_NOTBOL);
-    if (val == 0)
-    {
-        regfree(&rx);
-        return false;
-    }
-    else
-    {
-        if (val == REG_NOMATCH)
-        {
-            regfree(&rx);
-            return true;
-        }
-        else if (val == REG_ESPACE)
-        {
-            string s = (string) "Execution of regular expression out of space" + " in configuration file " + _keys_file_name;
-            throw BESInternalFatalError(s, __FILE__, __LINE__);
-        }
-        else
-        {
-            string s = (string) "Execution of regular expression has unknown " + " problem in configuration file " + _keys_file_name;
-            throw BESInternalFatalError(s, __FILE__, __LINE__);
-        }
-    }
-#endif
 }
 
 /** @brief allows the user to set key/value pairs from within the application.
@@ -433,15 +330,12 @@ void BESKeys::set_key(const string &key, const string &val, bool addto)
 {
     map<string, vector<string> >::iterator i;
     i = _the_keys->find(key);
-    if (i == _the_keys->end())
-    {
+    if (i == _the_keys->end()) {
         vector<string> vals;
         (*_the_keys)[key] = vals;
     }
-    if (!addto)
-        (*_the_keys)[key].clear();
-    if (!val.empty())
-    {
+    if (!addto) (*_the_keys)[key].clear();
+    if (!val.empty()) {
         (*_the_keys)[key].push_back(val);
     }
 }
@@ -485,20 +379,16 @@ void BESKeys::get_value(const string& s, string &val, bool &found)
     found = false;
     map<string, vector<string> >::iterator i;
     i = _the_keys->find(s);
-    if (i != _the_keys->end())
-    {
+    if (i != _the_keys->end()) {
         found = true;
-        if ((*i).second.size() > 1)
-        {
+        if ((*i).second.size() > 1) {
             string err = string("Multiple values for the key ") + s + " found, should only be one.";
             throw BESSyntaxUserError(err, __FILE__, __LINE__);
         }
-        if ((*i).second.size() == 1)
-        {
+        if ((*i).second.size() == 1) {
             val = (*i).second[0];
         }
-        else
-        {
+        else {
             val = "";
         }
     }
@@ -520,8 +410,7 @@ void BESKeys::get_values(const string& s, vector<string> &vals, bool &found)
     found = false;
     map<string, vector<string> >::iterator i;
     i = _the_keys->find(s);
-    if (i != _the_keys->end())
-    {
+    if (i != _the_keys->end()) {
         found = true;
         vals = (*i).second;
     }
@@ -538,36 +427,30 @@ void BESKeys::dump(ostream &strm) const
     strm << BESIndent::LMarg << "BESKeys::dump - (" << (void *) this << ")" << endl;
     BESIndent::Indent();
     strm << BESIndent::LMarg << "key file:" << _keys_file_name << endl;
-    if (_keys_file && *_keys_file)
-    {
+    if (_keys_file && *_keys_file) {
         strm << BESIndent::LMarg << "key file is valid" << endl;
     }
-    else
-    {
+    else {
         strm << BESIndent::LMarg << "key file is NOT valid" << endl;
     }
-    if (_the_keys && _the_keys->size())
-    {
+    if (_the_keys && _the_keys->size()) {
         strm << BESIndent::LMarg << "    keys:" << endl;
         BESIndent::Indent();
         Keys_citer i = _the_keys->begin();
         Keys_citer ie = _the_keys->end();
-        for (; i != ie; i++)
-        {
+        for (; i != ie; i++) {
             strm << BESIndent::LMarg << (*i).first << ":" << endl;
             BESIndent::Indent();
             vector<string>::const_iterator v = (*i).second.begin();
             vector<string>::const_iterator ve = (*i).second.end();
-            for (; v != ve; v++)
-            {
+            for (; v != ve; v++) {
                 strm << (*v) << endl;
             }
             BESIndent::UnIndent();
         }
         BESIndent::UnIndent();
     }
-    else
-    {
+    else {
         strm << BESIndent::LMarg << "keys: none" << endl;
     }
     BESIndent::UnIndent();

--- a/dispatch/TheBESKeys.cc
+++ b/dispatch/TheBESKeys.cc
@@ -42,7 +42,6 @@ string TheBESKeys::ConfigFile = "";
 
 BESKeys *TheBESKeys::TheKeys()
 {
-#if 1
     if (_instance)
         return _instance;
 
@@ -76,41 +75,4 @@ BESKeys *TheBESKeys::TheKeys()
     }
 
     throw BESInternalFatalError("Unable to find a conf file or module version mismatch.", __FILE__, __LINE__);
-
-#else
-
-    if (_instance == 0) {
-        string use_ini = TheBESKeys::ConfigFile;
-        if (use_ini == "") {
-            string try_ini = "/usr/local/etc/bes/bes.conf";
-            struct stat buf;
-            int statret = stat(try_ini.c_str(), &buf);
-            if (statret == -1 || !S_ISREG(buf.st_mode)) {
-                try_ini = "/etc/bes/bes.conf";
-                int statret = stat(try_ini.c_str(), &buf);
-                if (statret == -1 || !S_ISREG(buf.st_mode)) {
-                    try_ini = "/usr/etc/bes/bes.conf";
-                    int statret = stat(try_ini.c_str(), &buf);
-                    if (statret == -1 || !S_ISREG(buf.st_mode)) {
-                        throw BESInternalFatalError("Unable to find a conf file or module version mismatch.", __FILE__,
-                            __LINE__);
-                    }
-                    else {
-                        use_ini = try_ini;
-                    }
-                }
-                else {
-                    use_ini = try_ini;
-                }
-            }
-            else {
-                use_ini = try_ini;
-            }
-        }
-        _instance = new TheBESKeys(use_ini);
-    }
-
-    return _instance;
-
-#endif
 }

--- a/dispatch/unit-tests/Makefile.am
+++ b/dispatch/unit-tests/Makefile.am
@@ -4,8 +4,10 @@
 AUTOMAKE_OPTIONS = foreign subdir-objects
 
 # Arrange to build with the backward compatibility mode enabled.
-AM_CPPFLAGS = -I$(top_srcdir)/dispatch
-LDADD = $(top_builddir)/dispatch/libbes_dispatch.la $(XML2_LIBS)
+AM_CPPFLAGS = -I$(top_srcdir)/dispatch $(DAP_CFLAGS)
+LDADD = $(top_builddir)/dispatch/libbes_dispatch.la $(DAP_LIBS) 
+#$(LIBS)
+# $(XML2_LIBS)
 if CPPUNIT
 AM_CPPFLAGS += $(CPPUNIT_CFLAGS)
 LDADD += $(CPPUNIT_LIBS)

--- a/dispatch/unit-tests/keysT.cc
+++ b/dispatch/unit-tests/keysT.cc
@@ -132,6 +132,7 @@ public:
         }
         catch (BESError &e) {
             //cerr << "Error: " << e.get_message() << endl;
+            cerr << "TheBESKeys::ConfigFile: " << TheBESKeys::ConfigFile << endl;
             CPPUNIT_FAIL( "Unable to create BESKeys: " + e.get_message());
         }
 

--- a/dispatch/unit-tests/keysT.cc
+++ b/dispatch/unit-tests/keysT.cc
@@ -34,339 +34,280 @@
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/extensions/HelperMacros.h>
 
-using namespace CppUnit ;
+using namespace CppUnit;
 
 #include <cstdlib>
 #include <iostream>
 
-using std::cerr ;
-using std::cout ;
-using std::endl ;
+using std::cerr;
+using std::cout;
+using std::endl;
 
 #include "TheBESKeys.h"
 #include "BESError.h"
 #include <test_config.h>
 
-string KeyFile ;
+string KeyFile;
 
 class keysT: public TestFixture {
 private:
 
 public:
-    keysT() {}
-    ~keysT() {}
+    keysT()
+    {
+    }
+    ~keysT()
+    {
+    }
 
     void setUp()
     {
-
-#if 0
-	// env vars are too easy to abuse... removed from bes keys and
-	// these tests. jhrg 8/28/13
-
-	string env_var = (string)TEST_SRC_DIR + "/persistence_cgi_test.ini" ;
-	setenv( "BES_CONF", env_var.c_str(), 1 ) ;
-#endif
-    } 
+    }
 
     void tearDown()
     {
     }
 
-    CPPUNIT_TEST_SUITE( keysT ) ;
+    CPPUNIT_TEST_SUITE( keysT );
 
-    CPPUNIT_TEST( do_test ) ;
+    CPPUNIT_TEST( do_test );
 
-    CPPUNIT_TEST_SUITE_END() ;
+    CPPUNIT_TEST_SUITE_END();
 
     void do_test()
     {
-	cout << "*****************************************" << endl;
-	cout << "Entered keysT::run" << endl;
-	// unused. jhrg 5/24/16 int retVal = 0;
+        cout << "*****************************************" << endl;
+        cout << "Entered keysT::run" << endl;
+        // unused. jhrg 5/24/16 int retVal = 0;
 
-	if( KeyFile != "" )
-	{
-	    TheBESKeys::ConfigFile = KeyFile ;
-	    try
-	    {
-		TheBESKeys::TheKeys()->dump( cout ) ;
-	    }
-	    catch( BESError &e )
-	    {
-		cout << "unable to create BESKeys:" << endl ;
-		cout << e.get_message() << endl ;
-	    }
-	    catch( ... )
-	    {
-		cout << "unable to create BESKeys: unkown exception caught"
-		     << endl ;
-	    }
-	}
-#if 0
-	cout << "*****************************************" << endl;
-	cout << "no file set" << endl;
-	setenv( "BES_CONF", "", 1 ) ;
-	TheBESKeys::ConfigFile = "" ;
-	try
-	{
-	    TheBESKeys::TheKeys() ;
-	    CPPUNIT_ASSERT( !"loaded keys, should have failed" ) ;
-	}
-	catch( BESError &e )
-	{
-	    cout << "unable to create BESKeys, good, because:" << endl ;
-	}
+        if (KeyFile != "") {
+            TheBESKeys::ConfigFile = KeyFile;
+            try {
+                TheBESKeys::TheKeys()->dump(cout);
+            }
+            catch (BESError &e) {
+                cout << "unable to create BESKeys:" << endl;
+                cout << e.get_message() << endl;
+            }
+            catch (...) {
+                cout << "unable to create BESKeys: unkown exception caught" << endl;
+            }
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "notfound file set" << endl;
-	setenv( "BES_CONF", "notfound.ini", 1 ) ;
-	try
-	{
-	    TheBESKeys::TheKeys() ;
-	    CPPUNIT_ASSERT( !"loaded keys, should have failed"  ) ;
-	}
-	catch( BESError &e )
-	{
-	    cout << "unable to create BESKeys, good, because:" << endl ;
-	}
-#endif
-	cout << "*****************************************" << endl;
-	cout << "bad keys, not enough equal signs" << endl;
-	string bes_conf = (string)TEST_SRC_DIR + "/bad_keys1.ini" ;
-	TheBESKeys::ConfigFile = bes_conf ;
-	try
-	{
-	    TheBESKeys::TheKeys() ;
-	    CPPUNIT_ASSERT( !"loaded keys, should have failed" ) ;
-	}
-	catch( BESError &e )
-	{
-	    cout << "unable to create BESKeys, good, because:" << endl ;
-	    cout << e.get_message() << endl ;
-	}
+        cout << "*****************************************" << endl;
+        cout << "bad keys, not enough equal signs" << endl;
+        string bes_conf = (string) TEST_SRC_DIR + "/bad_keys1.ini";
+        TheBESKeys::ConfigFile = bes_conf;
+        try {
+            TheBESKeys::TheKeys();
+            CPPUNIT_ASSERT( !"loaded keys, should have failed" );
+        }
+        catch (BESError &e) {
+            cout << "unable to create BESKeys, good, because:" << endl;
+            cout << e.get_message() << endl;
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "good keys file, should load" << endl;
-	bes_conf = (string)TEST_SRC_DIR + "/keys_test.ini" ;
-	TheBESKeys::ConfigFile = bes_conf ;
-	try
-	{
-	    TheBESKeys::TheKeys() ;
-	}
-	catch( BESError &e )
-	{
-	    cerr << e.get_message() << endl ;
-	    CPPUNIT_ASSERT( !"unable to create BESKeys" ) ;
-	}
+        cout << "*****************************************" << endl;
+        cout << "good keys file, should load" << endl;
+        bes_conf = (string) TEST_SRC_DIR + "/keys_test.ini";
+        TheBESKeys::ConfigFile = bes_conf;
+        try {
+            TheBESKeys::TheKeys();
+        }
+        catch (BESError &e) {
+            cerr << "Error: " << e.get_message() << endl;
+            CPPUNIT_ASSERT( !"unable to create BESKeys" );
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "get keys" << endl;
-	bool found = false ;
-	string ret = "" ;
-	for( int i = 1; i < 5; i++ )
-	{
-	    char key[32] ;
-	    sprintf( key, "BES.KEY%d", i ) ;
-	    char val[32] ;
-	    sprintf( val, "val%d", i ) ;
-	    cout << "looking for " << key << " with value " << val << endl ;
-	    ret = "" ;
-	    TheBESKeys::TheKeys()->get_value( key, ret, found ) ;
-	    CPPUNIT_ASSERT( found ) ;
-	    CPPUNIT_ASSERT( !ret.empty() ) ;
-	    CPPUNIT_ASSERT( ret == val ) ;
-	}
+        cout << "*****************************************" << endl;
+        cout << "get keys" << endl;
+        bool found = false;
+        string ret = "";
+        for (int i = 1; i < 5; i++) {
+            char key[32];
+            sprintf(key, "BES.KEY%d", i);
+            char val[32];
+            sprintf(val, "val%d", i);
+            cout << "looking for " << key << " with value " << val << endl;
+            ret = "";
+            TheBESKeys::TheKeys()->get_value(key, ret, found);
+            CPPUNIT_ASSERT( found );
+            CPPUNIT_ASSERT( !ret.empty() );
+            CPPUNIT_ASSERT( ret == val );
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "use get_values to get a single value key" << endl;
-	found = false ;
-	vector<string> vals ;
-	TheBESKeys::TheKeys()->get_values( "BES.KEY1", vals, found ) ;
-	CPPUNIT_ASSERT( found ) ;
-	CPPUNIT_ASSERT( vals.size() == 1 ) ;
-	CPPUNIT_ASSERT( vals[0] == "val1" ) ;
+        cout << "*****************************************" << endl;
+        cout << "use get_values to get a single value key" << endl;
+        found = false;
+        vector<string> vals;
+        TheBESKeys::TheKeys()->get_values("BES.KEY1", vals, found);
+        CPPUNIT_ASSERT( found );
+        CPPUNIT_ASSERT( vals.size() == 1 );
+        CPPUNIT_ASSERT( vals[0] == "val1" );
 
-	cout << "*****************************************" << endl;
-	cout << "use get_values to get a multi value key" << endl;
-	found = false ;
-	vals.clear() ;
-	TheBESKeys::TheKeys()->get_values( "BES.KEY.MULTI", vals, found ) ;
-	CPPUNIT_ASSERT( found ) ;
-	CPPUNIT_ASSERT( vals.size() == 5 ) ;
-	for( int i = 0; i < 5; i++ )
-	{
-	    char val[32] ;
-	    sprintf( val, "val_multi_%d", i ) ;
-	    cout << "looking for value " << val << endl ;
-	    CPPUNIT_ASSERT( vals[i] == val ) ;
-	}
+        cout << "*****************************************" << endl;
+        cout << "use get_values to get a multi value key" << endl;
+        found = false;
+        vals.clear();
+        TheBESKeys::TheKeys()->get_values("BES.KEY.MULTI", vals, found);
+        CPPUNIT_ASSERT( found );
+        CPPUNIT_ASSERT( vals.size() == 5 );
+        for (int i = 0; i < 5; i++) {
+            char val[32];
+            sprintf(val, "val_multi_%d", i);
+            cout << "looking for value " << val << endl;
+            CPPUNIT_ASSERT( vals[i] == val );
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "use get_value on multi-value key" << endl;
-	ret = "" ;
-	found = false ;
-	try
-	{
-	    TheBESKeys::TheKeys()->get_value( "BES.KEY.MULTI", ret, found ) ;
-	}
-	catch( BESError &e )
-	{
-	    cout << "getting single value from multi-value key failed, good"
-		 << endl ;
-	    cout << e.get_message() << endl ;
-	}
+        cout << "*****************************************" << endl;
+        cout << "use get_value on multi-value key" << endl;
+        ret = "";
+        found = false;
+        try {
+            TheBESKeys::TheKeys()->get_value("BES.KEY.MULTI", ret, found);
+        }
+        catch (BESError &e) {
+            cout << "getting single value from multi-value key failed, good" << endl;
+            cout << e.get_message() << endl;
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "look for non existant key" << endl;
-	ret = "" ;
-	TheBESKeys::TheKeys()->get_value( "BES.NOTFOUND", ret, found ) ;
-	CPPUNIT_ASSERT( found == false ) ;
-	CPPUNIT_ASSERT( ret.empty() ) ;
+        cout << "*****************************************" << endl;
+        cout << "look for non existant key" << endl;
+        ret = "";
+        TheBESKeys::TheKeys()->get_value("BES.NOTFOUND", ret, found);
+        CPPUNIT_ASSERT( found == false );
+        CPPUNIT_ASSERT( ret.empty() );
 
-	cout << "*****************************************" << endl;
-	cout << "look for key with empty value" << endl;
-	TheBESKeys::TheKeys()->get_value( "BES.KEY5", ret, found ) ;
-	CPPUNIT_ASSERT( found ) ;
-	CPPUNIT_ASSERT( ret.empty() ) ;
+        cout << "*****************************************" << endl;
+        cout << "look for key with empty value" << endl;
+        TheBESKeys::TheKeys()->get_value("BES.KEY5", ret, found);
+        CPPUNIT_ASSERT( found );
+        CPPUNIT_ASSERT( ret.empty() );
 
-	cout << "*****************************************" << endl;
-	cout << "look for key with empty value in included file" << endl;
-	TheBESKeys::TheKeys()->get_value( "BES.KEY6", ret, found ) ;
-	CPPUNIT_ASSERT( found ) ;
-	CPPUNIT_ASSERT( ret.empty() ) ;
+        cout << "*****************************************" << endl;
+        cout << "look for key with empty value in included file" << endl;
+        TheBESKeys::TheKeys()->get_value("BES.KEY6", ret, found);
+        CPPUNIT_ASSERT( found );
+        CPPUNIT_ASSERT( ret.empty() );
 
-	cout << "*****************************************" << endl;
-	cout << "set bad key, 0 = characters" << endl;
-	try
-	{
-	    TheBESKeys::TheKeys()->set_key( "BES.NOEQS" ) ;
-	    CPPUNIT_ASSERT ( !"set_key successful, should have failed" ) ;
-	}
-	catch( BESError &e )
-	{
-	    cout << "unable to set the key, good, because:" << endl ;
-	    cout << e.get_message() ;
-	}
+        cout << "*****************************************" << endl;
+        cout << "set bad key, 0 = characters" << endl;
+        try {
+            TheBESKeys::TheKeys()->set_key("BES.NOEQS");
+            CPPUNIT_ASSERT ( !"set_key successful, should have failed" );
+        }
+        catch (BESError &e) {
+            cout << "unable to set the key, good, because:" << endl;
+            cout << e.get_message();
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "set key, 2 = characters" << endl;
-	try
-	{
-	    TheBESKeys::TheKeys()->set_key( "BES.2EQS=val1=val2" ) ;
-	    found = false ;
-	    TheBESKeys::TheKeys()->get_value( "BES.2EQS", ret, found ) ;
-	    CPPUNIT_ASSERT( ret == "val1=val2" ) ;
-	}
-	catch( BESError &e )
-	{
-	    cerr << e.get_message() << endl ;
-	    CPPUNIT_ASSERT( !"failed to set key where value has multiple =" ) ;
-	}
+        cout << "*****************************************" << endl;
+        cout << "set key, 2 = characters" << endl;
+        try {
+            TheBESKeys::TheKeys()->set_key("BES.2EQS=val1=val2");
+            found = false;
+            TheBESKeys::TheKeys()->get_value("BES.2EQS", ret, found);
+            CPPUNIT_ASSERT( ret == "val1=val2" );
+        }
+        catch (BESError &e) {
+            cerr << e.get_message() << endl;
+            CPPUNIT_ASSERT( !"failed to set key where value has multiple =" );
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "set BES.KEY7 to val7" << endl;
-	try
-	{
-	    TheBESKeys::TheKeys()->set_key( "BES.KEY7=val7" ) ;
-	    found = false ;
-	    TheBESKeys::TheKeys()->get_value( "BES.KEY7", ret, found ) ;
-	    CPPUNIT_ASSERT( ret == "val7" ) ;
-	}
-	catch( BESError &e )
-	{
-	    cerr << e.get_message() ;
-	    CPPUNIT_ASSERT( !"unable to set the key" ) ;
-	}
+        cout << "*****************************************" << endl;
+        cout << "set BES.KEY7 to val7" << endl;
+        try {
+            TheBESKeys::TheKeys()->set_key("BES.KEY7=val7");
+            found = false;
+            TheBESKeys::TheKeys()->get_value("BES.KEY7", ret, found);
+            CPPUNIT_ASSERT( ret == "val7" );
+        }
+        catch (BESError &e) {
+            cerr << e.get_message();
+            CPPUNIT_ASSERT( !"unable to set the key" );
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "set BES.KEY8 to val8" << endl;
-	try
-	{
-	    TheBESKeys::TheKeys()->set_key( "BES.KEY8", "val8" ) ;
-	    found = false ;
-	    TheBESKeys::TheKeys()->get_value( "BES.KEY8", ret, found ) ;
-	    CPPUNIT_ASSERT( ret == "val8" ) ;
-	}
-	catch( BESError &e )
-	{
-	    cerr << e.get_message() ;
-	    CPPUNIT_ASSERT( !"unable to set the key" ) ;
-	}
+        cout << "*****************************************" << endl;
+        cout << "set BES.KEY8 to val8" << endl;
+        try {
+            TheBESKeys::TheKeys()->set_key("BES.KEY8", "val8");
+            found = false;
+            TheBESKeys::TheKeys()->get_value("BES.KEY8", ret, found);
+            CPPUNIT_ASSERT( ret == "val8" );
+        }
+        catch (BESError &e) {
+            cerr << e.get_message();
+            CPPUNIT_ASSERT( !"unable to set the key" );
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "add val_multi_5 to BES.KEY.MULTI" << endl;
-	try
-	{
-	    TheBESKeys::TheKeys()->set_key( "BES.KEY.MULTI",
-					    "val_multi_5", true ) ;
-	    found = false ;
-	    vals.clear() ;
-	    TheBESKeys::TheKeys()->get_values( "BES.KEY.MULTI", vals, found ) ;
-	    CPPUNIT_ASSERT( found ) ;
-	    CPPUNIT_ASSERT( vals.size() == 6 ) ;
-	    for( int i = 0; i < 6; i++ )
-	    {
-		char val[32] ;
-		sprintf( val, "val_multi_%d", i ) ;
-		cout << "looking for value " << val << endl ;
-		CPPUNIT_ASSERT( vals[i] == val ) ;
-	    }
+        cout << "*****************************************" << endl;
+        cout << "add val_multi_5 to BES.KEY.MULTI" << endl;
+        try {
+            TheBESKeys::TheKeys()->set_key("BES.KEY.MULTI", "val_multi_5", true);
+            found = false;
+            vals.clear();
+            TheBESKeys::TheKeys()->get_values("BES.KEY.MULTI", vals, found);
+            CPPUNIT_ASSERT( found );
+            CPPUNIT_ASSERT( vals.size() == 6 );
+            for (int i = 0; i < 6; i++) {
+                char val[32];
+                sprintf(val, "val_multi_%d", i);
+                cout << "looking for value " << val << endl;
+                CPPUNIT_ASSERT( vals[i] == val );
+            }
 
-	}
-	catch( BESError &e )
-	{
-	    cerr << e.get_message() ;
-	    CPPUNIT_ASSERT( !"unable to set the key" ) ;
-	}
+        }
+        catch (BESError &e) {
+            cerr << e.get_message();
+            CPPUNIT_ASSERT( !"unable to set the key" );
+        }
 
+        cout << "*****************************************" << endl;
+        cout << "get keys from reg exp include" << endl;
+        found = false;
+        vals.clear();
+        TheBESKeys::TheKeys()->get_values("BES.KEY.MI", vals, found);
+        CPPUNIT_ASSERT( found );
+        CPPUNIT_ASSERT( vals.size() == 3 );
+        CPPUNIT_ASSERT( vals[0] == "val_multi_2" );
+        CPPUNIT_ASSERT( vals[1] == "val_multi_1" );
+        CPPUNIT_ASSERT( vals[2] == "val_multi_3" );
 
-	cout << "*****************************************" << endl;
-	cout << "get keys from reg exp include" << endl;
-	found = false ;
-	vals.clear() ;
-	TheBESKeys::TheKeys()->get_values( "BES.KEY.MI", vals, found ) ;
-	CPPUNIT_ASSERT( found ) ;
-	CPPUNIT_ASSERT( vals.size() == 3 ) ;
-	CPPUNIT_ASSERT( vals[0] == "val_multi_2" ) ;
-	CPPUNIT_ASSERT( vals[1] == "val_multi_1" ) ;
-	CPPUNIT_ASSERT( vals[2] == "val_multi_3" ) ;
+        cout << "*****************************************" << endl;
+        cout << "get keys" << endl;
+        for (int i = 1; i < 7; i++) {
+            char key[32];
+            sprintf(key, "BES.KEY%d", i);
+            char val[32];
+            if (i == 5 || i == 6)
+                sprintf(val, "");
+            else
+                sprintf(val, "val%d", i);
+            cout << "looking for " << key << " with value " << val << endl;
+            ret = "";
+            TheBESKeys::TheKeys()->get_value(key, ret, found);
+            CPPUNIT_ASSERT( found );
+            CPPUNIT_ASSERT( ret == val );
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "get keys" << endl;
-	for( int i = 1; i < 7; i++ )
-	{
-	    char key[32] ;
-	    sprintf( key, "BES.KEY%d", i ) ;
-	    char val[32] ;
-	    if( i == 5 || i == 6 ) sprintf( val, "" ) ;
-	    else sprintf( val, "val%d", i ) ;
-	    cout << "looking for " << key << " with value " << val << endl ;
-	    ret = "" ;
-	    TheBESKeys::TheKeys()->get_value( key, ret, found ) ;
-	    CPPUNIT_ASSERT( found ) ;
-	    CPPUNIT_ASSERT( ret == val ) ;
-	}
-
-	cout << "*****************************************" << endl;
-	cout << "Returning from keysT::run" << endl;
+        cout << "*****************************************" << endl;
+        cout << "Returning from keysT::run" << endl;
     }
-} ;
+};
 
-CPPUNIT_TEST_SUITE_REGISTRATION( keysT ) ;
+CPPUNIT_TEST_SUITE_REGISTRATION( keysT );
 
-int 
-main( int argC, char **argV )
+int main(int argC, char **argV)
 {
-    if( argC == 2 )
-    {
-	KeyFile = argV[1] ;
+    if (argC == 2) {
+        KeyFile = argV[1];
     }
 
-    CppUnit::TextTestRunner runner ;
-    runner.addTest( CppUnit::TestFactoryRegistry::getRegistry().makeTest() ) ;
+    CppUnit::TextTestRunner runner;
+    runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
 
-    bool wasSuccessful = runner.run( "", false )  ;
+    bool wasSuccessful = runner.run("", false);
 
-    return wasSuccessful ? 0 : 1 ;
+    return wasSuccessful ? 0 : 1;
 }
 

--- a/dispatch/unit-tests/persistence_cgi_test.ini
+++ b/dispatch/unit-tests/persistence_cgi_test.ini
@@ -1,10 +1,3 @@
-#-------------------------BES Initialization file-----------------------#
-#									#
-#       National Center for Atmospheric Research (NCAR)			#
-#       High Altitude Observatory (HAO)					#
-#       Key entries for OPeNDAP server run time behavior		#
-#									#
-#-----------------------------------------------------------------------#
 
 # If the persistence type is CGI this is how to translate 
 # container names to full qualify paths
@@ -13,5 +6,5 @@ BES.Container.Persistence.CGI.CGI.Dummy=cedar:cedar\/.*\.cbf;cdf:cdf\/.*\.cdf;
 
 BES.Info.Buffered=yes
 
-BES.Data.RootDirectory=.
+BES.Data.RootDirectory=./cache/
 

--- a/dispatch/unit-tests/pvolT.cc
+++ b/dispatch/unit-tests/pvolT.cc
@@ -34,17 +34,11 @@
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/extensions/HelperMacros.h>
 
-using namespace CppUnit;
-
 #include <iostream>
 #include <fstream>
 #include <cstdlib>
-
-using std::cerr;
-using std::cout;
-using std::endl;
-using std::ofstream;
-using std::ios;
+#include <string>
+#include <sstream>
 
 #include "BESContainerStorageVolatile.h"
 #include "BESContainer.h"
@@ -57,20 +51,29 @@ using std::ios;
 
 #include "test_config.h"
 
+using namespace CppUnit;
+using namespace std;
+
 static bool debug = false;
 static bool debug_2 = false;
+
+const string cache_dir = "./cache";
 
 #undef DBG
 #define DBG(x) do { if (debug) (x); } while(false);
 #undef DBG2
 #define DBG2(x) do { if (debug_2) (x); } while(false);
 
+
 class pvolT: public TestFixture {
 private:
     BESContainerStorageVolatile *cpv;
 
+    string real1, real2, real3, real4, real5;
+
 public:
-    pvolT() : cpv(0)
+    pvolT() : cpv(0), real1(cache_dir + "/real1"), real2(cache_dir + "/real2"),
+    real3(cache_dir + "/real3"), real4(cache_dir + "/real4"), real5(cache_dir + "/real5")
     {
         string bes_conf = (string) TEST_SRC_DIR + "/persistence_cgi_test.ini";
         TheBESKeys::ConfigFile = bes_conf;
@@ -78,31 +81,31 @@ public:
         // This cannot be constructed unless the Keys file can be read.
         cpv = new BESContainerStorageVolatile("volatile");
 
-        ofstream real1( "./real1", ios::trunc );
-        real1 << "real1" << endl;
+        ofstream of1( real1.c_str(), ios::trunc );
+        of1 << "real1" << endl;
 
-        ofstream real2( "./real2", ios::trunc );
-        real2 << "real2" << endl;
+        ofstream of2( real2.c_str(), ios::trunc );
+        of2 << "real2" << endl;
 
-        ofstream real3( "./real3", ios::trunc );
-        real3 << "real3" << endl;
+        ofstream of3( real3.c_str(), ios::trunc );
+        of3 << "real3" << endl;
 
-        ofstream real4( "./real4", ios::trunc );
-        real4 << "real4" << endl;
+        ofstream of4( real4.c_str(), ios::trunc );
+        of4 << "real4" << endl;
 
-        ofstream real5( "./real5", ios::trunc );
-        real5 << "real5" << endl;
+        ofstream of5( real5.c_str(), ios::trunc );
+        of5 << "real5" << endl;
     }
 
     ~pvolT()
     {
         delete cpv;
 
-        remove( "./real1" );
-        remove( "./real2" );
-        remove( "./real3" );
-        remove( "./real4" );
-        remove( "./real5" );
+        remove( real1.c_str() );
+        remove( real2.c_str() );
+        remove( real3.c_str() );
+        remove( real4.c_str() );
+        remove( real5.c_str() );
     }
 
     void setUp()
@@ -159,20 +162,20 @@ public:
 
         DBG(cerr << "test_look_for_containers BEGIN" << endl);
 
-        char s[10];
-        char r[10];
-        char c[10];
         for (int i = 1; i < 6; i++) {
-            sprintf(s, "sym%d", i);
-            sprintf(r, "./real%d", i);
-            sprintf(c, "type%d", i);
+            ostringstream s;
+            s << "sym" << i;
+            ostringstream r;
+            r << cache_dir + "/real" << i;
+            ostringstream c;
+            c << "type" << i;
 
             DBG(cerr << "    looking for " << s << endl);
 
-            BESContainer *d = cpv->look_for(s);
+            BESContainer *d = cpv->look_for(s.str());
             CPPUNIT_ASSERT( d );
-            CPPUNIT_ASSERT( d->get_real_name() == r );
-            CPPUNIT_ASSERT( d->get_container_type() == c );
+            CPPUNIT_ASSERT( d->get_real_name() == r.str() );
+            CPPUNIT_ASSERT( d->get_container_type() == c.str() );
         }
 
         DBG(cerr << "test_look_for_containers END" << endl);
@@ -203,20 +206,20 @@ public:
 
         // Double check the correct containers are really gone
         {
-            char s[10];
-            char r[10];
-            char c[10];
             for (int i = 2; i < 5; i++) {
-                sprintf(s, "sym%d", i);
-                sprintf(r, "./real%d", i);
-                sprintf(c, "type%d", i);
+                ostringstream s;
+                s << "sym" << i;
+                ostringstream r;
+                r << cache_dir + "/real" << i;
+                ostringstream c;
+                c << "type" << i;
 
                 DBG(cerr << "    looking for " << s << endl);
 
-                BESContainer *d = cpv->look_for(s);
+                BESContainer *d = cpv->look_for(s.str());
                 CPPUNIT_ASSERT( d );
-                CPPUNIT_ASSERT( d->get_real_name() == r );
-                CPPUNIT_ASSERT( d->get_container_type() == c );
+                CPPUNIT_ASSERT( d->get_real_name() == r.str() );
+                CPPUNIT_ASSERT( d->get_container_type() == c.str() );
             }
         }
     }

--- a/dispatch/unit-tests/pvolT.cc
+++ b/dispatch/unit-tests/pvolT.cc
@@ -34,17 +34,17 @@
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/extensions/HelperMacros.h>
 
-using namespace CppUnit ;
+using namespace CppUnit;
 
 #include <iostream>
 #include <fstream>
 #include <cstdlib>
 
-using std::cerr ;
-using std::cout ;
-using std::endl ;
-using std::ofstream ;
-using std::ios ;
+using std::cerr;
+using std::cout;
+using std::endl;
+using std::ofstream;
+using std::ios;
 
 #include "BESContainerStorageVolatile.h"
 #include "BESContainer.h"
@@ -57,173 +57,176 @@ class pvolT: public TestFixture {
 private:
 
 public:
-    pvolT() {}
-    ~pvolT() {}
+    pvolT()
+    {
+    }
+    ~pvolT()
+    {
+    }
 
     void setUp()
     {
-	string bes_conf = (string)TEST_SRC_DIR + "/persistence_cgi_test.ini" ;
-	TheBESKeys::ConfigFile = bes_conf ;
+        string bes_conf = (string) TEST_SRC_DIR + "/persistence_cgi_test.ini";
+        TheBESKeys::ConfigFile = bes_conf;
 
-	ofstream real1( "./real1", ios::trunc ) ;
-	real1 << "real1" << endl ;
-	real1.close() ;
-	ofstream real2( "./real2", ios::trunc ) ;
-	real2 << "real2" << endl ;
-	real2.close() ;
-	ofstream real3( "./real3", ios::trunc ) ;
-	real3 << "real3" << endl ;
-	real3.close() ;
-	ofstream real4( "./real4", ios::trunc ) ;
-	real4 << "real4" << endl ;
-	real4.close() ;
-	ofstream real5( "./real5", ios::trunc ) ;
-	real5 << "real5" << endl ;
-	real5.close() ;
-    } 
+#if 0
+        // TODO Remove. Not used and seems to cause (but why?) an error when
+        // this test is run in parallel with the keysT test. jhrg 3/26/17
+        ofstream real1( "./real1", ios::trunc );
+        real1 << "real1" << endl;
+        //real1.close() ;
+        ofstream real2( "./real2", ios::trunc );
+        real2 << "real2" << endl;
+        //real2.close() ;
+        ofstream real3( "./real3", ios::trunc );
+        real3 << "real3" << endl;
+        //real3.close() ;
+        ofstream real4( "./real4", ios::trunc );
+        real4 << "real4" << endl;
+        //real4.close() ;
+        ofstream real5( "./real5", ios::trunc );
+        real5 << "real5" << endl;
+        //real5.close() ;
+#endif
+    }
 
     void tearDown()
     {
-	remove( "./real1" ) ;
-	remove( "./real2" ) ;
-	remove( "./real3" ) ;
-	remove( "./real4" ) ;
-	remove( "./real5" ) ;
+#if 0
+        remove( "./real1" );
+        remove( "./real2" );
+        remove( "./real3" );
+        remove( "./real4" );
+        remove( "./real5" );
+#endif
     }
 
-    CPPUNIT_TEST_SUITE( pvolT ) ;
+    CPPUNIT_TEST_SUITE( pvolT );
 
-    CPPUNIT_TEST( do_test ) ;
+    CPPUNIT_TEST( do_test );
 
-    CPPUNIT_TEST_SUITE_END() ;
+    CPPUNIT_TEST_SUITE_END();
 
     void do_test()
     {
-	cout << "*****************************************" << endl;
-	cout << "Entered pvolT::run" << endl;
+        cout << "*****************************************" << endl;
+        cout << "Entered pvolT::run" << endl;
 
-	BESContainerStorageVolatile cpv( "volatile" ) ;
+        BESContainerStorageVolatile cpv("volatile");
 
-	cout << "*****************************************" << endl;
-	cout << "Create volatile and add five elements" << endl;
-	try
-	{
-	    cpv.add_container( "sym1", "real1", "type1" ) ;
-	    cpv.add_container( "sym2", "real2", "type2" ) ;
-	    cpv.add_container( "sym3", "real3", "type3" ) ;
-	    cpv.add_container( "sym4", "real4", "type4" ) ;
-	    cpv.add_container( "sym5", "real5", "type5" ) ;
-	}
-	catch( BESError &e )
-	{
-	    cerr << e.get_message() << endl ;
-	    CPPUNIT_ASSERT( ! "failed to add elements" ) ;
-	}
+        cout << "*****************************************" << endl;
+        cout << "Create volatile and add five elements" << endl;
+        try {
+            cpv.add_container("sym1", "real1", "type1");
+            cpv.add_container("sym2", "real2", "type2");
+            cpv.add_container("sym3", "real3", "type3");
+            cpv.add_container("sym4", "real4", "type4");
+            cpv.add_container("sym5", "real5", "type5");
+        }
+        catch (BESError &e) {
+            cerr << e.get_message() << endl;
+            CPPUNIT_ASSERT( ! "failed to add elements" );
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "show containers" << endl;
-	BESTextInfo info ;
-	cpv.show_containers( info ) ;
-	info.print( cout ) ;
+        cout << "*****************************************" << endl;
+        cout << "show containers" << endl;
+        BESTextInfo info;
+        cpv.show_containers(info);
+        info.print(cout);
 
-	cout << "*****************************************" << endl;
-	cout << "try to add sym1 again" << endl;
-	try
-	{
-	    cpv.add_container( "sym1", "real1", "type1" ) ;
-	    CPPUNIT_ASSERT( !"succesfully added sym1 again" ) ;
-	}
-	catch( BESError &e )
-	{
-	    cout << "unable to add sym1 again, good" << endl ;
-	    cout << e.get_message() << endl ;
-	}
+        cout << "*****************************************" << endl;
+        cout << "try to add sym1 again" << endl;
+        try {
+            cpv.add_container("sym1", "real1", "type1");
+            CPPUNIT_ASSERT( !"succesfully added sym1 again" );
+        }
+        catch (BESError &e) {
+            cout << "unable to add sym1 again, good" << endl;
+            cout << e.get_message() << endl;
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "Look for containers" << endl ;
-	{
-	    char s[10] ;
-	    char r[10] ;
-	    char c[10] ;
-	    for( int i = 1; i < 6; i++ )
-	    {
-		sprintf( s, "sym%d", i ) ;
-		sprintf( r, "./real%d", i ) ;
-		sprintf( c, "type%d", i ) ;
-		cout << "    looking for " << s << endl;
-		BESContainer *d = cpv.look_for( s ) ;
-		CPPUNIT_ASSERT( d ) ;
-		CPPUNIT_ASSERT( d->get_real_name() == r ) ;
-		CPPUNIT_ASSERT( d->get_container_type() == c ) ;
-	    }
-	}
+        cout << "*****************************************" << endl;
+        cout << "Look for containers" << endl;
+        {
+            char s[10];
+            char r[10];
+            char c[10];
+            for (int i = 1; i < 6; i++) {
+                sprintf(s, "sym%d", i);
+                sprintf(r, "./real%d", i);
+                sprintf(c, "type%d", i);
+                cout << "    looking for " << s << endl;
+                BESContainer *d = cpv.look_for(s);
+                CPPUNIT_ASSERT( d );
+                CPPUNIT_ASSERT( d->get_real_name() == r );
+                CPPUNIT_ASSERT( d->get_container_type() == c );
+            }
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "remove sym1" << endl;
-	CPPUNIT_ASSERT( cpv.del_container( "sym1" ) ) ;
+        cout << "*****************************************" << endl;
+        cout << "remove sym1" << endl;
+        CPPUNIT_ASSERT( cpv.del_container( "sym1" ) );
 
-	{
-	    cout << "*****************************************" << endl;
-	    cout << "find sym1" << endl;
-	    BESContainer *d = cpv.look_for( "sym1" ) ;
-	    CPPUNIT_ASSERT( !d ) ;
-	}
+        {
+            cout << "*****************************************" << endl;
+            cout << "find sym1" << endl;
+            BESContainer *d = cpv.look_for("sym1");
+            CPPUNIT_ASSERT( !d );
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "remove sym5" << endl;
-	CPPUNIT_ASSERT( cpv.del_container( "sym5" ) ) ;
+        cout << "*****************************************" << endl;
+        cout << "remove sym5" << endl;
+        CPPUNIT_ASSERT( cpv.del_container( "sym5" ) );
 
-	{
-	    cout << "*****************************************" << endl;
-	    cout << "find sym5" << endl;
-	    BESContainer *d = cpv.look_for( "sym5" ) ;
-	    CPPUNIT_ASSERT( !d ) ;
-	}
+        {
+            cout << "*****************************************" << endl;
+            cout << "find sym5" << endl;
+            BESContainer *d = cpv.look_for("sym5");
+            CPPUNIT_ASSERT( !d );
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "remove nosym" << endl;
-	CPPUNIT_ASSERT( !cpv.del_container( "nosym" ) ) ;
+        cout << "*****************************************" << endl;
+        cout << "remove nosym" << endl;
+        CPPUNIT_ASSERT( !cpv.del_container( "nosym" ) );
 
-	cout << "*****************************************" << endl;
-	cout << "Look for containers" << endl ;
-	{
-	    char s[10] ;
-	    char r[10] ;
-	    char c[10] ;
-	    for( int i = 2; i < 5; i++ )
-	    {
-		sprintf( s, "sym%d", i ) ;
-		sprintf( r, "./real%d", i ) ;
-		sprintf( c, "type%d", i ) ;
-		cout << "    looking for " << s << endl;
-		BESContainer *d = cpv.look_for( s ) ;
-		CPPUNIT_ASSERT( d ) ;
-		CPPUNIT_ASSERT( d->get_real_name() == r ) ;
-		CPPUNIT_ASSERT( d->get_container_type() == c ) ;
-	    }
-	}
+        cout << "*****************************************" << endl;
+        cout << "Look for containers" << endl;
+        {
+            char s[10];
+            char r[10];
+            char c[10];
+            for (int i = 2; i < 5; i++) {
+                sprintf(s, "sym%d", i);
+                sprintf(r, "./real%d", i);
+                sprintf(c, "type%d", i);
+                cout << "    looking for " << s << endl;
+                BESContainer *d = cpv.look_for(s);
+                CPPUNIT_ASSERT( d );
+                CPPUNIT_ASSERT( d->get_real_name() == r );
+                CPPUNIT_ASSERT( d->get_container_type() == c );
+            }
+        }
 
-	cout << "*****************************************" << endl;
-	cout << "show containers" << endl;
-	BESTextInfo info2 ;
-	cpv.show_containers( info2 ) ;
-	info2.print( cout ) ;
+        cout << "*****************************************" << endl;
+        cout << "show containers" << endl;
+        BESTextInfo info2;
+        cpv.show_containers(info2);
+        info2.print(cout);
 
-	cout << "*****************************************" << endl;
-	cout << "Returning from pvolT::run" << endl;
+        cout << "*****************************************" << endl;
+        cout << "Returning from pvolT::run" << endl;
     }
-} ;
+};
 
-CPPUNIT_TEST_SUITE_REGISTRATION( pvolT ) ;
+CPPUNIT_TEST_SUITE_REGISTRATION( pvolT );
 
-int 
-main( int, char** )
+int main(int, char**)
 {
-    CppUnit::TextTestRunner runner ;
-    runner.addTest( CppUnit::TestFactoryRegistry::getRegistry().makeTest() ) ;
+    CppUnit::TextTestRunner runner;
+    runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
 
-    bool wasSuccessful = runner.run( "", false )  ;
+    bool wasSuccessful = runner.run("", false);
 
-    return wasSuccessful ? 0 : 1 ;
+    return wasSuccessful ? 0 : 1;
 }
 


### PR DESCRIPTION
This patches the problem with parallel 'make check' in the bes/dispatch code. It does this by getting one test to use the 'cache' dir and not pollute the directory where the keysT test is reading its key file. A real fix would go into the BESDir class and fix the way it works.