### PR TITLE
Distcheck fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ before_script:
 # so we don't want to repeat that here.
 
 script:
-  - if [ ${COVERITY_SCAN_BRANCH} != 1 ]; then make -j7 && make install && make check -j7 && make distcheck -j7 DISTCHECK_CONFIGURE_FLAGS="--prefix=$HOME/build --with-dependencies=$HOME/deps"; fi
+  - if [ ${COVERITY_SCAN_BRANCH} != 1 ]; then make -j7 && make install && make check -j7 && make distcheck -j7; fi
 
 # after_failure:
 #   - LOG_FILE_TGZ=bes-autotest-${TRAVIS_BUILD_NUMBER}-logs.tar.gz

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,7 @@ if WITH_DEPENDENCIES
 # With automake 1.14 setting AM_DISTCHECK... means that the user variable
 # DISTCHECK_CONFIGURE_FLAGS no longer needs to be used. Earlier versions
 # of automake don't support this. jhrg 6/5/17
-AM_DISTCHECK_CONFIGURE_FLAGS=--with-dependencies=@ac_bes_dependencies_prefix@
+AM_DISTCHECK_CONFIGURE_FLAGS += --with-dependencies=@ac_bes_dependencies_prefix@
 endif
 
 SUBDIRS = dispatch xmlcommand ppt server cmdln standalone docs bin templates 

--- a/dispatch/unit-tests/Makefile.am
+++ b/dispatch/unit-tests/Makefile.am
@@ -3,11 +3,14 @@
 
 AUTOMAKE_OPTIONS = foreign
 
+# Because cacheT and uncompressT don't work with distcheck and a
+# parallel build. :-( jhrg 8/22/17
+.NOTPARALLEL:
+
 # Arrange to build with the backward compatibility mode enabled.
 AM_CPPFLAGS = -I$(top_srcdir)/dispatch $(DAP_CFLAGS)
 LDADD = $(top_builddir)/dispatch/libbes_dispatch.la $(DAP_LIBS) 
-#$(LIBS)
-# $(XML2_LIBS)
+
 if CPPUNIT
 AM_CPPFLAGS += $(CPPUNIT_CFLAGS)
 LDADD += $(CPPUNIT_LIBS)
@@ -19,9 +22,7 @@ CXXFLAGS_DEBUG = -g3 -O0  -Wall -W -Wcast-align
 TEST_COV_FLAGS = -ftest-coverage -fprofile-arcs
 
 check_PROGRAMS = $(TESTS)
-# noinst_PROGRAMS = BESCache3Test
 
-#nodist_include_HEADERS = test_config.h breaks make rpm jhrg
 noinst_HEADERS = test_config.h
 
 if CPPUNIT
@@ -139,7 +140,6 @@ regexT_SOURCES = regexT.cc
 scrubT_SOURCES = scrubT.cc
 
 checkT_SOURCES = checkT.cc
-
 
 servicesT_SOURCES = servicesT.cc
 servicesT_CPPFLAGS = $(AM_CPPFLAGS) $(XML2_CFLAGS)


### PR DESCRIPTION
There are better ways to fix the problem of broken parallel builds, but this is the fastest way forward. I added a '.NOTPARALLEL:' option to the top of the bes/dispatch/unit-tests Makefile.am. Fixes the issue. See https://opendap.atlassian.net/browse/HYRAX-465 for more info and a (maybe) better solution.