### PR TITLE
Gh docs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,14 +61,19 @@ OSX_Resources bes-config-pkgconfig besd.logrotate
 server-tests:
 	cd cmdln && make server-tests
 
-.PHONY: docs
-docs: doxy.conf
-	doxygen doxy.conf
-	(cd docs && tar -czf html.tar.gz html)
+HTML_DOCS=html
+DOXYGEN_CONF=doxy.conf
 
-# Not needed. jhrg 1/4/16
-# doxy.conf: doxy.conf.in config.status
-# 	./config.status --file=doxy.conf
+# This target only builds the documents, it does not move them to
+# github. Use the 'gh-docs' target below for that.
+.PHONY: docs
+docs: ${DOXYGEN_CONF}
+	doxygen ${DOXYGEN_CONF}
+
+# GitHub.io docs 
+.PHONY: gh-docs 
+gh-docs:
+	./build-gh-docs.sh
 
 # cccc computes metrics like Lines of code and McCabe. It'a available
 # on the web...

--- a/build-gh-docs.sh
+++ b/build-gh-docs.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+# Build the reference guide for this code and publish it using github.io.
+
+DOXYGEN_CONF=doxy.conf
+HTML_DOCS=html
+BRANCH=`git branch | grep '*' | cut -d ' ' -f 2`
+
+if ! git branch --list | grep gh-pages
+then
+    echo "Could not find gh-pages branch"
+    return 1
+fi
+
+# Switch to the gh-pages branch and clean the HTML_DOCS directory if
+# it exists.
+git checkout -q gh-pages
+
+if test -d $HTML_DOCS
+then
+    git rm -rf $HTML_DOCS
+    git commit -m "Removed old docs"
+fi
+
+git checkout -q $BRANCH
+
+# Build the docs. Puts them in a top-level dir named 'html' and that
+# must match $HTML_DOCS. Edit $DOXYGEN_CONF if $HTML_DOCS changes!
+doxygen $DOXYGEN_CONF
+
+# Now switch to the gh-pages branch and commit and push the docs.
+
+git checkout -q gh-pages
+
+git add ${HTML_DOCS}
+git commit -m "Added new docs"
+git push -q
+
+git checkout -q $BRANCH

--- a/doxy.conf.in
+++ b/doxy.conf.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docs
+OUTPUT_DIRECTORY       =
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/doxy.conf.in
+++ b/doxy.conf.in
@@ -107,7 +107,7 @@ BRIEF_MEMBER_DESC      = YES
 # brief descriptions will be completely suppressed.
 # The default value is: YES.
 
-REPEAT_BRIEF           = NO
+REPEAT_BRIEF           = YES
 
 # This tag implements a quasi-intelligent brief description abbreviator that is
 # used to form the text in various listings. Each string in this list, if found
@@ -983,7 +983,7 @@ REFERENCED_BY_RELATION = NO
 # all documented entities called/used by that function will be listed.
 # The default value is: NO.
 
-REFERENCES_RELATION    = YES
+REFERENCES_RELATION    = NO
 
 # If the REFERENCES_LINK_SOURCE tag is set to YES and SOURCE_BROWSER tag is set
 # to YES then the hyperlinks from functions in REFERENCES_RELATION and


### PR DESCRIPTION
This completes Hyrax 384 - automate the doxygen pages and serve them from github.io. Really, they are semi-automated, but the target _gh-docs_ will build an upload them to github.io/bes/html on the gh-pages branch, and there is a README.md file on that branch too. 

https://opendap.atlassian.net/browse/HYRAX-384