### PR TITLE
Fix for the daemon.cc argument handling code.

### DIFF
--- a/server/daemon.cc
+++ b/server/daemon.cc
@@ -1062,7 +1062,7 @@ int main(int argc, char *argv[])
         // If the -c option was not passed, but the -i option
         // was passed, then use the -i option to construct
         // the path to the config file
-        if (install_dir.empty() && !install_dir.empty()) {
+        if (config_file.empty() && !install_dir.empty()) {
             if (install_dir[install_dir.length() - 1] != '/') {
                 install_dir += '/';
             }


### PR DESCRIPTION
The software used: if (install_dir.empty() && !install_dir.empty())
when it should have been: if (config_file.empty() && !install_dir.empty())