### PR TITLE
Hyrax 91

### DIFF
--- a/modules/asciival/get_ascii_dap4.cc
+++ b/modules/asciival/get_ascii_dap4.cc
@@ -295,10 +295,10 @@ static void print_values_as_ascii(Array *a, bool print_name, ostream &strm, Crc3
 
 static void print_structure_header(Structure *s, ostream &strm)
 {
-	Constructor::Vars_iter p = s->var_begin(), e = s->var_end();
-	bool needs_comma = false;
-	while (p != e) {
-	    if((*p)->send_p()){
+    Constructor::Vars_iter p = s->var_begin(), e = s->var_end();
+    bool needs_comma = false;
+    while (p != e) {
+        if((*p)->send_p()){
             if ((*p)->is_simple_type())
                 strm << (needs_comma?", ":"") <<  (*p)->FQN();
             else if ((*p)->type() == dods_structure_c)
@@ -308,9 +308,9 @@ static void print_structure_header(Structure *s, ostream &strm)
             else
                 throw InternalErr(__FILE__, __LINE__, "Unknown or unsupported type.");
             needs_comma = true;
-	    }
-		++p;
-	}
+        }
+        ++p;
+    }
 }
 
 static void print_structure_ascii(Structure *s, ostream &strm, bool print_name, Crc32 &checksum)
@@ -381,10 +381,10 @@ static void print_val_by_rows(D4Sequence *seq, ostream &strm, Crc32 &checksum)
 
 static void print_sequence_header(D4Sequence *s, ostream &strm)
 {
-	Constructor::Vars_iter p = s->var_begin(), e = s->var_end();
-	bool needs_comma = false;
-	while (p != e) {
-	    if((*p)->send_p()){
+    Constructor::Vars_iter p = s->var_begin(), e = s->var_end();
+    bool needs_comma = false;
+    while (p != e) {
+        if((*p)->send_p()){
             if((*p)->is_simple_type())
                 strm  << (needs_comma?", ":"") << (*p)->FQN();
             else if ((*p)->type() == dods_structure_c)
@@ -395,9 +395,9 @@ static void print_sequence_header(D4Sequence *s, ostream &strm)
                 throw InternalErr(__FILE__, __LINE__, "Unknown or unsupported type.");
 
             needs_comma = true;
-	    }
-		++p;
-	}
+        }
+        ++p;
+    }
 }
 
 

--- a/modules/asciival/get_ascii_dap4.cc
+++ b/modules/asciival/get_ascii_dap4.cc
@@ -296,16 +296,20 @@ static void print_values_as_ascii(Array *a, bool print_name, ostream &strm, Crc3
 static void print_structure_header(Structure *s, ostream &strm)
 {
 	Constructor::Vars_iter p = s->var_begin(), e = s->var_end();
+	bool needs_comma = false;
 	while (p != e) {
-		if ((*p)->is_simple_type())
-			strm << (*p)->FQN();
-		else if ((*p)->type() == dods_structure_c)
-			print_structure_header(static_cast<Structure*>(*p), strm);
-		else if ((*p)->type() == dods_sequence_c)
-			print_sequence_header(static_cast<D4Sequence*>(*p), strm);
-		else
-			throw InternalErr(__FILE__, __LINE__, "Unknown or unsupported type.");
-		if (++p != e) strm << ", ";
+	    if((*p)->send_p()){
+            if ((*p)->is_simple_type())
+                strm << (needs_comma?", ":"") <<  (*p)->FQN();
+            else if ((*p)->type() == dods_structure_c)
+                print_structure_header(static_cast<Structure*>(*p), strm);
+            else if ((*p)->type() == dods_sequence_c)
+                print_sequence_header(static_cast<D4Sequence*>(*p), strm);
+            else
+                throw InternalErr(__FILE__, __LINE__, "Unknown or unsupported type.");
+            needs_comma = true;
+	    }
+		++p;
 	}
 }
 
@@ -378,16 +382,21 @@ static void print_val_by_rows(D4Sequence *seq, ostream &strm, Crc32 &checksum)
 static void print_sequence_header(D4Sequence *s, ostream &strm)
 {
 	Constructor::Vars_iter p = s->var_begin(), e = s->var_end();
+	bool needs_comma = false;
 	while (p != e) {
-		if ((*p)->is_simple_type())
-			strm << (*p)->FQN();
-		else if ((*p)->type() == dods_structure_c)
-			print_structure_header(static_cast<Structure*>(*p), strm);
-		else if ((*p)->type() == dods_sequence_c)
-			print_sequence_header(static_cast<D4Sequence*>(*p), strm);
-		else
-			throw InternalErr(__FILE__, __LINE__, "Unknown or unsupported type.");
-		if (++p != e) strm << ", ";
+	    if((*p)->send_p()){
+            if((*p)->is_simple_type())
+                strm  << (needs_comma?", ":"") << (*p)->FQN();
+            else if ((*p)->type() == dods_structure_c)
+                print_structure_header(static_cast<Structure*>((*p)), strm);
+            else if ((*p)->type() == dods_sequence_c)
+                print_sequence_header(static_cast<D4Sequence*>((*p)), strm);
+            else
+                throw InternalErr(__FILE__, __LINE__, "Unknown or unsupported type.");
+
+            needs_comma = true;
+	    }
+		++p;
 	}
 }
 


### PR DESCRIPTION
This fixes the DAP4 CSV output so that sequence and structure headers only contain member variables that are being transmitted.