### PR TITLE
changed how configure looks for cppunit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,9 +254,10 @@ AC_ARG_WITH(libwrap,
     
 AC_HEADER_TR1_FUNCTIONAL
 
-AM_PATH_CPPUNIT(1.12.0,
-	[AM_CONDITIONAL([CPPUNIT], [true])],
-	[AM_CONDITIONAL([CPPUNIT], [false])])
+# Check for cppunit to enable unit testing.
+PKG_CHECK_MODULES([cppunit], [cppunit >= 1.12],
+                             [AM_CONDITIONAL([CPPUNIT], [true])],
+                             [AM_CONDITIONAL([CPPUNIT], [false])])
 
 dnl Use this we add in SQL and DMR++. jhrg 10/9/17
 

--- a/configure.ac
+++ b/configure.ac
@@ -255,9 +255,15 @@ AC_ARG_WITH(libwrap,
 AC_HEADER_TR1_FUNCTIONAL
 
 # Check for cppunit to enable unit testing.
-PKG_CHECK_MODULES([cppunit], [cppunit >= 1.12],
-                             [AM_CONDITIONAL([CPPUNIT], [true])],
-                             [AM_CONDITIONAL([CPPUNIT], [false])])
+AM_PATH_CPPUNIT(1.12.0,
+	[AM_CONDITIONAL([CPPUNIT], [true])],
+	[
+	    PKG_CHECK_MODULES(CPPUNIT, [cppunit >= 1.12.0],
+		[AM_CONDITIONAL([CPPUNIT], [true])],
+		[AM_CONDITIONAL([CPPUNIT], [false])]
+	    )
+	]
+)
 
 dnl Use this we add in SQL and DMR++. jhrg 10/9/17
 


### PR DESCRIPTION
This switches to the new way to find cppunit. See 
https://bugzilla.redhat.com/show_bug.cgi?id=1311694 for an explanation of why cppunit stopped supporting cppunit-config.

In this fix the same thing is accomplished with PKG_CHECK_MODULES.