### PR TITLE
Dmrpp dap2

### DIFF
--- a/dap/BESDASResponse.h
+++ b/dap/BESDASResponse.h
@@ -58,9 +58,13 @@ public:
 
     virtual void dump(ostream &strm) const;
 
-    libdap::DAS * get_das()
+    virtual libdap::DAS * get_das()
     {
         return _das;
+    }
+    virtual void set_das(libdap::DAS *das)
+    {
+        _das = das;
     }
 };
 

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -435,6 +435,9 @@ bool DmrppArray::read_chunks()
     }
     //##############################################################################
 
+    set_read_p(true);
+
+    BESDEBUG("dmrpp", "DmrppArray::"<< __func__ << "() for " << name() << " END"<< endl);
     return true;
 }
 

--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -473,15 +473,7 @@ bool DmrppRequestHandler::dap_build_das(BESDataHandlerInterface & dhi) {
                 dds->print(*BESDebug::GetStrm());
             }
 
-            DAS *tmpdas;
-            tmpdas = das;
-            dds->get_das(tmpdas);
-            // delete tmpdas;
-            // bdas->set_das(das);
-
-            BESDEBUG(module, __func__ << "() - das:             " << (void **)das << endl);
-            BESDEBUG(module, __func__ << "() - bdas->get_das(): " << (void **)bdas->get_das() << endl);
-
+            dds->get_das(das);
 
             // Print the DAS
             if(BESDebug::IsSet(module)){

--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -467,29 +467,24 @@ bool DmrppRequestHandler::dap_build_das(BESDataHandlerInterface & dhi) {
             // Get a DDS from the DMR
             DDS *dds = dmr->getDDS();
             BESDEBUG(module, __func__ << "() - DDS retrieved from DMR." << endl);
-
+            // Print the DDS
             if(BESDebug::IsSet(module)){
                 BESDEBUG(module, __func__ << "() - DDS: " << endl);
                 dds->print(*BESDebug::GetStrm());
             }
 
+            // Load the BESDASResponse DAS from the DDS
             dds->get_das(das);
-
             // Print the DAS
             if(BESDebug::IsSet(module)){
                 BESDEBUG(module, __func__ << "() -  " << "DAS: " << endl);
                 das->print(*(BESDebug::GetStrm()), false);
             }
 
-            BESDEBUG(module, __func__ << "() -  " << "DDS get_attr_table()" << endl);
-            AttrTable at = dds->get_attr_table();
-            for(AttrTable::Attr_iter i = at.attr_begin(); i!=at.attr_end() ; ++i){
-                BESDEBUG(module, __func__ << "() - at.get_name(i): " << at.get_name(i)<< endl);
-            }
-            BESDEBUG(module, __func__ << "() -  " << "Reading Ancillary DAS..." << endl);
+            delete dds;
+            delete dmr;
 
             Ancillary::read_ancillary_das(*das, accessed);
-
             // Add to cache if cache is active
             if (das_cache) {
                 // add a copy
@@ -497,7 +492,6 @@ bool DmrppRequestHandler::dap_build_das(BESDataHandlerInterface & dhi) {
                         "DAS added to the cache for : " << accessed << endl);
                 das_cache->add(new DAS(*das), accessed);
             }
-
         }
         bdas->clear_container();
     }

