### PR TITLE
Fixed a bug in BESDebug.h and reformatted BESStopWatch.cc

### DIFF
--- a/dispatch/BESDebug.h
+++ b/dispatch/BESDebug.h
@@ -59,7 +59,7 @@
 #define BESDEBUG( x, y ) do { if( BESDebug::IsSet( x ) ) *(BESDebug::GetStrm()) << "[" << BESDebug::GetPidStr() << "]["<< x << "] " << y ; } while( 0 )
 #endif
 
-#ifndef NDEBUG
+#ifdef NDEBUG
 #define BESISDEBUG( x ) (false)
 #else
 /** @brief macro used to determine if the specified debug context is set

--- a/dispatch/BESStopWatch.cc
+++ b/dispatch/BESStopWatch.cc
@@ -149,7 +149,7 @@ BESStopWatch::~BESStopWatch()
 		else
 		{
 			// get the difference between the _start_usage and the
-			// _stop_usage and save the difference.
+			// _stop_usage and save the difference in _result.
 			bool success = timeval_subtract() ;
 			if( !success )
 			{
@@ -170,65 +170,9 @@ BESStopWatch::~BESStopWatch()
     				*(BESDebug::GetStrm()) << "[" << BESDebug::GetPidStr() << "]["<< _log_name << "][" << _req_id << "][STOPPED][" << stoptime << "][ms][" << _timer_name << "][ELAPSED][" << elapsed << "][ms]" << endl;
 
 			}
-
-
 		}
 	}
-
 }
-
-
-#if 0
-bool
-BESStopWatch::stop()
-{
-	// if we have started, the we can stop. Otherwise just fall through.
-	if( _started )
-	{
-		// get timer for current usage
-		if( getrusage( RUSAGE_SELF, &_stop_usage ) != 0 )
-		{
-			int myerrno = errno ;
-			char *c_err = strerror( myerrno ) ;
-			string err = "getrusage failed in stop: " ;
-			if( c_err )
-			{
-				err += c_err ;
-			}
-			else
-			{
-				err += "unknown error" ;
-			}
-			BESDEBUG( _log_name, err << endl ) ;
-			_started = false ;
-			_stopped = false ;
-		}
-		else
-		{
-			// get the difference between the _start_usage and the
-			// _stop_usage and save the difference.
-			bool success = timeval_subtract() ;
-			if( !success )
-			{
-				BESDEBUG( _log_name, "failed to get timing" << endl ) ;
-				_started = false ;
-				_stopped = false ;
-			}
-			else
-			{
-				_stopped = true ;
-			}
-		}
-	}
-	else
-	{
-		BESDEBUG( _log_name, "timing not started" << endl ) ;
-	}
-
-	return _stopped ;
-}
-#endif
-
 
 bool
 BESStopWatch::timeval_subtract()


### PR DESCRIPTION
Short and sweet - this fixes one problem where the bes debug context "timing" was noever enabled when --enable-debug was used. In fact, it was only eabled when it _was not_ used. I also removed some old code, but only in one place.