--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -475,8 +475,10 @@ bool DmrppRequestHandler::dap_build_das(BESDataHandlerInterface & dhi) {
 
             DAS *tmpdas;
             tmpdas = das;
-            das = dds->get_das();
-            delete tmpdas;
+            dds->get_das(tmpdas);
+            // delete tmpdas;
+            // bdas->set_das(das);
+
             BESDEBUG(module, __func__ << "() - das:             " << (void **)das << endl);
             BESDEBUG(module, __func__ << "() - bdas->get_das(): " << (void **)bdas->get_das() << endl);
 
@@ -484,8 +486,15 @@ bool DmrppRequestHandler::dap_build_das(BESDataHandlerInterface & dhi) {
             // Print the DAS
             if(BESDebug::IsSet(module)){
                 BESDEBUG(module, __func__ << "() -  " << "DAS: " << endl);
-                das->print(*BESDebug::GetStrm(), true);
+                das->print(*(BESDebug::GetStrm()), false);
             }
+
+            BESDEBUG(module, __func__ << "() -  " << "DDS get_attr_table()" << endl);
+            AttrTable at = dds->get_attr_table();
+            for(AttrTable::Attr_iter i = at.attr_begin(); i!=at.attr_end() ; ++i){
+                BESDEBUG(module, __func__ << "() - at.get_name(i): " << at.get_name(i)<< endl);
+            }
+            BESDEBUG(module, __func__ << "() -  " << "Reading Ancillary DAS..." << endl);
 
             Ancillary::read_ancillary_das(*das, accessed);
 
@@ -496,6 +505,7 @@ bool DmrppRequestHandler::dap_build_das(BESDataHandlerInterface & dhi) {
                         "DAS added to the cache for : " << accessed << endl);
                 das_cache->add(new DAS(*das), accessed);
             }
+
         }
         bdas->clear_container();
     }

--- a/modules/dmrpp_module/DmrppRequestHandler.h
+++ b/modules/dmrpp_module/DmrppRequestHandler.h
@@ -63,6 +63,7 @@ public:
 	static bool dap_build_dap4data(BESDataHandlerInterface &dhi);
     static bool dap_build_das(BESDataHandlerInterface &dhi);
     static bool dap_build_dds(BESDataHandlerInterface &dhi);
+    static bool dap_build_dap2data(BESDataHandlerInterface &dhi);
 
 	static bool dap_build_vers(BESDataHandlerInterface &dhi);
 	static bool dap_build_help(BESDataHandlerInterface &dhi);

--- a/modules/dmrpp_module/DmrppRequestHandler.h
+++ b/modules/dmrpp_module/DmrppRequestHandler.h
@@ -61,7 +61,8 @@ public:
 
 	static bool dap_build_dmr(BESDataHandlerInterface &dhi);
 	static bool dap_build_dap4data(BESDataHandlerInterface &dhi);
-	static bool dap_build_das(BESDataHandlerInterface &dhi);
+    static bool dap_build_das(BESDataHandlerInterface &dhi);
+    static bool dap_build_dds(BESDataHandlerInterface &dhi);
 
 	static bool dap_build_vers(BESDataHandlerInterface &dhi);
 	static bool dap_build_help(BESDataHandlerInterface &dhi);

--- a/modules/dmrpp_module/DmrppRequestHandler.h
+++ b/modules/dmrpp_module/DmrppRequestHandler.h
@@ -29,6 +29,7 @@
 #include "BESRequestHandler.h"
 
 #undef DAP2
+class ObjMemCache;  // in bes/dap
 
 namespace libdap {
 	class DMR;
@@ -38,6 +39,12 @@ namespace libdap {
 namespace dmrpp {
 
 class DmrppRequestHandler: public BESRequestHandler {
+
+private:
+    static ObjMemCache *das_cache;
+    static ObjMemCache *dds_cache;
+    static ObjMemCache *dmr_cache;
+
 
 	// These are static because they are used by the static public methods.
 	static void build_dmr_from_file(const std::string& accessed, bool explicit_containers, libdap::DMR* dmr);
@@ -54,6 +61,7 @@ public:
 
 	static bool dap_build_dmr(BESDataHandlerInterface &dhi);
 	static bool dap_build_dap4data(BESDataHandlerInterface &dhi);
+	static bool dap_build_das(BESDataHandlerInterface &dhi);
 
 	static bool dap_build_vers(BESDataHandlerInterface &dhi);
 	static bool dap_build_help(BESDataHandlerInterface &dhi);


### PR DESCRIPTION
These changes enabled DAP 2 responses for DMRPP datasets. Also this change enables the ncml_handler to work correctly (Tested joinNew and joinExisiting)