### PR TITLE
Migrating dmrpp representation to dedicated namespaces

### DIFF
--- a/modules/dmrpp_module/DmrppParserSax2.cc
+++ b/modules/dmrpp_module/DmrppParserSax2.cc
@@ -57,7 +57,7 @@
 #include "DmrppCommon.h"
 
 static const string module = "dmrpp:2";
-static const string dmrpp_namespace = "http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#";
+static const string dmrpp_namespace = "http://xml.opendap.org/dap/dmrpp/1.0.0#";
 
 using namespace libdap;
 using namespace std;

--- a/modules/dmrpp_module/DmrppParserSax2.cc
+++ b/modules/dmrpp_module/DmrppParserSax2.cc
@@ -57,7 +57,7 @@
 #include "DmrppCommon.h"
 
 static const string module = "dmrpp:2";
-static const string hdf4_namespace = "http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1";
+static const string dmrpp_namespace = "http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#";
 
 using namespace libdap;
 using namespace std;
@@ -86,7 +86,7 @@ static const char *states[] = { "parser_start",
 
     "inside_constructor",
 
-    "not_dap4_element", "inside_h4_object", "inside_h4_chunkDimensionSizes_element",
+    "not_dap4_element", "inside_dmrpp_object", "inside_dmrpp_chunkDimensionSizes_element",
 
     "parser_unknown", "parser_error", "parser_fatal_error",
 
@@ -636,16 +636,16 @@ void DmrppParserSax2::dmr_start_element(void *p, const xmlChar *l, const xmlChar
         string dap4_ns_name = DapXmlNamspaces::getDapNamespaceString(DAP_4_0);
         if (parser->debug()) cerr << "dap4_ns_name:         " << dap4_ns_name << endl;
 
-        if (this_element_ns_name == hdf4_namespace) {
+        if (this_element_ns_name == dmrpp_namespace) {
             if (strcmp(localname, "chunkDimensionSizes") == 0) {
-                if (parser->debug()) cerr << "Found h4:chunkDimensionSizes element. Pushing state." << endl;
-                parser->push_state(inside_h4_chunkDimensionSizes_element);
+                if (parser->debug()) cerr << "Found dmrpp:chunkDimensionSizes element. Pushing state." << endl;
+                parser->push_state(inside_dmrpp_chunkDimensionSizes_element);
             }
             else {
                 if (parser->debug())
-                    cerr << "Start of element in hdf4 namespace: " << localname << " detected." << endl;
-                parser->push_state(inside_h4_object);
-                // Ingest the h4:chunkDimensionSizes element text content
+                    cerr << "Start of element in dmrpp namespace: " << localname << " detected." << endl;
+                parser->push_state(inside_dmrpp_object);
+                // Ingest the dmrpp namespaced element text content
             }
 
         }
@@ -680,6 +680,11 @@ void DmrppParserSax2::dmr_start_element(void *p, const xmlChar *l, const xmlChar
             parser->dmr()->set_request_xml_base(parser->xml_attrs["base"].value);
         }
         if (parser->debug()) cerr << "Dataset xml:base is set to '" << parser->dmr()->request_xml_base() << "'" << endl;
+
+        if (parser->check_attribute("href")) {
+            parser->dmrpp_dataset_href = parser->xml_attrs["href"].value;
+        }
+        if (parser->debug()) cerr << "Dataset dmrpp:href is set to '" << parser->dmrpp_dataset_href << "'" << endl;
 
         if (!parser->root_ns.empty()) parser->dmr()->set_namespace(parser->root_ns);
 
@@ -837,9 +842,9 @@ void DmrppParserSax2::dmr_start_element(void *p, const xmlChar *l, const xmlChar
                 << endl;
         break;
 
-    case inside_h4_object: {
-        if (parser->debug()) cerr << "Inside hdf4 namespaced element. localname: " << localname << endl;
-        assert(this_element_ns_name == hdf4_namespace);
+    case inside_dmrpp_object: {
+        if (parser->debug()) cerr << "Inside dmrpp namespaced element. localname: " << localname << endl;
+        assert(this_element_ns_name == dmrpp_namespace);
 
         parser->transfer_xml_attrs(attributes, nb_attributes); // load up xml_attrs
 
@@ -850,7 +855,7 @@ void DmrppParserSax2::dmr_start_element(void *p, const xmlChar *l, const xmlChar
         if (!dc)
             throw BESInternalError("Could not cast BaseType to DmrppType in the drmpp handler.", __FILE__, __LINE__);
 
-        // Ingest the h4:chunks element and it attributes
+        // Ingest the dmrpp:chunks element and it attributes
         if (strcmp(localname, "chunks") == 0) {
             if (parser->debug()) cerr << "Inside HDF4 chunks element. localname: " << localname << endl;
 #if 0
@@ -883,8 +888,8 @@ void DmrppParserSax2::dmr_start_element(void *p, const xmlChar *l, const xmlChar
                         << " " << bt->name() << "'" << endl;
             }
         }
-        // Ingest an h4:byteStream element and its attributes
-        else if (strcmp(localname, "byteStream") == 0) {
+        // Ingest an dmrpp:chunk element and its attributes
+        else if (strcmp(localname, "chunk") == 0) {
             string data_url = "unknown_data_location";
             if (parser->check_attribute("href")) {
                 istringstream data_url_ss(parser->xml_attrs["href"].value);
@@ -893,12 +898,12 @@ void DmrppParserSax2::dmr_start_element(void *p, const xmlChar *l, const xmlChar
                     cerr << "Processing 'href' value into data_url. href: " << data_url_ss.str() << endl;
             }
             else {
-                if (parser->debug()) cerr << "No attribute 'href' located. Trying xml:base..." << endl;
+                if (parser->debug()) cerr << "No attribute 'href' located. Trying Dataset/@dmrpp:href..." << endl;
                 // This bit of magic sets the URL used to get the data and it's
                 // magic in part because it may be a file or an http URL
-                data_url = parser->dmr()->request_xml_base();
+                data_url = parser->dmrpp_dataset_href;
                 if (parser->debug())
-                    cerr << "Processing xml:base into data_url. xml:base: '" << data_url << "'" << endl;
+                    cerr << "Processing dmrpp:href into data_url. dmrpp:href='" << data_url << "'" << endl;
             }
             // First we see if it's an HTTP URL, and if not we
             // make a local file url based on the Catalog Root
@@ -907,7 +912,7 @@ void DmrppParserSax2::dmr_start_element(void *p, const xmlChar *l, const xmlChar
             std::string file("file://");
             if (data_url.compare(0, http.size(), http) && data_url.compare(0, https.size(), https)
                 && data_url.compare(0, file.size(), file)) {
-                if (parser->debug()) cerr << "xml:base does NOT start with '" << http << "' or with '" << https << "'. "
+                if (parser->debug()) cerr << "data_url does NOT start with '" << http << "' or with '" << https << "'. "
                     "Retrieving default catalog root directory" << endl;
                 // Now we try to find the default catalog. If we can't find it we punt and leave it be.
                 string defcatname = BESCatalogList::TheCatalogList()->default_catalog_name();
@@ -993,8 +998,8 @@ void DmrppParserSax2::dmr_start_element(void *p, const xmlChar *l, const xmlChar
     }
         break;
 
-    case inside_h4_chunkDimensionSizes_element:
-        // The h4:chunkDimensionSizes value is processed by the end element code.
+    case inside_dmrpp_chunkDimensionSizes_element:
+        // The dmrpp:chunkDimensionSizes value is processed by the end element code.
         break;
 
     case parser_unknown:
@@ -1242,12 +1247,12 @@ void DmrppParserSax2::dmr_end_element(void *p, const xmlChar *l, const xmlChar *
         parser->pop_state();
         break;
 
-    case inside_h4_object:
-        if (parser->debug()) cerr << "End of h4 namespace element: " << localname << endl;
+    case inside_dmrpp_object:
+        if (parser->debug()) cerr << "End of dmrpp namespace element: " << localname << endl;
         parser->pop_state();
         break;
 
-    case inside_h4_chunkDimensionSizes_element: {
+    case inside_dmrpp_chunkDimensionSizes_element: {
         if (parser->debug()) cerr << "End of chunkDimensionSizes element. localname: " << localname << endl;
 
         if (is_not(localname, "chunkDimensionSizes"))
@@ -1288,7 +1293,7 @@ void DmrppParserSax2::dmr_get_characters(void * p, const xmlChar * ch, int len)
 
     switch (parser->get_state()) {
     case inside_attribute_value:
-    case inside_h4_chunkDimensionSizes_element:
+    case inside_dmrpp_chunkDimensionSizes_element:
         parser->char_data.append((const char *) (ch), len);
         BESDEBUG(module, "Characters: '" << parser->char_data << "'" << endl);
         break;

--- a/modules/dmrpp_module/DmrppParserSax2.h
+++ b/modules/dmrpp_module/DmrppParserSax2.h
@@ -52,7 +52,7 @@ class D4Dimension;
 namespace dmrpp {
 /**
  * Hacked DMR parser copied from libdap. This version of the parser processes
- * h4:byteStream elements and stores their information (xml attributes) in
+ * dmrpp:chunk elements and stores their information (xml attributes) in
  * Dmrpp BaseTypes.
  */
 class DmrppParserSax2
@@ -90,10 +90,10 @@ private:
 
         // inside_sequence, Removed from merged code jhrg 5/2/14
 
-        // FIXMEinside_h4_byte_stream,
+        // FIXMEinside_dmrpp_byte_stream,
         not_dap4_element,
-        inside_h4_object,
-        inside_h4_chunkDimensionSizes_element,
+        inside_dmrpp_object,
+        inside_dmrpp_chunkDimensionSizes_element,
 
         parser_unknown,
         parser_error,
@@ -165,6 +165,8 @@ private:
 
     bool d_strict;
 
+    string dmrpp_dataset_href;
+
     class XMLAttribute {
         public:
         string prefix;
@@ -232,7 +234,7 @@ private:
     bool process_group(const char *name, const xmlChar **attrs, int nb_attributes);
     bool process_enum_def(const char *name, const xmlChar **attrs, int nb_attributes);
     bool process_enum_const(const char *name, const xmlChar **attrs, int nb_attributes);
-    bool process_h4_object(const char *name, const xmlChar **attrs, int nb_attributes);
+    bool process_dmrpp_object(const char *name, const xmlChar **attrs, int nb_attributes);
 
     void finish_variable(const char *tag, libdap::Type t, const char *expected);
     //@}
@@ -245,7 +247,8 @@ public:
         other_xml(""), other_xml_depth(0), unknown_depth(0),
         error_msg(""), context(0),
         dods_attr_name(""), dods_attr_type(""),
-        char_data(""), root_ns(""), d_debug(false), d_strict(true)
+        char_data(""), root_ns(""), d_debug(false), d_strict(true),
+        dmrpp_dataset_href("")
     {
         //xmlSAXHandler ddx_sax_parser;
         memset(&ddx_sax_parser, 0, sizeof(xmlSAXHandler));

--- a/modules/dmrpp_module/data/convert
+++ b/modules/dmrpp_module/data/convert
@@ -6,7 +6,7 @@ outfile=$2
 echo "input file:  ${infile}"
 echo "output file: ${outfile}"
 
-dmrppNamespace="xmlns:dmrpp=\"http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#\""
+dmrppNamespace="xmlns:dmrpp=\"http://xml.opendap.org/dap/dmrpp/1.0.0#\""
 echo "dmrppNamespace: ${dmrppNamespace}"
 
 #       <h4:byteStream offset="5304" nBytes="32000" uuid="ec77e116-5c0c-4f92-9f21-592479a2bbb0" md5="a06ab7cf03daed2e76209059b8001d76"/>

--- a/modules/dmrpp_module/data/convert
+++ b/modules/dmrpp_module/data/convert
@@ -6,7 +6,7 @@ outfile=$2
 echo "input file:  ${infile}"
 echo "output file: ${outfile}"
 
-dmrppNamespace="xmlns:dmrpp=\"http://xml.opendap.org/dap/dmrpp/1.0.0#\""
+dmrppNamespace="    xmlns:dmrpp=\"http://xml.opendap.org/dap/dmrpp/1.0.0#\""
 echo "dmrppNamespace: ${dmrppNamespace}"
 
 #       <h4:byteStream offset="5304" nBytes="32000" uuid="ec77e116-5c0c-4f92-9f21-592479a2bbb0" md5="a06ab7cf03daed2e76209059b8001d76"/>

--- a/modules/dmrpp_module/data/convert
+++ b/modules/dmrpp_module/data/convert
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+infile=$1
+outfile=$2
+
+echo "input file:  ${infile}"
+echo "output file: ${outfile}"
+
+dmrppNamespace="xmlns:dmrpp=\"http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#\""
+echo "dmrppNamespace: ${dmrppNamespace}"
+
+#       <h4:byteStream offset="5304" nBytes="32000" uuid="ec77e116-5c0c-4f92-9f21-592479a2bbb0" md5="a06ab7cf03daed2e76209059b8001d76"/>
+
+awk -v dmrppNamespace="${dmrppNamespace}" '{
+
+    if(index($0,"xmlns:h4")!=0){
+        for(i=1; i<=NF ;i++){
+            // convert h4 namespace prefix to our new one
+            if(index($i,"xmlns:h4")==1){
+                $i = dmrppNamespace;
+            }
+        }
+    }
+    if($1 == "<h4:byteStream"){
+        # print "Converting: ";
+        # print $0;
+        whitespace =  index($0,"<")-1;
+        $1 = "<dmrpp:chunk"
+        for(i=2; i<=NF ;i++){
+            if(index($i,"uuid")==1){
+                $i = "";
+            }
+            else if(index($i,"md5")==1){
+                $i = "";
+            }
+        }
+        if(match($0,"^.*/>$")==0){
+            $0 = $0"/>";
+        }
+        for(i=0;i<whitespace; i++){
+            printf(" ");
+        }
+    }
+    else {
+        // convert h4 elements to dmrpp
+        gsub("h4:","dmrpp:");
+        // convert xml base to dmrpp href
+        gsub("xml:base","dmrpp:href");
+        
+    }
+    print $0;
+    
+}' $infile > $outfile
+    

--- a/modules/dmrpp_module/data/dmrpp/a2_local_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/a2_local_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_twoD.h5">

--- a/modules/dmrpp_module/data/dmrpp/a2_local_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/a2_local_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_twoD.h5">

--- a/modules/dmrpp_module/data/dmrpp/a2_local_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/a2_local_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_twoD.h5">
@@ -14,12 +14,12 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_4_chunks</Value>
     </Attribute>
-    <h4:chunks>
-      <h4:chunkDimensionSizes>50 50</h4:chunkDimensionSizes>
-      <h4:byteStream nBytes="10000" offset="4016" chunkPositionInArray="[0,0]" uuid="dfb35a6e-9a2a-489b-8db4-0ac6e72024ac" md5="e9fe1c46d8972badd0a9fc63ac20b9c8" href="data/dmrpp/chunked_twoD.h5" />
-      <h4:byteStream nBytes="10000" offset="14016" chunkPositionInArray="[0,50]" uuid="7ee1dcec-0281-463e-b916-6a25ba71e583" md5="44c89fb4f22581458713fbb694d3a5a5" href="data/dmrpp/chunked_twoD.h5" />
-      <h4:byteStream nBytes="10000" offset="24016" chunkPositionInArray="[50,0]" uuid="f2104e92-1775-488d-a2a2-dc487c49c35b" md5="f289b3eb40673d17d23fefcab6b8b7b2" href="data/dmrpp/chunked_twoD.h5" />
-      <h4:byteStream nBytes="10000" offset="34016" chunkPositionInArray="[50,50]" uuid="3aff561a-460e-49ba-9219-e0df6129d0f1" md5="b539d5234abdfc314935f548f28a7330" href="data/dmrpp/chunked_twoD.h5" />
-    </h4:chunks>
+    <dmrpp:chunks>
+      <dmrpp:chunkDimensionSizes>50 50</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk nBytes="10000" offset="4016" chunkPositionInArray="[0,0]"   href="data/dmrpp/chunked_twoD.h5" />
+      <dmrpp:chunk nBytes="10000" offset="14016" chunkPositionInArray="[0,50]"   href="data/dmrpp/chunked_twoD.h5" />
+      <dmrpp:chunk nBytes="10000" offset="24016" chunkPositionInArray="[50,0]"   href="data/dmrpp/chunked_twoD.h5" />
+      <dmrpp:chunk nBytes="10000" offset="34016" chunkPositionInArray="[50,50]"   href="data/dmrpp/chunked_twoD.h5" />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/a3_local_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/a3_local_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0"
     dmrVersion="1.0"
     name="chunked_shufzip_twoD.h5">

--- a/modules/dmrpp_module/data/dmrpp/a3_local_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/a3_local_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0"
     dmrVersion="1.0"
     name="chunked_shufzip_twoD.h5">

--- a/modules/dmrpp_module/data/dmrpp/a3_local_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/a3_local_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1"
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0"
     dmrVersion="1.0"
     name="chunked_shufzip_twoD.h5">
@@ -14,12 +14,12 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_4_shufzip_chunks</Value>
     </Attribute>
-    <h4:chunks deflate_level="6" compressionType="shuffle deflate">
-      <h4:chunkDimensionSizes>50 50</h4:chunkDimensionSizes>
-      <h4:byteStream chunkPositionInArray="[0,0]" nBytes="976" md5="a6fee7e3efc727e4b43ae9daf881cb58" offset="0" uuid="fdb9ab5b-3847-401b-9607-b27dab10956f" href="data/dmrpp/bstream_a6fee7e3efc727e4b43ae9daf881cb58.bs" />
-      <h4:byteStream chunkPositionInArray="[0,50]" nBytes="978" md5="63004b2080d84a81469dc0f113a3c843" offset="0" uuid="71ae8820-7128-4e6c-89c9-0be546dd490a" href="data/dmrpp/bstream_63004b2080d84a81469dc0f113a3c843.bs" />
-      <h4:byteStream chunkPositionInArray="[50,0]" nBytes="532" md5="52310773dfe8f711ca3ad4a95cbd65d8" offset="0" uuid="d1f06001-3413-4e0f-acb7-3a996d0e09c1" href="data/dmrpp/bstream_52310773dfe8f711ca3ad4a95cbd65d8.bs" />
-      <h4:byteStream chunkPositionInArray="[50,50]" nBytes="530" md5="3980492644c726c40d98833e277e02da" offset="0" uuid="8d04d293-06f6-4637-bf11-92f9e7e4af6d" href="data/dmrpp/bstream_3980492644c726c40d98833e277e02da.bs" />
-    </h4:chunks>
+    <dmrpp:chunks deflate_level="6" compressionType="shuffle deflate">
+      <dmrpp:chunkDimensionSizes>50 50</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk chunkPositionInArray="[0,0]" nBytes="976"  offset="0"  href="data/dmrpp/bstream_a6fee7e3efc727e4b43ae9daf881cb58.bs" />
+      <dmrpp:chunk chunkPositionInArray="[0,50]" nBytes="978"  offset="0"  href="data/dmrpp/bstream_63004b2080d84a81469dc0f113a3c843.bs" />
+      <dmrpp:chunk chunkPositionInArray="[50,0]" nBytes="532"  offset="0"  href="data/dmrpp/bstream_52310773dfe8f711ca3ad4a95cbd65d8.bs" />
+      <dmrpp:chunk chunkPositionInArray="[50,50]" nBytes="530"  offset="0"  href="data/dmrpp/bstream_3980492644c726c40d98833e277e02da.bs" />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_fourD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_fourD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_fourD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_fourD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_fourD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_fourD.h5"
-    xml:base="data/dmrpp/chunked_fourD.h5">
+    dmrpp:href="data/dmrpp/chunked_fourD.h5">
   <Float32 name="d_16_chunks">
     <Dim size="40"/>
     <Dim size="40"/>
@@ -17,24 +17,24 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_16_chunks</Value>
     </Attribute>
-    <h4:chunks>
-      <h4:chunkDimensionSizes>20 20 20 20</h4:chunkDimensionSizes>
-      <h4:byteStream offset="4728" uuid="33145d5e-5d0f-4f45-847c-22a1a17f5fc5" nBytes="640000" chunkPositionInArray="[0,0,0,0]" md5="0be2486ca003317033500ba637a08c20"/>
-      <h4:byteStream offset="644728" uuid="3e66bd31-0879-4cf3-86ae-a1799d8cef8f" nBytes="640000" chunkPositionInArray="[0,0,0,20]" md5="a0eb5e4d7530db08b22787eb481dfae2"/>
-      <h4:byteStream offset="1284728" uuid="97c10076-57a0-44a2-a2e1-598a4efe24c9" nBytes="640000" chunkPositionInArray="[0,0,20,0]" md5="996f2b55d2fa5c648d2ead32a543252f"/>
-      <h4:byteStream offset="1924728" uuid="4a9b1006-8ce4-4f9b-a3cc-c5abdd034122" nBytes="640000" chunkPositionInArray="[0,0,20,20]" md5="d9f4e9ecd5e14462a5a37e5db54a5588"/>
-      <h4:byteStream offset="2564728" uuid="da0a1ebd-0237-47f2-82bc-28f9493be33f" nBytes="640000" chunkPositionInArray="[0,20,0,0]" md5="eebe6cc78a975433305350944f07687a"/>
-      <h4:byteStream offset="3204728" uuid="37050004-9c2c-437e-8c4f-2df08b3fa863" nBytes="640000" chunkPositionInArray="[0,20,0,20]" md5="d0152263f5f846cbcb59b87ec8a5d9be"/>
-      <h4:byteStream offset="3844728" uuid="74901920-14af-4633-a3c5-07188a9d26ab" nBytes="640000" chunkPositionInArray="[0,20,20,0]" md5="d3af03a82f7d1edd8ec08b79befae5ba"/>
-      <h4:byteStream offset="4484728" uuid="a34dd3d6-d466-45a7-b7fc-340be2891693" nBytes="640000" chunkPositionInArray="[0,20,20,20]" md5="5a6a71b3b3499adde7a4100e8911d128"/>
-      <h4:byteStream offset="5124728" uuid="546657b3-b253-4e66-b18f-131903907a97" nBytes="640000" chunkPositionInArray="[20,0,0,0]" md5="5c404ecb9e91c65d3040d00fa120a535"/>
-      <h4:byteStream offset="5764728" uuid="ccb317a6-da4d-476d-8195-02c8e884aed1" nBytes="640000" chunkPositionInArray="[20,0,0,20]" md5="ebb033e4089fe806995fdb98c99e2b69"/>
-      <h4:byteStream offset="6404728" uuid="905dd747-857b-48b5-8779-97a4950b1bec" nBytes="640000" chunkPositionInArray="[20,0,20,0]" md5="744165d12ce7e711d351b34e26bdda93"/>
-      <h4:byteStream offset="7044728" uuid="d32ae4f2-cfcd-49f3-a75e-7d629670f2b7" nBytes="640000" chunkPositionInArray="[20,0,20,20]" md5="92b32b823475edd1d7a883a38c421f5f"/>
-      <h4:byteStream offset="7684728" uuid="1ebb6fd4-daa1-4823-b88f-fe2258f6929d" nBytes="640000" chunkPositionInArray="[20,20,0,0]" md5="c3c0d9fcb49c278c6d6f87cf4e055533"/>
-      <h4:byteStream offset="8324728" uuid="a0b01b6a-5223-45b2-a9c7-25863ec21e24" nBytes="640000" chunkPositionInArray="[20,20,0,20]" md5="da76457dbbc0cd4ff297d47dc3ac71cd"/>
-      <h4:byteStream offset="8964728" uuid="02392809-7018-4f7a-8dd7-ad853fa11518" nBytes="640000" chunkPositionInArray="[20,20,20,0]" md5="6f43b5e854d39fa311ba21e006f2ec26"/>
-      <h4:byteStream offset="9606776" uuid="9ba9ad4c-fb1f-4de1-9235-19cf2e4dd09b" nBytes="640000" chunkPositionInArray="[20,20,20,20]" md5="dd4b683673450ccd2c9da64966cfc7b9"/>
-    </h4:chunks>
+    <dmrpp:chunks>
+      <dmrpp:chunkDimensionSizes>20 20 20 20</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk offset="4728"  nBytes="640000" chunkPositionInArray="[0,0,0,0]" />
+      <dmrpp:chunk offset="644728"  nBytes="640000" chunkPositionInArray="[0,0,0,20]" />
+      <dmrpp:chunk offset="1284728"  nBytes="640000" chunkPositionInArray="[0,0,20,0]" />
+      <dmrpp:chunk offset="1924728"  nBytes="640000" chunkPositionInArray="[0,0,20,20]" />
+      <dmrpp:chunk offset="2564728"  nBytes="640000" chunkPositionInArray="[0,20,0,0]" />
+      <dmrpp:chunk offset="3204728"  nBytes="640000" chunkPositionInArray="[0,20,0,20]" />
+      <dmrpp:chunk offset="3844728"  nBytes="640000" chunkPositionInArray="[0,20,20,0]" />
+      <dmrpp:chunk offset="4484728"  nBytes="640000" chunkPositionInArray="[0,20,20,20]" />
+      <dmrpp:chunk offset="5124728"  nBytes="640000" chunkPositionInArray="[20,0,0,0]" />
+      <dmrpp:chunk offset="5764728"  nBytes="640000" chunkPositionInArray="[20,0,0,20]" />
+      <dmrpp:chunk offset="6404728"  nBytes="640000" chunkPositionInArray="[20,0,20,0]" />
+      <dmrpp:chunk offset="7044728"  nBytes="640000" chunkPositionInArray="[20,0,20,20]" />
+      <dmrpp:chunk offset="7684728"  nBytes="640000" chunkPositionInArray="[20,20,0,0]" />
+      <dmrpp:chunk offset="8324728"  nBytes="640000" chunkPositionInArray="[20,20,0,20]" />
+      <dmrpp:chunk offset="8964728"  nBytes="640000" chunkPositionInArray="[20,20,20,0]" />
+      <dmrpp:chunk offset="9606776"  nBytes="640000" chunkPositionInArray="[20,20,20,20]" />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_gzipped_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_gzipped_fourD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_gzipped_fourD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_gzipped_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_gzipped_fourD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_gzipped_fourD.h5"
-    xml:base="data/dmrpp/chunked_gzipped_fourD.h5">
+    dmrpp:href="data/dmrpp/chunked_gzipped_fourD.h5">
 
   <Float32 name="d_16_gzipped_chunks">
     <Dim size="40"/>
@@ -18,24 +18,24 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_16_gzipped_chunks</Value>
     </Attribute>
-    <h4:chunks deflate_level="6" compressionType="deflate">
-      <h4:chunkDimensionSizes>20 20 20 20</h4:chunkDimensionSizes>
-      <h4:byteStream offset="4728" uuid="e5853038-de02-48e0-9eaf-5fb8ec4f01cb" nBytes="170568" chunkPositionInArray="[0,0,0,0]" md5="214548350db769caf59f4b345c8ec9eb"/>
-      <h4:byteStream offset="175296" uuid="0588f68c-9272-41ca-ae3e-2e49153de3da" nBytes="174124" chunkPositionInArray="[0,0,0,20]" md5="ad64da75a72ac0f8bfaf433737e01ba1"/>
-      <h4:byteStream offset="349420" uuid="b975412a-ef8c-4c87-a5b1-7d8cfd424ab7" nBytes="170395" chunkPositionInArray="[0,0,20,0]" md5="c3a87ccdaa0d94c50debde9d8ff6012e"/>
-      <h4:byteStream offset="519815" uuid="524465d2-709a-41d9-8dbf-a493d6d2904f" nBytes="173864" chunkPositionInArray="[0,0,20,20]" md5="7a8c8ba0bcbfba7dac5af8d04cc4aa73"/>
-      <h4:byteStream offset="693679" uuid="d2e25bdd-fce1-4633-8ec0-411ada19488e" nBytes="171774" chunkPositionInArray="[0,20,0,0]" md5="9a0a28f2c3561f6eac7f0136452755f5"/>
-      <h4:byteStream offset="865453" uuid="5d230c25-fa2f-4ca6-8248-a01827112e46" nBytes="175411" chunkPositionInArray="[0,20,0,20]" md5="3a2cc35a7951c9293a175869b3032780"/>
-      <h4:byteStream offset="1040864" uuid="5f24a960-b44b-4e0e-b9dd-8b8b68316f71" nBytes="171786" chunkPositionInArray="[0,20,20,0]" md5="8725046c1398e5a69b09c12e1a4a9d4e"/>
-      <h4:byteStream offset="1212650" uuid="fc19f61d-561e-457b-b88e-e6f36bbf57de" nBytes="175367" chunkPositionInArray="[0,20,20,20]" md5="0576f155306bef7cf88afac9dbac65eb"/>
-      <h4:byteStream offset="1388017" uuid="99b40758-e426-407b-b13d-8dd44188d2bc" nBytes="184284" chunkPositionInArray="[20,0,0,0]" md5="ab3e15f50b649345174821e0d60d27ef"/>
-      <h4:byteStream offset="1572301" uuid="690a8673-dd84-4931-9c82-9343e3d69cfb" nBytes="185508" chunkPositionInArray="[20,0,0,20]" md5="a390819f2d46d836e1aa8cabb969df3f"/>
-      <h4:byteStream offset="1757809" uuid="cb5a147b-3a24-47c8-a2ca-3d311c190bc2" nBytes="184548" chunkPositionInArray="[20,0,20,0]" md5="e4e7077c431ff23112f1e61ab3359b6c"/>
-      <h4:byteStream offset="1942357" uuid="e619d3a2-f6b5-4fda-b94c-fc5d7900a5dd" nBytes="185617" chunkPositionInArray="[20,0,20,20]" md5="3a7f5683c0a130776433ad4473efdccf"/>
-      <h4:byteStream offset="2127974" uuid="ea802b31-abff-43ee-b400-40a5cbdf75eb" nBytes="184387" chunkPositionInArray="[20,20,0,0]" md5="79fefb8db5fbf30f6a01c5d75083ec2d"/>
-      <h4:byteStream offset="2312361" uuid="f16a8ff0-2f24-4354-949f-77ce5940e5db" nBytes="185511" chunkPositionInArray="[20,20,0,20]" md5="3a911f845c7057737661d3794ab42f55"/>
-      <h4:byteStream offset="2497872" uuid="351be986-7288-41b1-b3d2-91a838158457" nBytes="184573" chunkPositionInArray="[20,20,20,0]" md5="7ae2d4dd22d899fb54840072f91888d8"/>
-      <h4:byteStream offset="2684493" uuid="3de388ae-fc63-4288-a806-a042d9002cd9" nBytes="185594" chunkPositionInArray="[20,20,20,20]" md5="f3faaa949ebff53cbd22d68265786d55"/>
-    </h4:chunks>
+    <dmrpp:chunks deflate_level="6" compressionType="deflate">
+      <dmrpp:chunkDimensionSizes>20 20 20 20</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk offset="4728"  nBytes="170568" chunkPositionInArray="[0,0,0,0]" />
+      <dmrpp:chunk offset="175296"  nBytes="174124" chunkPositionInArray="[0,0,0,20]" />
+      <dmrpp:chunk offset="349420"  nBytes="170395" chunkPositionInArray="[0,0,20,0]" />
+      <dmrpp:chunk offset="519815"  nBytes="173864" chunkPositionInArray="[0,0,20,20]" />
+      <dmrpp:chunk offset="693679"  nBytes="171774" chunkPositionInArray="[0,20,0,0]" />
+      <dmrpp:chunk offset="865453"  nBytes="175411" chunkPositionInArray="[0,20,0,20]" />
+      <dmrpp:chunk offset="1040864"  nBytes="171786" chunkPositionInArray="[0,20,20,0]" />
+      <dmrpp:chunk offset="1212650"  nBytes="175367" chunkPositionInArray="[0,20,20,20]" />
+      <dmrpp:chunk offset="1388017"  nBytes="184284" chunkPositionInArray="[20,0,0,0]" />
+      <dmrpp:chunk offset="1572301"  nBytes="185508" chunkPositionInArray="[20,0,0,20]" />
+      <dmrpp:chunk offset="1757809"  nBytes="184548" chunkPositionInArray="[20,0,20,0]" />
+      <dmrpp:chunk offset="1942357"  nBytes="185617" chunkPositionInArray="[20,0,20,20]" />
+      <dmrpp:chunk offset="2127974"  nBytes="184387" chunkPositionInArray="[20,20,0,0]" />
+      <dmrpp:chunk offset="2312361"  nBytes="185511" chunkPositionInArray="[20,20,0,20]" />
+      <dmrpp:chunk offset="2497872"  nBytes="184573" chunkPositionInArray="[20,20,20,0]" />
+      <dmrpp:chunk offset="2684493"  nBytes="185594" chunkPositionInArray="[20,20,20,20]" />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_gzipped_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_gzipped_fourD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_gzipped_fourD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_gzipped_oneD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_gzipped_oneD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_gziped_oneD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_gzipped_oneD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_gzipped_oneD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_gziped_oneD.h5"
-    xml:base="data/dmrpp/chunked_gzipped_oneD.h5">
+    dmrpp:href="data/dmrpp/chunked_gzipped_oneD.h5">
 
   <Float32 name="d_4_gzipped_chunks">
     <Dim size="40000"/>
@@ -15,12 +15,12 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_4_gzipped_chunks</Value>
     </Attribute>
-    <h4:chunks deflate_level="6" compressionType="deflate">
-      <h4:chunkDimensionSizes>10000</h4:chunkDimensionSizes>
-      <h4:byteStream offset="3496" uuid="191531fb-33b5-4cb9-ab01-b9661a8c228f" nBytes="11393" chunkPositionInArray="[0]" md5="be6bb18691c0ad1ea78f485c492f7397"/>
-      <h4:byteStream offset="14889" uuid="08773442-6870-4d09-97c7-3209f360b87d" nBytes="12398" chunkPositionInArray="[10000]" md5="fd86a87d380c308c5a59ec7b7ddf9134"/>
-      <h4:byteStream offset="27287" uuid="b5a71bad-4e72-408f-a14a-eb60766e9b4f" nBytes="12738" chunkPositionInArray="[20000]" md5="93ed41084f0e8dd204872c9d0c64d7b3"/>
-      <h4:byteStream offset="40025" uuid="725e1404-e555-4f0f-aafb-98d6b60b4460" nBytes="13920" chunkPositionInArray="[30000]" md5="01c5fe739f3fc73e0a8e6ad7dbd213cb"/>
-    </h4:chunks>
+    <dmrpp:chunks deflate_level="6" compressionType="deflate">
+      <dmrpp:chunkDimensionSizes>10000</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk offset="3496"  nBytes="11393" chunkPositionInArray="[0]" />
+      <dmrpp:chunk offset="14889"  nBytes="12398" chunkPositionInArray="[10000]" />
+      <dmrpp:chunk offset="27287"  nBytes="12738" chunkPositionInArray="[20000]" />
+      <dmrpp:chunk offset="40025"  nBytes="13920" chunkPositionInArray="[30000]" />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_gzipped_oneD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_gzipped_oneD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_gziped_oneD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_gzipped_threeD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_gzipped_threeD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_gzipped_threeD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_gzipped_threeD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_gzipped_threeD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_gzipped_threeD.h5"
-    xml:base="data/dmrpp/chunked_gzipped_threeD.h5">
+    dmrpp:href="data/dmrpp/chunked_gzipped_threeD.h5">
 
   <Float32 name="d_8_gzipped_chunks">
     <Dim size="100"/>
@@ -17,16 +17,16 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_8_gzipped_chunks</Value>
     </Attribute>
-    <h4:chunks deflate_level="6" compressionType="deflate">
-      <h4:chunkDimensionSizes>50 50 50</h4:chunkDimensionSizes>
-      <h4:byteStream offset="4208" uuid="d8c80ec2-28a9-4cc8-a048-01cdb10e6e31" nBytes="131549" chunkPositionInArray="[0,0,0]" md5="ba7a50dd5cbf5503d2de98a33de3fef1"/>
-      <h4:byteStream offset="135757" uuid="8b7520af-82ee-4ac1-8167-0f7f6640e37f" nBytes="133648" chunkPositionInArray="[0,0,50]" md5="2fd5abfceed0a2a01d0454338caf422a"/>
-      <h4:byteStream offset="269405" uuid="3fd48b6d-12c0-4c56-bc4a-77a34364e550" nBytes="131239" chunkPositionInArray="[0,50,0]" md5="59d58e2b848f9c9e1a050f73cd1c1db7"/>
-      <h4:byteStream offset="400644" uuid="af33e62c-954d-45be-aafc-8e6c41f1e286" nBytes="133468" chunkPositionInArray="[0,50,50]" md5="92c81c5d83b10c646ef377a39d0c5c18"/>
-      <h4:byteStream offset="534112" uuid="472bec76-e6ae-40af-bc07-5adf7206fb10" nBytes="126076" chunkPositionInArray="[50,0,0]" md5="8d91d79d2c3e5f1cbdefde5d13a7258d"/>
-      <h4:byteStream offset="660188" uuid="6fe8fe93-e205-4cfd-b3c9-3c4aa30fe98d" nBytes="127667" chunkPositionInArray="[50,0,50]" md5="0ed8dda973d8c3ae3a2f2c22f52d52df"/>
-      <h4:byteStream offset="789903" uuid="50cc4e58-7450-45dc-b846-f88e8bf5223e" nBytes="126915" chunkPositionInArray="[50,50,0]" md5="4d2c268a4b83d69f30327aa8480d5b39"/>
-      <h4:byteStream offset="916818" uuid="845d8325-d4fe-42c1-97ad-da70908ede1d" nBytes="127903" chunkPositionInArray="[50,50,50]" md5="5e40661df635531a24fe9be011e57300"/>
-    </h4:chunks>
+    <dmrpp:chunks deflate_level="6" compressionType="deflate">
+      <dmrpp:chunkDimensionSizes>50 50 50</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk offset="4208"  nBytes="131549" chunkPositionInArray="[0,0,0]" />
+      <dmrpp:chunk offset="135757"  nBytes="133648" chunkPositionInArray="[0,0,50]" />
+      <dmrpp:chunk offset="269405"  nBytes="131239" chunkPositionInArray="[0,50,0]" />
+      <dmrpp:chunk offset="400644"  nBytes="133468" chunkPositionInArray="[0,50,50]" />
+      <dmrpp:chunk offset="534112"  nBytes="126076" chunkPositionInArray="[50,0,0]" />
+      <dmrpp:chunk offset="660188"  nBytes="127667" chunkPositionInArray="[50,0,50]" />
+      <dmrpp:chunk offset="789903"  nBytes="126915" chunkPositionInArray="[50,50,0]" />
+      <dmrpp:chunk offset="916818"  nBytes="127903" chunkPositionInArray="[50,50,50]" />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_gzipped_threeD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_gzipped_threeD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_gzipped_threeD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_gzipped_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_gzipped_twoD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_gzipped_twoD.h5"
-    xml:base="data/dmrpp/chunked_gzipped_twoD.h5">
+    dmrpp:href="data/dmrpp/chunked_gzipped_twoD.h5">
   <Float32 name="d_4_gzipped_chunks">
     <Dim size="100"/>
     <Dim size="100"/>
@@ -15,12 +15,12 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_4_gzipped_chunks</Value>
     </Attribute>
-    <h4:chunks deflate_level="6" compressionType="deflate">
-      <h4:chunkDimensionSizes>50 50</h4:chunkDimensionSizes>
-      <h4:byteStream nBytes="2949" chunkPositionInArray="[0,0]" offset="4016" md5="2a7c8a494dc85a7cc696a697ed778f60" uuid="d47d0848-f212-4726-bc67-e4f10a84d8ed"/>
-      <h4:byteStream nBytes="2973" chunkPositionInArray="[0,50]" offset="6965" md5="2d3d6c2b81e7ff3a546b25ded4bc4ec7" uuid="2aa9a04c-7118-4300-9447-316e18076e64"/>
-      <h4:byteStream nBytes="3020" chunkPositionInArray="[50,0]" offset="9938" md5="cb29efd938338763c7f1c41580e2cc28" uuid="734108ae-0864-40a4-a6d5-e316c640d8bd"/>
-      <h4:byteStream nBytes="3022" chunkPositionInArray="[50,50]" offset="12958" md5="ec5089904e7869b57a51c9908102062e" uuid="a3b8145a-207b-4789-9213-fcfcd231b1ff"/>
-    </h4:chunks>
+    <dmrpp:chunks deflate_level="6" compressionType="deflate">
+      <dmrpp:chunkDimensionSizes>50 50</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk nBytes="2949" chunkPositionInArray="[0,0]" offset="4016"  />
+      <dmrpp:chunk nBytes="2973" chunkPositionInArray="[0,50]" offset="6965"  />
+      <dmrpp:chunk nBytes="3020" chunkPositionInArray="[50,0]" offset="9938"  />
+      <dmrpp:chunk nBytes="3022" chunkPositionInArray="[50,50]" offset="12958"  />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_gzipped_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_gzipped_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_gzipped_twoD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_gzipped_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_gzipped_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_gzipped_twoD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_oneD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_oneD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_oneD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_oneD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_oneD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_oneD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_oneD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_oneD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_oneD.h5"
-    xml:base="data/dmrpp/chunked_oneD.h5">
+    dmrpp:href="data/dmrpp/chunked_oneD.h5">
   <Float32 name="d_4_chunks">
     <Dim size="40000"/>
     <Attribute name="origname" type="String">
@@ -14,12 +14,12 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_4_chunks</Value>
     </Attribute>
-    <h4:chunks>
-      <h4:chunkDimensionSizes>10000</h4:chunkDimensionSizes>
-      <h4:byteStream offset="3496" uuid="3455d50e-1e9b-423b-a012-34bf43ea8dbd" nBytes="40000" chunkPositionInArray="[0]" md5="7f3099f4f10c8e6a4b65f707a2771b93"/>
-      <h4:byteStream offset="43496" uuid="eb501560-3e4e-48eb-b58a-36dd74a8f2bc" nBytes="40000" chunkPositionInArray="[10000]" md5="eb9a6be4e00f7205cd8b0f85d4d40668"/>
-      <h4:byteStream offset="83496" uuid="3148fabf-569a-4fd4-b68b-2b67f723eb1a" nBytes="40000" chunkPositionInArray="[20000]" md5="067c4a3758a28d3f0d9917b4ec3fce73"/>
-      <h4:byteStream offset="123496" uuid="a3ebed1e-f618-42a2-8454-103a340a7c45" nBytes="40000" chunkPositionInArray="[30000]" md5="e33ebd2d2cb2f933c0d5f51211491c22"/>
-    </h4:chunks>
+    <dmrpp:chunks>
+      <dmrpp:chunkDimensionSizes>10000</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk offset="3496"  nBytes="40000" chunkPositionInArray="[0]" />
+      <dmrpp:chunk offset="43496"  nBytes="40000" chunkPositionInArray="[10000]" />
+      <dmrpp:chunk offset="83496"  nBytes="40000" chunkPositionInArray="[20000]" />
+      <dmrpp:chunk offset="123496"  nBytes="40000" chunkPositionInArray="[30000]" />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_oneD_uneven.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_oneD_uneven.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_oneD_uneven.h5"
-    xml:base="data/dmrpp/chunked_oneD_uneven.h5">
+    dmrpp:href="data/dmrpp/chunked_oneD_uneven.h5">
         
   <Float32 name="d_5_odd_chunks">
     <Dim size="40000"/>
@@ -15,13 +15,13 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_5_odd_chunks</Value>
     </Attribute>
-    <h4:chunks>
-      <h4:chunkDimensionSizes>9501</h4:chunkDimensionSizes>
-      <h4:byteStream md5="96b12e4a3988da5c93b255c0272551f2" uuid="0b6399cc-c0b3-4f6d-a867-3688b02bbf01" chunkPositionInArray="[0]" nBytes="38004" offset="3496"/>
-      <h4:byteStream md5="220e7a2fd6e658ba6d0e9e8db013c541" uuid="512cd247-0302-428e-9ad1-cfc547039061" chunkPositionInArray="[9501]" nBytes="38004" offset="41500"/>
-      <h4:byteStream md5="1da4839817d5dd988d892ab11672a37f" uuid="41dd84b2-bbf7-48ad-b3fe-831364709c33" chunkPositionInArray="[19002]" nBytes="38004" offset="79504"/>
-      <h4:byteStream md5="aed217eddc2a377b559c6610402fd642" uuid="5ddeb0eb-27f2-4f6d-b12c-fbc589fb7b38" chunkPositionInArray="[28503]" nBytes="38004" offset="117508"/>
-      <h4:byteStream md5="a4233f328af49b80bd4ac8ea7084a133" uuid="f31b1353-5399-4bea-9748-f19cf03aadd0" chunkPositionInArray="[38004]" nBytes="38004" offset="155512"/>
-    </h4:chunks>
+    <dmrpp:chunks>
+      <dmrpp:chunkDimensionSizes>9501</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk   chunkPositionInArray="[0]" nBytes="38004" offset="3496"/>
+      <dmrpp:chunk   chunkPositionInArray="[9501]" nBytes="38004" offset="41500"/>
+      <dmrpp:chunk   chunkPositionInArray="[19002]" nBytes="38004" offset="79504"/>
+      <dmrpp:chunk   chunkPositionInArray="[28503]" nBytes="38004" offset="117508"/>
+      <dmrpp:chunk   chunkPositionInArray="[38004]" nBytes="38004" offset="155512"/>
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_oneD_uneven.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_oneD_uneven.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_oneD_uneven.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_oneD_uneven.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_oneD_uneven.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_oneD_uneven.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shuffled_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shuffled_fourD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shuffled_fourD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shuffled_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shuffled_fourD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shuffled_fourD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shuffled_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shuffled_fourD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shuffled_fourD.h5"
-    xml:base="data/dmrpp/chunked_shuffled_fourD.h5">
+    dmrpp:href="data/dmrpp/chunked_shuffled_fourD.h5">
     
   <Float32 name="d_16_shuffled_chunks">
     <Dim size="40"/>
@@ -18,264 +18,264 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_16_shuffled_chunks</Value>
     </Attribute>
-    <h4:chunks compressionType="shuffle">
-      <h4:chunkDimensionSizes>10 10 10 10</h4:chunkDimensionSizes>
-      <h4:byteStream chunkPositionInArray="[0,0,0,0]" nBytes="40000" uuid="1dd8294a-4bee-422f-a44f-7b77604d427b" md5="e28c5c6eb545886f54f5ce68a27a03ac" offset="4728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,0,10]" nBytes="40000" uuid="1746a6cc-3749-43aa-8f07-9219660488e6" md5="ede797c8d35df5e90704c7fcfe8a1174" offset="44728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,0,20]" nBytes="40000" uuid="5ca24dd0-ef99-4cc0-8342-360d6c4ef053" md5="9d251ad1d652e1299b142e290c316b28" offset="84728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,0,30]" nBytes="40000" uuid="0fd55ad1-ae9b-4a8b-84b4-d946af6b522e" md5="30646fc984f6d2533f8557f7f67adafe" offset="124728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,10,0]" nBytes="40000" uuid="e79474f9-3b67-4607-b2e9-70be4daa9724" md5="e7fb0cd92f7957bef22e84b2787e6929" offset="164728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,10,10]" nBytes="40000" uuid="49ebd7c0-016c-442d-97c3-a43604541edc" md5="f8a10cd2ae3eb0b836dc8f8fe05a2b1a" offset="204728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,10,20]" nBytes="40000" uuid="5efda8cf-738d-4288-814e-44a361d40fe9" md5="f1ea06d57a92e5fe5f2036c4770cb924" offset="244728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,10,30]" nBytes="40000" uuid="392aa22c-3ebb-42bb-8982-d8be922b3305" md5="0b81f795c344041283ca3343e62645a5" offset="284728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,20,0]" nBytes="40000" uuid="15c6cca7-cb83-4270-a3db-ea02cb76e629" md5="d39bf86dcbfd9bfc131d9edf11d94c0a" offset="324728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,20,10]" nBytes="40000" uuid="6324739d-029a-4db8-9391-730898b6e2d4" md5="94d3b9b8d2a2b933b60f562f2399dc5a" offset="364728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,20,20]" nBytes="40000" uuid="3760318b-b6f0-4295-8865-bd3e1433b64c" md5="13f86b48c16430a35737f94ffb32b96e" offset="404728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,20,30]" nBytes="40000" uuid="6019f72f-24e8-4b7e-bcaa-b0c7065fe2f4" md5="7b2f7057a91fd1c4a9d75d07abc59b86" offset="444728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,30,0]" nBytes="40000" uuid="d00a8552-9cac-454a-82da-b3b275606830" md5="3e6f98192ced3b916006a1661b8de074" offset="484728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,30,10]" nBytes="40000" uuid="0f21df13-0f05-4d21-8edb-c0f2070bffc2" md5="c864be7d1d899dfb91950a39a205879e" offset="524728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,30,20]" nBytes="40000" uuid="a265026b-f447-46b2-a9de-4b9ceb151302" md5="b3dccc46835759868f3d3614399950c7" offset="564728"/>
-      <h4:byteStream chunkPositionInArray="[0,0,30,30]" nBytes="40000" uuid="44b6db48-d2ed-4b6c-95a2-5b3862596c94" md5="fae2ef829562d2ba4bc159b0e46e0920" offset="604728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,0,0]" nBytes="40000" uuid="b8cd68aa-340d-4c4e-9c19-f5e645efe76e" md5="a706ed7360fd580288e59cdc922ee780" offset="644728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,0,10]" nBytes="40000" uuid="eebaeaec-dd1a-47bd-936f-346e6ecf6b80" md5="50b2fdbae5624e1697930372df881ca1" offset="684728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,0,20]" nBytes="40000" uuid="04d8ee65-561b-42dc-80e4-caca7dcd5ee9" md5="17fdafa14432db04a3759dae63e2959c" offset="724728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,0,30]" nBytes="40000" uuid="08894345-3271-4051-b1b3-7893ad170896" md5="0b1de3c42268f6b0a4b49a87524195c3" offset="764728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,10,0]" nBytes="40000" uuid="30e28871-3647-4d66-8ab3-28f8063d3123" md5="009654465a02fbf318e327980d884578" offset="804728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,10,10]" nBytes="40000" uuid="90326d0c-8fb1-4c86-adf8-26fdd3641276" md5="dce37060c11d5cd53af1cdfef211f009" offset="844728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,10,20]" nBytes="40000" uuid="8aca597e-5ee0-4043-ad46-ee4070335e20" md5="07f8f7694a91f0c9e786bb20aed5d1b7" offset="884728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,10,30]" nBytes="40000" uuid="6f9387c0-4b00-412e-8a89-8074be127307" md5="5729aa1358d9efc001f2543ed23b3d7a" offset="924728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,20,0]" nBytes="40000" uuid="8007c1ef-4dcb-4a7a-94b3-a909d4db14e3" md5="c10758a3821905ecd7a28e54514faf3d" offset="964728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,20,10]" nBytes="40000" uuid="b61e97df-09eb-43da-993d-ce87efce79e6" md5="3fe12ad885a293c66d74e7c9cfefa953" offset="1004728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,20,20]" nBytes="40000" uuid="1501b26f-2af7-4dba-bf4c-92f2a85bf9f9" md5="45ec2a8dd446dcdee45eb32d05f5ff43" offset="1044728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,20,30]" nBytes="40000" uuid="8869ea79-3685-4bc6-b13c-ae0f737788ad" md5="0beec8b3e119dde57acc00107fbe6351" offset="1084728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,30,0]" nBytes="40000" uuid="ced6e706-b5a0-417b-837e-1fdea184fb35" md5="a59108645f292b4fae373eefea43e459" offset="1124728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,30,10]" nBytes="40000" uuid="587b73dd-d531-4537-bb56-c2f24a5a1d49" md5="08967d2e1afa219d112d5459ade14917" offset="1164728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,30,20]" nBytes="40000" uuid="37868802-6ecb-49ff-a505-fc9639823a88" md5="b90b87174a3b581cc97a8c3664eec0d7" offset="1204728"/>
-      <h4:byteStream chunkPositionInArray="[0,10,30,30]" nBytes="40000" uuid="5d617fb0-cc2a-4292-b475-9198b4ea2837" md5="01e4f6eed11c0a748c12115a877152e3" offset="1244728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,0,0]" nBytes="40000" uuid="ec27aaab-3104-42fa-ac97-9786b0b221b6" md5="a6e6380c87d7cd621474861766e93888" offset="1284728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,0,10]" nBytes="40000" uuid="5527a2c9-6e02-4a20-9fbe-4cb6563cdbbf" md5="0d9dca0e5e9ede4410b058b7a45c6f20" offset="1324728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,0,20]" nBytes="40000" uuid="c5e68929-f359-4e33-8740-00329c03b655" md5="cc054f6116f41a5515c5715f4efbe77b" offset="1364728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,0,30]" nBytes="40000" uuid="dc4c37e7-1fd9-46b2-8b16-4648b8dfd254" md5="d95c085e7b0f16b850e10b5392ca1059" offset="1404728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,10,0]" nBytes="40000" uuid="da278b69-21f2-4680-a3ba-55af4cf5ddb5" md5="12e6a9dcdf1d1380ee91bd865a1172f2" offset="1444728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,10,10]" nBytes="40000" uuid="b14a9361-3728-4080-8e80-e374bdfd8707" md5="9f136136721b5d4df0710c29c2e24612" offset="1484728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,10,20]" nBytes="40000" uuid="5f6b7159-b952-4ce9-a3aa-e0fbf22e5cb4" md5="b9ab5d3b9d479c96597ada1da7199eed" offset="1524728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,10,30]" nBytes="40000" uuid="9a8cf76f-f16e-40fb-97ee-b470722a68bf" md5="0544184847ccb9ad6f48052fe73a319f" offset="1564728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,20,0]" nBytes="40000" uuid="b0e71cfb-5e11-44d3-9ef1-5088f7d868ac" md5="fad24c37ba300d87a1cccb04df13c074" offset="1604728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,20,10]" nBytes="40000" uuid="817702ea-b1d8-4662-842e-6e72c1d0bba7" md5="349d29a54587f730cab7e3315f40675e" offset="1644728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,20,20]" nBytes="40000" uuid="1e23286d-0f41-4020-aca7-5a24a91c1f5e" md5="2401f2c75b3cc539990d309d68e7af78" offset="1684728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,20,30]" nBytes="40000" uuid="b87ffac6-3f8b-4139-b811-b5399d3bf57c" md5="90dcdf69cfb4693a852cf4bcf118502e" offset="1724728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,30,0]" nBytes="40000" uuid="e5b783dd-0ee2-49cf-aa03-aac52aa9d8ab" md5="a6e1f983f1805299f700f9a718bada09" offset="1764728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,30,10]" nBytes="40000" uuid="803c5ae6-fcc7-4db8-9530-63d2f6dd5b8f" md5="75890d4f9e72ee10d57e23071776eea1" offset="1804728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,30,20]" nBytes="40000" uuid="78085751-a83c-4933-92d1-785590876d92" md5="dcf317fa2c9ba903adb1961463aa1f4b" offset="1844728"/>
-      <h4:byteStream chunkPositionInArray="[0,20,30,30]" nBytes="40000" uuid="3fdc946e-ec60-481e-88b0-9dec8b6d8b6f" md5="7669215b83aa0aac13116913d86a604a" offset="1884728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,0,0]" nBytes="40000" uuid="8aa0abb7-9bf7-4067-9cec-cb97763017e5" md5="03711732ba8c0f541e5e21ba46012d0e" offset="1924728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,0,10]" nBytes="40000" uuid="92f3a52e-e083-4be5-8986-931f0b42a950" md5="ece554d1ded35408846530d8fed8b544" offset="1964728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,0,20]" nBytes="40000" uuid="e7d13152-a6e5-49af-b00a-4cf147a6b48b" md5="52765b47e0edc3233241f629caa5aa7e" offset="2004728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,0,30]" nBytes="40000" uuid="4d10916f-dc27-4454-9fcb-075e21a9dcc8" md5="ccdcf19f04af55e4bd6f8ecfaa5f4d41" offset="2044728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,10,0]" nBytes="40000" uuid="a33a7a5e-f60b-4a1b-a769-cab80a7bdc0c" md5="a48de1d9fae59386d315a92583117313" offset="2084728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,10,10]" nBytes="40000" uuid="7720ef79-58b5-4224-9926-56020da42d23" md5="8f40004cd43bed3d1661af7ae1ebb97a" offset="2124728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,10,20]" nBytes="40000" uuid="0273a05a-1e95-4cba-95f5-ddc13e519699" md5="a4a6e4204a5fda9395fb6737b82c72f4" offset="2164728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,10,30]" nBytes="40000" uuid="52d37f76-6b67-4285-95d4-b09b21e912ae" md5="20753d521b8365f7e73ccea58775f9f2" offset="2204728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,20,0]" nBytes="40000" uuid="e8fe1d55-d4cb-415e-b61b-f9f0dc4aedb9" md5="e5a1e9bdd76a8d91698a035e42e46dca" offset="2244728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,20,10]" nBytes="40000" uuid="9ed1a6e7-2b76-44ec-a9ce-36e69a948e0b" md5="f6980d04be589b9ac231e1dccb8afc5a" offset="2284728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,20,20]" nBytes="40000" uuid="965aaeea-c594-4e66-a05e-d41572981fbe" md5="b291909771917ce037d272591a087bff" offset="2324728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,20,30]" nBytes="40000" uuid="bb131d20-ff6d-4b6a-887e-281be68fff05" md5="2f6aa75c006e92ec3111cfa7d55e6948" offset="2364728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,30,0]" nBytes="40000" uuid="b3614ff9-6986-47d2-bef9-fa0f7e11199b" md5="fb3e7af3d2c3ce9806d0bf5fa73da25c" offset="2404728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,30,10]" nBytes="40000" uuid="d1c47298-460c-4828-9b66-da7c0af1f3d0" md5="fced1538563c3d90f1fc744c817a644d" offset="2444728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,30,20]" nBytes="40000" uuid="e9045b72-8801-4326-8613-1017caa0d158" md5="4fe53fc58b01a2b49fc32e22865a28ae" offset="2484728"/>
-      <h4:byteStream chunkPositionInArray="[0,30,30,30]" nBytes="40000" uuid="948486f4-c984-49ea-bfd2-637f36899143" md5="0f672da7b7850841f73044902fd528f7" offset="2524728"/>
-      <h4:byteStream chunkPositionInArray="[10,0,0,0]" nBytes="40000" uuid="8743ecdf-83a1-412f-9c41-21697b123cf0" md5="a424aa0768d55b6e39726a4b1d872a66" offset="2564728"/>
-      <h4:byteStream chunkPositionInArray="[10,0,0,10]" nBytes="40000" uuid="6f777c84-4a75-4427-82e3-f9c70d13d22b" md5="85776cf56b45f24fff34277cb2617f71" offset="2612040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,0,20]" nBytes="40000" uuid="df48b42d-df1d-4c80-8b27-b753b469136d" md5="f11e86b0f32ae2908a886f762bccabe7" offset="2652040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,0,30]" nBytes="40000" uuid="80dafd3f-9731-4486-a5ca-da339d5145a3" md5="f8254f57fa4dfb3cf25f7ec81f445b0a" offset="2692040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,10,0]" nBytes="40000" uuid="9e1658d5-4e11-490d-bba5-60136f614c20" md5="daec35241e7ff91b4d81ff145358fa7d" offset="2732040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,10,10]" nBytes="40000" uuid="383d0d53-5fdc-406b-89f1-a28fa14a02bd" md5="3d4710467fcae9b66215813249edd8ce" offset="2772040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,10,20]" nBytes="40000" uuid="1180e16b-1687-4618-882d-ea40f2191a8e" md5="a49113f96a99be6cf9aa134dcd368a22" offset="2812040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,10,30]" nBytes="40000" uuid="b27555d5-d9ea-4e19-a3b6-de1dadeed249" md5="9ef59f74fbfbbeffa03af8ee368329b1" offset="2852040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,20,0]" nBytes="40000" uuid="ba7b1d38-724b-4108-90ff-c521b5b33de8" md5="3c3f9a7eb0901f030d0455cd1b12cb72" offset="2892040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,20,10]" nBytes="40000" uuid="f6f1e885-a794-4114-abca-b6e673f920e4" md5="c93f58c4f81f2d43beb55ce198873b51" offset="2932040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,20,20]" nBytes="40000" uuid="90d0003f-a6f2-4d85-8cbc-6829ac4f09d8" md5="ae382aedead42f553e230bb04e37e8d4" offset="2972040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,20,30]" nBytes="40000" uuid="5a0f5bf9-921e-4177-8927-dff06201c94e" md5="6e71b6df190a70c598b570a8de031ee5" offset="3012040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,30,0]" nBytes="40000" uuid="65cab9bc-821a-4463-9086-77a983ac7acb" md5="540cd7adb1ec00b5ac46641aa4374574" offset="3052040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,30,10]" nBytes="40000" uuid="c156c0a1-677b-4790-ba18-7cc52144af1b" md5="0268e23a99d857fdba95d8666d16a46d" offset="3092040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,30,20]" nBytes="40000" uuid="9e220bdd-9d06-43cb-9c02-3f0f4de95a2c" md5="afd77172e3d579e9187e0e73bf02e2ca" offset="3132040"/>
-      <h4:byteStream chunkPositionInArray="[10,0,30,30]" nBytes="40000" uuid="f5b779aa-775c-4449-9054-e36edf82832b" md5="de0323af7eef03f4c8c6b531e1440c74" offset="3172040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,0,0]" nBytes="40000" uuid="137bffdb-ce2b-463f-8109-c4a61a42f87f" md5="d058e60924f7f5d9ae2fde494cee38db" offset="3212040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,0,10]" nBytes="40000" uuid="a2fb7611-c3e8-44a0-8921-f7fa1dcfe2dd" md5="69d94f5e30a8f0a4a8e1a32f5350c4ed" offset="3252040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,0,20]" nBytes="40000" uuid="5186d910-a929-4957-a643-c3ecd3f983c3" md5="d75509d5c4543fe7daeaecce217edc73" offset="3292040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,0,30]" nBytes="40000" uuid="8eabfe5d-9a96-4725-b874-8eb2484ea9f1" md5="87b15a69d613c64473a1cf7297a6202e" offset="3332040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,10,0]" nBytes="40000" uuid="f4cbcd57-8584-4562-bdb3-a6a6ac4deab1" md5="86201211479cf5fc43c90aab6889f2c3" offset="3372040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,10,10]" nBytes="40000" uuid="48100aec-412b-4877-9bff-f5375019b111" md5="3b20edb8ef7fa94aa9702ecb671b0e2a" offset="3412040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,10,20]" nBytes="40000" uuid="b5fb2955-7231-4462-8fa5-4871982898d2" md5="6118e29668fcf70142e722db2430dc8c" offset="3452040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,10,30]" nBytes="40000" uuid="dba18555-b331-418b-93a0-d115201f049e" md5="869ba84a9ffab9f8d44cddf7061f374c" offset="3492040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,20,0]" nBytes="40000" uuid="4af2c525-8977-4569-87a5-3f720c98686b" md5="a1c12ef6f05e373779fe0836dc5ea841" offset="3532040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,20,10]" nBytes="40000" uuid="b4956c5b-d3c2-4d90-b47d-59bb72f1d679" md5="6227dc25d395f52e4650f87a8cc91c5f" offset="3572040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,20,20]" nBytes="40000" uuid="68b0eafb-97b8-4e15-8b31-ccc05720c515" md5="0b961996c885fcc406c738c08b3b55cd" offset="3612040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,20,30]" nBytes="40000" uuid="7335890f-1098-46aa-b08d-83e6ab348bff" md5="1f9a9ac9a0aad41a6af4a187d0eb178b" offset="3652040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,30,0]" nBytes="40000" uuid="331d76da-0a80-416f-a780-8946e8c51142" md5="2f2cdd70705d456a9117da92abda62b4" offset="3692040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,30,10]" nBytes="40000" uuid="aaf3cd86-5f1d-41d7-b3be-c508fd5f5688" md5="f218fec3c98810987b6e055a4ffa4947" offset="3732040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,30,20]" nBytes="40000" uuid="fc4a1d03-1497-4a37-ae2d-9f19ce7ca160" md5="cdd5ff472b0a8b5d44e852b5586b7a9a" offset="3772040"/>
-      <h4:byteStream chunkPositionInArray="[10,10,30,30]" nBytes="40000" uuid="9f6dc3b8-f3c1-4969-8faf-869708ca43f9" md5="607d72050a744cd505fc073d8d4ddb73" offset="3812040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,0,0]" nBytes="40000" uuid="ec4fe0fa-fdb3-4ca6-ae8f-658d422ff2a9" md5="d5d96b32a03573e7a3fe0a87d8179630" offset="3852040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,0,10]" nBytes="40000" uuid="8f7a69fa-d3df-48a6-bb6e-58d7ca194d42" md5="a3c9fdca624f073e443be5b8dbf6a2d9" offset="3892040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,0,20]" nBytes="40000" uuid="796f1adc-faf3-496a-a906-49d4c9186bf2" md5="08c31a1181aed771426889b7a7094377" offset="3932040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,0,30]" nBytes="40000" uuid="f08480db-9690-4329-96a6-4a408e987a5c" md5="46f7431f6247e94f7ae941ea8c2f5447" offset="3972040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,10,0]" nBytes="40000" uuid="76fdb598-f3fb-4cf7-a61d-8f05fcd2f449" md5="906b284ca51bad859140d484a577d2d2" offset="4012040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,10,10]" nBytes="40000" uuid="eccde72e-ee6c-4441-a924-053c051c42b8" md5="d8ab358a1d75ab3e70cd165d5055044a" offset="4052040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,10,20]" nBytes="40000" uuid="fd63b990-b5ee-4a9c-94d4-a97f52a0ae65" md5="be529d8a42774bb0a9c8115e5170f2ff" offset="4092040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,10,30]" nBytes="40000" uuid="a394f532-38e2-4624-a993-a2395ff914a4" md5="2bf55c2e429a81973ff05fac68f51dbc" offset="4132040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,20,0]" nBytes="40000" uuid="4ee56e78-b067-427b-873b-22561153d6ef" md5="47712612fc7afb2df55b9316c850cdf5" offset="4172040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,20,10]" nBytes="40000" uuid="7dfe2d46-3b98-4003-b514-ccf0b7a225ed" md5="92b1310e880ac21dac8595c99b4d32b4" offset="4212040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,20,20]" nBytes="40000" uuid="e8b10a0c-b6b7-4c1f-8598-4adfba02f75a" md5="5dc8f12118981e2d359b118be2c284c1" offset="4252040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,20,30]" nBytes="40000" uuid="7799cc19-cea3-4ac8-a7fd-01838a900a8b" md5="c5530e3f5969de043a8c71760fc5e25c" offset="4292040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,30,0]" nBytes="40000" uuid="4cf7d5bf-d7a8-4b2b-ad30-afe84c23bcc2" md5="bab690dd7a3bfa1bcc8d668d79266713" offset="4332040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,30,10]" nBytes="40000" uuid="3f0c04c0-f72f-47de-b859-3ace128b366b" md5="7e2b2a09fd5899fe0434b6be6cab315a" offset="4372040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,30,20]" nBytes="40000" uuid="6698f1fc-862f-4dc2-84cd-f2ef40d66054" md5="a6ea560a2fc1356589a295adf7d78fd0" offset="4412040"/>
-      <h4:byteStream chunkPositionInArray="[10,20,30,30]" nBytes="40000" uuid="8d81caf8-968b-4066-9f02-3d4a8cc6c26d" md5="0ca23fc6a95c09e76acb552374bb9214" offset="4452040"/>
-      <h4:byteStream chunkPositionInArray="[10,30,0,0]" nBytes="40000" uuid="53f9668b-36d7-4524-a9c8-81f6c96f6545" md5="b4f70ac60030d459178d03817d5a6228" offset="4492040"/>
-      <h4:byteStream chunkPositionInArray="[10,30,0,10]" nBytes="40000" uuid="10b009d4-61b8-48fc-aa30-db151fc03b94" md5="458ea19435125536a35c06354bc940a5" offset="4532040"/>
-      <h4:byteStream chunkPositionInArray="[10,30,0,20]" nBytes="40000" uuid="41d7b2ad-5c6c-422a-87aa-2111429fa7a9" md5="9376f045acb66ef5986489bde72a0d3e" offset="4572040"/>
-      <h4:byteStream chunkPositionInArray="[10,30,0,30]" nBytes="40000" uuid="142db983-e183-4cf7-94e1-fa3b143c013c" md5="c1144604b23121e025ba12b88df89453" offset="4612040"/>
-      <h4:byteStream chunkPositionInArray="[10,30,10,0]" nBytes="40000" uuid="5b758ffd-1dfb-4e8d-9eb9-f515d28213c2" md5="0e3a599b1adb97f3885bd0f4ba8d3357" offset="4652040"/>
-      <h4:byteStream chunkPositionInArray="[10,30,10,10]" nBytes="40000" uuid="4a420bd4-ccb8-4c8d-a0f1-417e4ae361f9" md5="6348ddb14e119c55de4091368f26220f" offset="4692040"/>
-      <h4:byteStream chunkPositionInArray="[10,30,10,20]" nBytes="40000" uuid="20f69341-7579-4511-8feb-238bf116cd8c" md5="49a7c1c68e6b98ee161956afe2104559" offset="4732040"/>
-      <h4:byteStream chunkPositionInArray="[10,30,10,30]" nBytes="40000" uuid="76253f7e-fce7-4834-922a-0cda7f3f006c" md5="7d9686c4099f9fea67e9253cfa0d06e6" offset="4772040"/>
-      <h4:byteStream chunkPositionInArray="[10,30,20,0]" nBytes="40000" uuid="79d89808-437e-4691-a4c1-576cc557ddfe" md5="af34d49c186a84c8e555646203e5c105" offset="4812040"/>
-      <h4:byteStream chunkPositionInArray="[10,30,20,10]" nBytes="40000" uuid="954289e7-9e1b-4cfe-bb56-75a26ba695ed" md5="a838574d8b560a8fb4d47a7a1804e557" offset="4852040"/>
-      <h4:byteStream chunkPositionInArray="[10,30,20,20]" nBytes="40000" uuid="4f323c6b-fae0-4a77-8920-7a0bf1750c82" md5="f3960cf69a3d52c19b82207df18d5d65" offset="4895696"/>
-      <h4:byteStream chunkPositionInArray="[10,30,20,30]" nBytes="40000" uuid="5fe7f612-5306-40bb-b1d4-117f35c721bc" md5="72c346f197810130444a6a635d189c82" offset="4935696"/>
-      <h4:byteStream chunkPositionInArray="[10,30,30,0]" nBytes="40000" uuid="93e93bcb-5fad-4bf2-bb52-b95a92e39cee" md5="864c7dd92c39d1f8e14aeeaf0a192018" offset="4975696"/>
-      <h4:byteStream chunkPositionInArray="[10,30,30,10]" nBytes="40000" uuid="b34e7e61-6f0e-4f2c-8296-f41f91d8e9ee" md5="5281ef7fe1025462862a941bc3eddebb" offset="5015696"/>
-      <h4:byteStream chunkPositionInArray="[10,30,30,20]" nBytes="40000" uuid="5678a409-06a8-4809-82a7-a43e92c26ffc" md5="3379f040dd1f08cf8176e99eb26715d3" offset="5055696"/>
-      <h4:byteStream chunkPositionInArray="[10,30,30,30]" nBytes="40000" uuid="51d3addf-1f47-4ab4-a0e7-fa8bb277d5b5" md5="3b56a5c86a6fbf2ac9819f547735a67f" offset="5095696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,0,0]" nBytes="40000" uuid="9fbc7ec0-2459-4852-a360-026bf50a42ba" md5="a47702a56e8fa87ea80af8baeec46d68" offset="5135696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,0,10]" nBytes="40000" uuid="9a1dd932-e473-4029-a07a-4aa01dbf5920" md5="06d989ba2f8bf35421f4bf5e20342ff5" offset="5175696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,0,20]" nBytes="40000" uuid="a0719555-e073-4f03-ac75-7ab1f3ec3947" md5="2a3de5e29170bb122081babd868fb59c" offset="5215696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,0,30]" nBytes="40000" uuid="12f2d1cb-0aee-4249-b358-0cc29b76871e" md5="727420e8464ee39a779b9dd1ab6a7039" offset="5255696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,10,0]" nBytes="40000" uuid="74a37806-cc7a-413d-8b11-e662539e708a" md5="e92b63568f5b56b2d1b29d85da066444" offset="5295696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,10,10]" nBytes="40000" uuid="935dcdb2-8f76-453e-9d8f-8bb4b86e79ff" md5="6cbed71551eba9de321edbaf95654d06" offset="5335696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,10,20]" nBytes="40000" uuid="fa3834c2-cbd4-4a29-8102-89d14607b445" md5="c8347726a3572af654f66de1de4da1aa" offset="5375696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,10,30]" nBytes="40000" uuid="f450c1b6-2e2d-4e5b-8a6f-46600a42ee6a" md5="c33089085e19a5f4bb53a57c985d6583" offset="5415696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,20,0]" nBytes="40000" uuid="516f489c-6e92-4ab1-ba92-526a5a4619e5" md5="12a2b337bf6c5860d4be6b58aafeb651" offset="5455696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,20,10]" nBytes="40000" uuid="78b48c9d-12e8-40a2-a412-b06a7d675c2f" md5="2ccf22f1714a92ab983a849c279f630b" offset="5495696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,20,20]" nBytes="40000" uuid="42ca8487-1b01-4cfa-b877-371092d75057" md5="2094d78c3b88462efb639a9d4dcf539f" offset="5535696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,20,30]" nBytes="40000" uuid="f3bed144-b7fe-430e-9dd1-a4ea21df6379" md5="5aa77ee144084ed770d420aeaed90b03" offset="5575696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,30,0]" nBytes="40000" uuid="8f290bc6-74a9-4bea-9933-c3cba38b93cb" md5="c63dceaef40a46270025f878ab231920" offset="5615696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,30,10]" nBytes="40000" uuid="cf1efacb-81fc-4d12-9a2b-70ef2d1cc5fd" md5="14fb948433b8682a6ea6604fcd880c51" offset="5655696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,30,20]" nBytes="40000" uuid="c19053f5-1355-46ea-8cbf-a094a63532c9" md5="d92038acfdfda1bbf2b2a579180ad370" offset="5695696"/>
-      <h4:byteStream chunkPositionInArray="[20,0,30,30]" nBytes="40000" uuid="df23c014-112a-4b2e-8809-9da93df71f33" md5="abd601d57b0708c6ec665e6d5dc1bf87" offset="5735696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,0,0]" nBytes="40000" uuid="2ee3ed98-63e0-4278-a3ca-c4c15a0fbfce" md5="db690f91d141bbb8956c5e146a08fadc" offset="5775696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,0,10]" nBytes="40000" uuid="59b73253-3d36-468a-9f79-08681d05a3a6" md5="1865f4b7e538c4cba1975e305ddbbfd3" offset="5815696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,0,20]" nBytes="40000" uuid="a958141d-7980-4517-a82c-fc477271b3c7" md5="c264af367227621ad3f989c076aa2964" offset="5855696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,0,30]" nBytes="40000" uuid="b57c7acb-c75f-4fa3-9426-f917d7b05181" md5="b2449d1e7d76aacab43d6756a90427c0" offset="5895696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,10,0]" nBytes="40000" uuid="32593344-2b46-4cb2-aa5d-0bf237e76eed" md5="58de18215b74e06d750a9850d3aab743" offset="5935696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,10,10]" nBytes="40000" uuid="b117f246-3c9d-46bc-83f6-3bc145e968a1" md5="055678d0a57d2daa1ca361b5579d4444" offset="5975696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,10,20]" nBytes="40000" uuid="2fe84682-3a0c-4515-962d-cbe774241566" md5="dd19b7bf446637631a3fb8b63ce7d740" offset="6015696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,10,30]" nBytes="40000" uuid="39e6dbb5-36e0-491f-8444-a1a21848b853" md5="f987ab24da71b9c7718ac1d5682e093f" offset="6055696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,20,0]" nBytes="40000" uuid="d21e7e86-1279-4412-9485-021e81d7a751" md5="f078cbba57ba22d182ade1a78b9c14ba" offset="6095696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,20,10]" nBytes="40000" uuid="ff0602dc-7191-4da4-a317-d17d5dfdc9ce" md5="e1a58d058317e8546f1ee830bddd14e3" offset="6135696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,20,20]" nBytes="40000" uuid="7a257303-b3ed-43eb-85d1-01cc08d9438f" md5="0d3458cb04d54d8bd9e97f90daf94873" offset="6175696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,20,30]" nBytes="40000" uuid="9580e9cd-74f3-4d63-b01e-2fd54578c3ab" md5="4796358bbfbfeed5fb6826f82c4cb82f" offset="6215696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,30,0]" nBytes="40000" uuid="7c02f074-abdd-4872-8950-99a058aa0142" md5="2ef0eb71086f6e16f9b0766fa25864f1" offset="6255696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,30,10]" nBytes="40000" uuid="b5ff27d7-0637-4333-9f60-2f72ddff8e11" md5="5e1adab6006df8130ca0fcce283d2c9e" offset="6295696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,30,20]" nBytes="40000" uuid="5d7b184a-4cde-4cbd-aaeb-69a21fb17903" md5="8d3a54415f46887367bc4ddd63c9b26c" offset="6335696"/>
-      <h4:byteStream chunkPositionInArray="[20,10,30,30]" nBytes="40000" uuid="13c52d3e-5a34-486a-8f23-4de812fbbddc" md5="130e0fb2898650662cdcbda3f085ab0b" offset="6375696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,0,0]" nBytes="40000" uuid="0b888148-8826-49f2-94b9-21923cd62134" md5="5efb1d0b04645fd645caae57b3be642e" offset="6415696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,0,10]" nBytes="40000" uuid="fa61bb29-7b8b-4a99-8078-f924e5917ba3" md5="f3e5d7dd2698e5e539761a220aecbe3a" offset="6455696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,0,20]" nBytes="40000" uuid="a3370eab-a6d7-41bb-a6db-7d1ee7ecaece" md5="5139fd1742ba4c72db941c5ddb9866ae" offset="6495696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,0,30]" nBytes="40000" uuid="f0833e73-0766-4043-9df5-b30e1bc4a67f" md5="06913a18f93e41ced16019ae917b47cd" offset="6535696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,10,0]" nBytes="40000" uuid="b3a3950c-5c82-4fcb-b9cc-6dca824da2f8" md5="ed91ccced820225a09fbb799418cefbd" offset="6575696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,10,10]" nBytes="40000" uuid="8de0e949-71d9-496c-92bb-bd8b0d29b475" md5="9a3edf8f947dfe8697f370ef5bd7af27" offset="6615696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,10,20]" nBytes="40000" uuid="564feba5-0fe4-47d1-b356-dea94e4c46b8" md5="1c75e51262e423b74742c26aa2adcbd3" offset="6655696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,10,30]" nBytes="40000" uuid="d1e68299-28cd-447f-91c9-3b8a03d56be0" md5="1df83868b81123550534f4c0855180ff" offset="6695696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,20,0]" nBytes="40000" uuid="39575a80-98fe-4070-b262-a6bb337ec58b" md5="66d353fbddf7419ed4a980f1bfc205a4" offset="6735696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,20,10]" nBytes="40000" uuid="ab085729-8108-4af4-9aae-21472e63106d" md5="c598637e629e2415a0f8d3b8185c320c" offset="6775696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,20,20]" nBytes="40000" uuid="de0c4bff-a66d-4a51-897a-35224345229b" md5="97c12f4f4c02e7c133ee29102829eada" offset="6815696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,20,30]" nBytes="40000" uuid="fbe0ba2b-9fcf-4433-9cf1-8f2b603e6a75" md5="c1938563e3fd8affabb6ea3d5aaf3db6" offset="6855696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,30,0]" nBytes="40000" uuid="f1f92dbd-fe57-40cb-b8b4-c971fb1fb43a" md5="7d886adae84974e2d2086f84e76c7a1d" offset="6895696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,30,10]" nBytes="40000" uuid="0861fb7b-1a15-4c3d-a185-3de98d70e703" md5="892e46798c5f5ca3ff8934ff49571b0a" offset="6935696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,30,20]" nBytes="40000" uuid="6675444a-aff0-4fe0-b9b6-3af644269e2a" md5="0c3f8f869b403e849cd68d6b694547fa" offset="6975696"/>
-      <h4:byteStream chunkPositionInArray="[20,20,30,30]" nBytes="40000" uuid="3c3fc8bd-a314-4e35-88d1-1bb481b1a269" md5="c4710b4b65d27759bca6034f0766a923" offset="7015696"/>
-      <h4:byteStream chunkPositionInArray="[20,30,0,0]" nBytes="40000" uuid="9f2550b8-a40e-407d-bea6-8eaa10a311ca" md5="86a90b6a0080a6bcde18b570ab4101e0" offset="7055696"/>
-      <h4:byteStream chunkPositionInArray="[20,30,0,10]" nBytes="40000" uuid="e6c0e991-5876-4849-97dd-ce90989c20de" md5="35e9cfe152b5db3764fd9704d7f50824" offset="7095696"/>
-      <h4:byteStream chunkPositionInArray="[20,30,0,20]" nBytes="40000" uuid="4d5cda8a-6e4f-4474-9f64-d5da239f4e69" md5="f3b4caba34e694123e9645c6c114d7e3" offset="7135696"/>
-      <h4:byteStream chunkPositionInArray="[20,30,0,30]" nBytes="40000" uuid="9746b6dd-06af-43c0-9e40-f3f5cf164e24" md5="732d91b9179206cbf3986ec52af582be" offset="7179352"/>
-      <h4:byteStream chunkPositionInArray="[20,30,10,0]" nBytes="40000" uuid="82074b39-5907-493f-aa0d-14457e4e6ca8" md5="ecbd288efc01f227c97d8e70d94d0cff" offset="7219352"/>
-      <h4:byteStream chunkPositionInArray="[20,30,10,10]" nBytes="40000" uuid="1a2da16b-1e48-448b-879d-260f0089d936" md5="d36381442a4415ce6bf13cc4c7f47e48" offset="7259352"/>
-      <h4:byteStream chunkPositionInArray="[20,30,10,20]" nBytes="40000" uuid="6dd2e4e9-bae7-4b47-9b67-f2e9a12d3c4f" md5="3755e2e5c9a414fab0c4f4d5210b90e9" offset="7299352"/>
-      <h4:byteStream chunkPositionInArray="[20,30,10,30]" nBytes="40000" uuid="3b8e19a5-2856-444a-9978-f44d4cae2873" md5="78fdf3900d0004f9c89d4fd86bff59c4" offset="7339352"/>
-      <h4:byteStream chunkPositionInArray="[20,30,20,0]" nBytes="40000" uuid="fb4bb4ef-d904-4602-8abf-14420d2afad0" md5="2b0789beeef5f236c2e29a74da071c39" offset="7379352"/>
-      <h4:byteStream chunkPositionInArray="[20,30,20,10]" nBytes="40000" uuid="000bbb90-7177-4ed2-9518-f06c42f20539" md5="1e50630b003bfe2ed0b5ddffb8539316" offset="7419352"/>
-      <h4:byteStream chunkPositionInArray="[20,30,20,20]" nBytes="40000" uuid="ac3c576f-cb67-4776-a665-f866fd932fda" md5="d024367b951dd590522a60f5f936cdc3" offset="7459352"/>
-      <h4:byteStream chunkPositionInArray="[20,30,20,30]" nBytes="40000" uuid="d51152a3-e840-4647-bb17-e77195cb5ca8" md5="e611ac1ecd37d89b154c2eb2be468071" offset="7499352"/>
-      <h4:byteStream chunkPositionInArray="[20,30,30,0]" nBytes="40000" uuid="13ea5a6a-65a6-4b8a-b3b1-2278955c0b47" md5="1f9c692d48ae4268efb0e6338eda6cec" offset="7539352"/>
-      <h4:byteStream chunkPositionInArray="[20,30,30,10]" nBytes="40000" uuid="b3506475-beff-4373-bf69-14553712b1f0" md5="5d0032b157923cf17711c6c2d330206a" offset="7579352"/>
-      <h4:byteStream chunkPositionInArray="[20,30,30,20]" nBytes="40000" uuid="febefe59-3e89-494f-b4e3-5f4b75f94d79" md5="d5071f5ab099e241b09e84ee51ace326" offset="7619352"/>
-      <h4:byteStream chunkPositionInArray="[20,30,30,30]" nBytes="40000" uuid="7b8a1f04-8e62-48b6-9dcc-256c5f962cbc" md5="d65fa466733bf7f8ba154a11bfdfaf95" offset="7659352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,0,0]" nBytes="40000" uuid="fdfac3fa-77e0-4880-90ac-65fc98aaec82" md5="421d9d6f1636d8310f9b4e42b454cb19" offset="7699352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,0,10]" nBytes="40000" uuid="5162fe8a-e463-483c-8518-bcdb315d27c5" md5="3850609d654be8c0dbbe0d1cffe2f2a5" offset="7739352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,0,20]" nBytes="40000" uuid="2430f85b-0fe5-485c-970d-f51c9947e45e" md5="7e72e51b4e652cfaa33d15ab7ef958b1" offset="7779352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,0,30]" nBytes="40000" uuid="14f6d41f-3ec0-4369-8343-330523e2313c" md5="1bbd2a6bc111d5930162a7bca24faeef" offset="7819352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,10,0]" nBytes="40000" uuid="905d6538-80f8-449a-b227-1f58f6a5b344" md5="beaf1a69f5464d7a66b8507a1f8aa617" offset="7859352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,10,10]" nBytes="40000" uuid="268400a5-b80d-464e-8ec6-9d1f513b133d" md5="9ee4df3b297662485e1e22cef7297725" offset="7899352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,10,20]" nBytes="40000" uuid="1b73767d-594a-4938-a804-c10e530841dd" md5="139c46a59c4665bb6ed883a0978b1ced" offset="7939352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,10,30]" nBytes="40000" uuid="40eb7508-a969-4952-b75f-96d64f06462b" md5="889dddbc45587814cb657139162b5049" offset="7979352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,20,0]" nBytes="40000" uuid="ea68e4ef-84f6-4e7e-9e9b-e358870b138d" md5="5374697ad20a2f98a3c681c06b0ab3cf" offset="8019352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,20,10]" nBytes="40000" uuid="605586e2-8f95-4d68-b4b2-3ce5a6609e65" md5="e33225025b178709aeeab337e492c0ca" offset="8059352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,20,20]" nBytes="40000" uuid="d6d12d1d-c408-4d6e-9b2d-ebb8b44aa87b" md5="122e4e7987bcc96f0fcc82ee6509855c" offset="8099352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,20,30]" nBytes="40000" uuid="59f41e99-a184-4556-aa5f-502496bcf53f" md5="8457650eb3d6f7cb3194ab906309ea78" offset="8139352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,30,0]" nBytes="40000" uuid="683d38d0-826f-4293-90f5-a5eebf19a848" md5="21f19ab3d8a0b6df0f231935ae5fcf80" offset="8179352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,30,10]" nBytes="40000" uuid="8cd56b6a-29a8-4204-97b6-2991d6aebf36" md5="4aaa87f6f158d8e2f2f9031407197a09" offset="8219352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,30,20]" nBytes="40000" uuid="1b9285a1-5433-4ec1-9755-e2cfab4ff7ff" md5="68c90437ae223d6c7da4300bb96c8d9e" offset="8259352"/>
-      <h4:byteStream chunkPositionInArray="[30,0,30,30]" nBytes="40000" uuid="6779694b-b5ac-4197-a5d6-1fbd5b5610f0" md5="83f8f56f9a7148b84badef282a38298c" offset="8299352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,0,0]" nBytes="40000" uuid="66dc3852-7afb-48ed-99ef-5a29b781c665" md5="c3c73e3364af87d6643f02bd6b41729c" offset="8339352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,0,10]" nBytes="40000" uuid="2684f708-c5b7-4611-9f61-c2ebae88cd2c" md5="2a26e8c6a7eaae39c62940317578a13e" offset="8379352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,0,20]" nBytes="40000" uuid="30ebcf41-db26-4cd2-b8e8-b14060d87c47" md5="c4068993dca2599b9fd20c6c9c678a9c" offset="8419352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,0,30]" nBytes="40000" uuid="b6355693-8a0c-4525-ab37-7598b597c82a" md5="b7d6e54c085359a4b204b90d959e24c4" offset="8459352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,10,0]" nBytes="40000" uuid="141f156a-abbe-491d-9a8a-2889f6e8c1a0" md5="8ef9587f89e26dfaa7e40dcfa8dfcde9" offset="8499352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,10,10]" nBytes="40000" uuid="320b1e05-bc01-4a45-b18e-8b2d7b33149f" md5="7823703e0b203988b381df6b44cfd19e" offset="8539352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,10,20]" nBytes="40000" uuid="849b4f19-a24d-4ab3-9fde-cadc1d0c9b8a" md5="d2c7783b0ceefeda70db0d706297e80c" offset="8579352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,10,30]" nBytes="40000" uuid="e1db81c1-b440-46a1-800f-5067b5036c61" md5="aaa87c8625369fe715cedaa8d37fb100" offset="8619352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,20,0]" nBytes="40000" uuid="9e52e133-6d07-442c-9581-daf1e8c03b4f" md5="40d477638a1db2db914628eb96413f82" offset="8659352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,20,10]" nBytes="40000" uuid="52e886f4-acc7-4506-9a95-ae183631478e" md5="1321911364f089b1ec55974884a00ec4" offset="8699352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,20,20]" nBytes="40000" uuid="817c5d1c-cb38-4845-aa4c-0fa4846f4d05" md5="5433eaaaa7d5ab0efd1c7f6e92dff400" offset="8739352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,20,30]" nBytes="40000" uuid="e4db4560-9ed1-4dde-8fa8-420ac1f8b7a7" md5="8bc9f0128cd924090fd54e74b62c8b3a" offset="8779352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,30,0]" nBytes="40000" uuid="b4f2877b-e3b7-43f5-846f-b94a313a262c" md5="d2b3384bcd8e20e83c447f59eadc4f67" offset="8819352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,30,10]" nBytes="40000" uuid="432b32a3-f6b7-480a-b674-162e425cd095" md5="304cf8d268b7ef3880e0ebe49725898f" offset="8859352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,30,20]" nBytes="40000" uuid="0f1cf8bd-a6a1-47ad-99c7-64d504fd12b1" md5="043b840a328b438f64d824554d7250e2" offset="8899352"/>
-      <h4:byteStream chunkPositionInArray="[30,10,30,30]" nBytes="40000" uuid="86f438ce-3d84-48d4-b0a0-829985f63d48" md5="2858c401dbcdd58510c410d231050ec7" offset="8939352"/>
-      <h4:byteStream chunkPositionInArray="[30,20,0,0]" nBytes="40000" uuid="643261eb-2d46-4d8a-8e00-493a4d8e13bd" md5="f94a3941906f4b1651867d622f8f8d7b" offset="8979352"/>
-      <h4:byteStream chunkPositionInArray="[30,20,0,10]" nBytes="40000" uuid="89f30279-b64c-41b7-8d4a-d28fb814246c" md5="3d8db4aeb2bc7cdc262f2be6b13975ad" offset="9019352"/>
-      <h4:byteStream chunkPositionInArray="[30,20,0,20]" nBytes="40000" uuid="b689fe4f-944f-4c0b-9419-ee938859858a" md5="64a150354e31e351876ba8ea5238a901" offset="9059352"/>
-      <h4:byteStream chunkPositionInArray="[30,20,0,30]" nBytes="40000" uuid="61b90fc4-1b45-4812-b308-fc96a60864cf" md5="9f86a3560013b761c8f0c24cae5ea458" offset="9099352"/>
-      <h4:byteStream chunkPositionInArray="[30,20,10,0]" nBytes="40000" uuid="91a20f67-3d7a-45e5-bbb9-2690615ea902" md5="192fd43f9fdfa6dc2039433727d1911e" offset="9139352"/>
-      <h4:byteStream chunkPositionInArray="[30,20,10,10]" nBytes="40000" uuid="9c46eecf-5353-40d3-ae31-44eabf4970ce" md5="df436a213de7f711bd7cfa57eda9a5c3" offset="9179352"/>
-      <h4:byteStream chunkPositionInArray="[30,20,10,20]" nBytes="40000" uuid="ba2c90bd-4bf8-4905-981a-9c811aa05887" md5="4d51f7c94268ad48896cc12f001e6aba" offset="9221400"/>
-      <h4:byteStream chunkPositionInArray="[30,20,10,30]" nBytes="40000" uuid="651c99e1-feba-44a9-87d0-eb823b61838c" md5="3f638b842dbfbad2a30409e074dff457" offset="9261400"/>
-      <h4:byteStream chunkPositionInArray="[30,20,20,0]" nBytes="40000" uuid="64ad106a-64a2-4237-bd41-2271d93e562e" md5="f95302bd868434ae71066e202089fc62" offset="9301400"/>
-      <h4:byteStream chunkPositionInArray="[30,20,20,10]" nBytes="40000" uuid="720734c6-db41-4cd5-a5ee-3d470cb95056" md5="4cbf28aec6ec728cc99d9f5a9ce285bf" offset="9341400"/>
-      <h4:byteStream chunkPositionInArray="[30,20,20,20]" nBytes="40000" uuid="c7284ee2-2d74-4882-8e42-9c2402792677" md5="f9871855eccc5bc7e90be555f64297bc" offset="9381400"/>
-      <h4:byteStream chunkPositionInArray="[30,20,20,30]" nBytes="40000" uuid="f679e884-7e80-42da-b399-e3fb71eea671" md5="9009d97ad61ec84cc0ae7bbe433bd696" offset="9421400"/>
-      <h4:byteStream chunkPositionInArray="[30,20,30,0]" nBytes="40000" uuid="cbc92d34-82ca-495b-8045-7a527f182de9" md5="2a43391393fcdcc528e2eb266d08d0a7" offset="9465056"/>
-      <h4:byteStream chunkPositionInArray="[30,20,30,10]" nBytes="40000" uuid="1d4d3d92-49a8-4fa8-aefe-d195c6d5d83e" md5="dac936c41f31631853f3f9920381e369" offset="9505056"/>
-      <h4:byteStream chunkPositionInArray="[30,20,30,20]" nBytes="40000" uuid="eb57a2e6-2ff4-4008-aa5e-6e8cba6a7fa1" md5="2d8c43b234fbbfe05ebe492333b925b4" offset="9545056"/>
-      <h4:byteStream chunkPositionInArray="[30,20,30,30]" nBytes="40000" uuid="8198da21-c5f0-4d24-9775-1fb2e869668f" md5="0dd817397d358afebb50456bafbf2b08" offset="9585056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,0,0]" nBytes="40000" uuid="45dd2209-e120-48eb-b5bb-0a28a4740a3e" md5="0784629174d2c11af2a5a6d6c99609fc" offset="9625056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,0,10]" nBytes="40000" uuid="c9683e47-6e14-4a32-a203-fc2df7609110" md5="f5b42aeba2ccb5fae9af21d6577bc8da" offset="9665056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,0,20]" nBytes="40000" uuid="6b7099d9-3602-4c62-a058-827c754ecebe" md5="d9e64986af12d1b39be900566629525b" offset="9705056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,0,30]" nBytes="40000" uuid="f814c13b-4aac-4f51-88f3-5a6500dc23c3" md5="7060fd0c0a6fd62cf7a599cdb888f726" offset="9745056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,10,0]" nBytes="40000" uuid="d6083079-6c0d-41e8-a238-3ee1bcad6811" md5="d855cf5883b1b15c9ab04784833d52cd" offset="9785056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,10,10]" nBytes="40000" uuid="728d0ebb-56a4-481b-9458-18e04b37e5cb" md5="63aedd877d86e932beeea2e71f1dda75" offset="9825056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,10,20]" nBytes="40000" uuid="fe098e64-eca5-417c-bb3d-a7755b23f6a2" md5="93ad4737c2cb98a9df15a006cbadb66c" offset="9865056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,10,30]" nBytes="40000" uuid="5b3d40e5-5500-4148-bd99-30e469064781" md5="17f22781de298d36db68c2c97cd8f650" offset="9905056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,20,0]" nBytes="40000" uuid="e1638b06-994a-4a05-b066-9dae9bcd254f" md5="09b7f78fea7f293b91ad73618d11ccc3" offset="9945056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,20,10]" nBytes="40000" uuid="bd5b050c-5b64-4b58-ab26-106ba1c67ac8" md5="3efe2ec017d59e3da6d0ff6b895edb28" offset="9985056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,20,20]" nBytes="40000" uuid="9c15ef39-9137-443b-94be-919f17ca493b" md5="961c44f5a1eec5db92b22bad7df68004" offset="10025056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,20,30]" nBytes="40000" uuid="7575ec38-6725-4451-bbff-8023fff0d898" md5="ff66fea387dca9f5fb076be8c92fee09" offset="10065056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,30,0]" nBytes="40000" uuid="78a8b4d2-361d-499c-b451-19be769fc4cd" md5="b5100d1efac5e94bc1a5a51e6369c69e" offset="10105056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,30,10]" nBytes="40000" uuid="e5c9e3aa-a961-4485-a777-970d411bedcf" md5="616e11f29fc0ee4ff6a83ba753c31363" offset="10145056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,30,20]" nBytes="40000" uuid="9d86ea3e-9b46-4601-a20e-71b3c1506ef3" md5="adca4590f439ed9f3f56529ed2f4ea2d" offset="10185056"/>
-      <h4:byteStream chunkPositionInArray="[30,30,30,30]" nBytes="40000" uuid="3f9cf8cf-4f68-4a8b-b60a-e5eb85660cb1" md5="29ba7dfba79366df9bffa90d2f50134a" offset="10225056"/>
-    </h4:chunks>
+    <dmrpp:chunks compressionType="shuffle">
+      <dmrpp:chunkDimensionSizes>10 10 10 10</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk chunkPositionInArray="[0,0,0,0]" nBytes="40000"   offset="4728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,0,10]" nBytes="40000"   offset="44728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,0,20]" nBytes="40000"   offset="84728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,0,30]" nBytes="40000"   offset="124728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,10,0]" nBytes="40000"   offset="164728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,10,10]" nBytes="40000"   offset="204728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,10,20]" nBytes="40000"   offset="244728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,10,30]" nBytes="40000"   offset="284728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,20,0]" nBytes="40000"   offset="324728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,20,10]" nBytes="40000"   offset="364728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,20,20]" nBytes="40000"   offset="404728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,20,30]" nBytes="40000"   offset="444728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,30,0]" nBytes="40000"   offset="484728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,30,10]" nBytes="40000"   offset="524728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,30,20]" nBytes="40000"   offset="564728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,0,30,30]" nBytes="40000"   offset="604728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,0,0]" nBytes="40000"   offset="644728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,0,10]" nBytes="40000"   offset="684728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,0,20]" nBytes="40000"   offset="724728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,0,30]" nBytes="40000"   offset="764728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,10,0]" nBytes="40000"   offset="804728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,10,10]" nBytes="40000"   offset="844728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,10,20]" nBytes="40000"   offset="884728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,10,30]" nBytes="40000"   offset="924728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,20,0]" nBytes="40000"   offset="964728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,20,10]" nBytes="40000"   offset="1004728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,20,20]" nBytes="40000"   offset="1044728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,20,30]" nBytes="40000"   offset="1084728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,30,0]" nBytes="40000"   offset="1124728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,30,10]" nBytes="40000"   offset="1164728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,30,20]" nBytes="40000"   offset="1204728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,10,30,30]" nBytes="40000"   offset="1244728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,0,0]" nBytes="40000"   offset="1284728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,0,10]" nBytes="40000"   offset="1324728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,0,20]" nBytes="40000"   offset="1364728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,0,30]" nBytes="40000"   offset="1404728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,10,0]" nBytes="40000"   offset="1444728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,10,10]" nBytes="40000"   offset="1484728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,10,20]" nBytes="40000"   offset="1524728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,10,30]" nBytes="40000"   offset="1564728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,20,0]" nBytes="40000"   offset="1604728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,20,10]" nBytes="40000"   offset="1644728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,20,20]" nBytes="40000"   offset="1684728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,20,30]" nBytes="40000"   offset="1724728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,30,0]" nBytes="40000"   offset="1764728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,30,10]" nBytes="40000"   offset="1804728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,30,20]" nBytes="40000"   offset="1844728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,20,30,30]" nBytes="40000"   offset="1884728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,0,0]" nBytes="40000"   offset="1924728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,0,10]" nBytes="40000"   offset="1964728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,0,20]" nBytes="40000"   offset="2004728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,0,30]" nBytes="40000"   offset="2044728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,10,0]" nBytes="40000"   offset="2084728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,10,10]" nBytes="40000"   offset="2124728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,10,20]" nBytes="40000"   offset="2164728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,10,30]" nBytes="40000"   offset="2204728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,20,0]" nBytes="40000"   offset="2244728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,20,10]" nBytes="40000"   offset="2284728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,20,20]" nBytes="40000"   offset="2324728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,20,30]" nBytes="40000"   offset="2364728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,30,0]" nBytes="40000"   offset="2404728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,30,10]" nBytes="40000"   offset="2444728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,30,20]" nBytes="40000"   offset="2484728"/>
+      <dmrpp:chunk chunkPositionInArray="[0,30,30,30]" nBytes="40000"   offset="2524728"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,0,0]" nBytes="40000"   offset="2564728"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,0,10]" nBytes="40000"   offset="2612040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,0,20]" nBytes="40000"   offset="2652040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,0,30]" nBytes="40000"   offset="2692040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,10,0]" nBytes="40000"   offset="2732040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,10,10]" nBytes="40000"   offset="2772040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,10,20]" nBytes="40000"   offset="2812040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,10,30]" nBytes="40000"   offset="2852040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,20,0]" nBytes="40000"   offset="2892040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,20,10]" nBytes="40000"   offset="2932040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,20,20]" nBytes="40000"   offset="2972040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,20,30]" nBytes="40000"   offset="3012040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,30,0]" nBytes="40000"   offset="3052040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,30,10]" nBytes="40000"   offset="3092040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,30,20]" nBytes="40000"   offset="3132040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,0,30,30]" nBytes="40000"   offset="3172040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,0,0]" nBytes="40000"   offset="3212040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,0,10]" nBytes="40000"   offset="3252040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,0,20]" nBytes="40000"   offset="3292040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,0,30]" nBytes="40000"   offset="3332040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,10,0]" nBytes="40000"   offset="3372040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,10,10]" nBytes="40000"   offset="3412040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,10,20]" nBytes="40000"   offset="3452040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,10,30]" nBytes="40000"   offset="3492040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,20,0]" nBytes="40000"   offset="3532040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,20,10]" nBytes="40000"   offset="3572040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,20,20]" nBytes="40000"   offset="3612040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,20,30]" nBytes="40000"   offset="3652040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,30,0]" nBytes="40000"   offset="3692040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,30,10]" nBytes="40000"   offset="3732040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,30,20]" nBytes="40000"   offset="3772040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,10,30,30]" nBytes="40000"   offset="3812040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,0,0]" nBytes="40000"   offset="3852040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,0,10]" nBytes="40000"   offset="3892040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,0,20]" nBytes="40000"   offset="3932040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,0,30]" nBytes="40000"   offset="3972040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,10,0]" nBytes="40000"   offset="4012040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,10,10]" nBytes="40000"   offset="4052040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,10,20]" nBytes="40000"   offset="4092040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,10,30]" nBytes="40000"   offset="4132040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,20,0]" nBytes="40000"   offset="4172040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,20,10]" nBytes="40000"   offset="4212040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,20,20]" nBytes="40000"   offset="4252040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,20,30]" nBytes="40000"   offset="4292040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,30,0]" nBytes="40000"   offset="4332040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,30,10]" nBytes="40000"   offset="4372040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,30,20]" nBytes="40000"   offset="4412040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,20,30,30]" nBytes="40000"   offset="4452040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,0,0]" nBytes="40000"   offset="4492040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,0,10]" nBytes="40000"   offset="4532040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,0,20]" nBytes="40000"   offset="4572040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,0,30]" nBytes="40000"   offset="4612040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,10,0]" nBytes="40000"   offset="4652040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,10,10]" nBytes="40000"   offset="4692040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,10,20]" nBytes="40000"   offset="4732040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,10,30]" nBytes="40000"   offset="4772040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,20,0]" nBytes="40000"   offset="4812040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,20,10]" nBytes="40000"   offset="4852040"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,20,20]" nBytes="40000"   offset="4895696"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,20,30]" nBytes="40000"   offset="4935696"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,30,0]" nBytes="40000"   offset="4975696"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,30,10]" nBytes="40000"   offset="5015696"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,30,20]" nBytes="40000"   offset="5055696"/>
+      <dmrpp:chunk chunkPositionInArray="[10,30,30,30]" nBytes="40000"   offset="5095696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,0,0]" nBytes="40000"   offset="5135696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,0,10]" nBytes="40000"   offset="5175696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,0,20]" nBytes="40000"   offset="5215696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,0,30]" nBytes="40000"   offset="5255696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,10,0]" nBytes="40000"   offset="5295696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,10,10]" nBytes="40000"   offset="5335696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,10,20]" nBytes="40000"   offset="5375696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,10,30]" nBytes="40000"   offset="5415696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,20,0]" nBytes="40000"   offset="5455696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,20,10]" nBytes="40000"   offset="5495696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,20,20]" nBytes="40000"   offset="5535696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,20,30]" nBytes="40000"   offset="5575696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,30,0]" nBytes="40000"   offset="5615696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,30,10]" nBytes="40000"   offset="5655696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,30,20]" nBytes="40000"   offset="5695696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,0,30,30]" nBytes="40000"   offset="5735696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,0,0]" nBytes="40000"   offset="5775696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,0,10]" nBytes="40000"   offset="5815696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,0,20]" nBytes="40000"   offset="5855696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,0,30]" nBytes="40000"   offset="5895696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,10,0]" nBytes="40000"   offset="5935696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,10,10]" nBytes="40000"   offset="5975696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,10,20]" nBytes="40000"   offset="6015696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,10,30]" nBytes="40000"   offset="6055696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,20,0]" nBytes="40000"   offset="6095696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,20,10]" nBytes="40000"   offset="6135696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,20,20]" nBytes="40000"   offset="6175696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,20,30]" nBytes="40000"   offset="6215696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,30,0]" nBytes="40000"   offset="6255696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,30,10]" nBytes="40000"   offset="6295696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,30,20]" nBytes="40000"   offset="6335696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,10,30,30]" nBytes="40000"   offset="6375696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,0,0]" nBytes="40000"   offset="6415696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,0,10]" nBytes="40000"   offset="6455696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,0,20]" nBytes="40000"   offset="6495696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,0,30]" nBytes="40000"   offset="6535696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,10,0]" nBytes="40000"   offset="6575696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,10,10]" nBytes="40000"   offset="6615696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,10,20]" nBytes="40000"   offset="6655696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,10,30]" nBytes="40000"   offset="6695696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,20,0]" nBytes="40000"   offset="6735696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,20,10]" nBytes="40000"   offset="6775696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,20,20]" nBytes="40000"   offset="6815696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,20,30]" nBytes="40000"   offset="6855696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,30,0]" nBytes="40000"   offset="6895696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,30,10]" nBytes="40000"   offset="6935696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,30,20]" nBytes="40000"   offset="6975696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,20,30,30]" nBytes="40000"   offset="7015696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,0,0]" nBytes="40000"   offset="7055696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,0,10]" nBytes="40000"   offset="7095696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,0,20]" nBytes="40000"   offset="7135696"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,0,30]" nBytes="40000"   offset="7179352"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,10,0]" nBytes="40000"   offset="7219352"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,10,10]" nBytes="40000"   offset="7259352"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,10,20]" nBytes="40000"   offset="7299352"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,10,30]" nBytes="40000"   offset="7339352"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,20,0]" nBytes="40000"   offset="7379352"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,20,10]" nBytes="40000"   offset="7419352"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,20,20]" nBytes="40000"   offset="7459352"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,20,30]" nBytes="40000"   offset="7499352"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,30,0]" nBytes="40000"   offset="7539352"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,30,10]" nBytes="40000"   offset="7579352"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,30,20]" nBytes="40000"   offset="7619352"/>
+      <dmrpp:chunk chunkPositionInArray="[20,30,30,30]" nBytes="40000"   offset="7659352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,0,0]" nBytes="40000"   offset="7699352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,0,10]" nBytes="40000"   offset="7739352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,0,20]" nBytes="40000"   offset="7779352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,0,30]" nBytes="40000"   offset="7819352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,10,0]" nBytes="40000"   offset="7859352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,10,10]" nBytes="40000"   offset="7899352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,10,20]" nBytes="40000"   offset="7939352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,10,30]" nBytes="40000"   offset="7979352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,20,0]" nBytes="40000"   offset="8019352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,20,10]" nBytes="40000"   offset="8059352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,20,20]" nBytes="40000"   offset="8099352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,20,30]" nBytes="40000"   offset="8139352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,30,0]" nBytes="40000"   offset="8179352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,30,10]" nBytes="40000"   offset="8219352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,30,20]" nBytes="40000"   offset="8259352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,0,30,30]" nBytes="40000"   offset="8299352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,0,0]" nBytes="40000"   offset="8339352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,0,10]" nBytes="40000"   offset="8379352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,0,20]" nBytes="40000"   offset="8419352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,0,30]" nBytes="40000"   offset="8459352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,10,0]" nBytes="40000"   offset="8499352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,10,10]" nBytes="40000"   offset="8539352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,10,20]" nBytes="40000"   offset="8579352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,10,30]" nBytes="40000"   offset="8619352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,20,0]" nBytes="40000"   offset="8659352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,20,10]" nBytes="40000"   offset="8699352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,20,20]" nBytes="40000"   offset="8739352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,20,30]" nBytes="40000"   offset="8779352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,30,0]" nBytes="40000"   offset="8819352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,30,10]" nBytes="40000"   offset="8859352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,30,20]" nBytes="40000"   offset="8899352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,10,30,30]" nBytes="40000"   offset="8939352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,0,0]" nBytes="40000"   offset="8979352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,0,10]" nBytes="40000"   offset="9019352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,0,20]" nBytes="40000"   offset="9059352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,0,30]" nBytes="40000"   offset="9099352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,10,0]" nBytes="40000"   offset="9139352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,10,10]" nBytes="40000"   offset="9179352"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,10,20]" nBytes="40000"   offset="9221400"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,10,30]" nBytes="40000"   offset="9261400"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,20,0]" nBytes="40000"   offset="9301400"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,20,10]" nBytes="40000"   offset="9341400"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,20,20]" nBytes="40000"   offset="9381400"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,20,30]" nBytes="40000"   offset="9421400"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,30,0]" nBytes="40000"   offset="9465056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,30,10]" nBytes="40000"   offset="9505056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,30,20]" nBytes="40000"   offset="9545056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,20,30,30]" nBytes="40000"   offset="9585056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,0,0]" nBytes="40000"   offset="9625056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,0,10]" nBytes="40000"   offset="9665056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,0,20]" nBytes="40000"   offset="9705056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,0,30]" nBytes="40000"   offset="9745056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,10,0]" nBytes="40000"   offset="9785056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,10,10]" nBytes="40000"   offset="9825056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,10,20]" nBytes="40000"   offset="9865056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,10,30]" nBytes="40000"   offset="9905056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,20,0]" nBytes="40000"   offset="9945056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,20,10]" nBytes="40000"   offset="9985056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,20,20]" nBytes="40000"   offset="10025056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,20,30]" nBytes="40000"   offset="10065056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,30,0]" nBytes="40000"   offset="10105056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,30,10]" nBytes="40000"   offset="10145056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,30,20]" nBytes="40000"   offset="10185056"/>
+      <dmrpp:chunk chunkPositionInArray="[30,30,30,30]" nBytes="40000"   offset="10225056"/>
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_shuffled_oneD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shuffled_oneD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shuffled_oneD.h5"
-    xml:base="data/dmrpp/chunked_shuffled_oneD.h5">
+    dmrpp:href="data/dmrpp/chunked_shuffled_oneD.h5">
     
   <Float32 name="d_4_shuffled_chunks">
     <Dim size="40000"/>
@@ -15,12 +15,12 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_4_shuffled_chunks</Value>
     </Attribute>
-    <h4:chunks compressionType="shuffle">
-      <h4:chunkDimensionSizes>10000</h4:chunkDimensionSizes>
-      <h4:byteStream md5="3abf2710049911731e3bcd7aa257b59d" offset="3496" nBytes="40000" uuid="4df8720c-2632-41fd-9a44-889dd5b2fd54" chunkPositionInArray="[0]"/>
-      <h4:byteStream md5="c1cef20c0b838eeb6419f280ef8d0e8d" offset="43496" nBytes="40000" uuid="bf583725-bcc4-4edc-a5a0-05aed57ae207" chunkPositionInArray="[10000]"/>
-      <h4:byteStream md5="d3570ea81146712e7cc2c74eb3d2861d" offset="83496" nBytes="40000" uuid="e68d1c0d-1230-4b22-a28f-619d06874c98" chunkPositionInArray="[20000]"/>
-      <h4:byteStream md5="f92b9533cb9f3ac1128ca7bd511c7c1b" offset="123496" nBytes="40000" uuid="cff426d8-9f73-400e-867b-9a05e29c332a" chunkPositionInArray="[30000]"/>
-    </h4:chunks>
+    <dmrpp:chunks compressionType="shuffle">
+      <dmrpp:chunkDimensionSizes>10000</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk  offset="3496" nBytes="40000"  chunkPositionInArray="[0]"/>
+      <dmrpp:chunk  offset="43496" nBytes="40000"  chunkPositionInArray="[10000]"/>
+      <dmrpp:chunk  offset="83496" nBytes="40000"  chunkPositionInArray="[20000]"/>
+      <dmrpp:chunk  offset="123496" nBytes="40000"  chunkPositionInArray="[30000]"/>
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_shuffled_oneD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shuffled_oneD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shuffled_oneD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shuffled_oneD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shuffled_oneD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shuffled_oneD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shuffled_threeD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shuffled_threeD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shuffled_threeD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shuffled_threeD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shuffled_threeD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shuffled_threeD.h5"
-    xml:base="data/dmrpp/chunked_shuffled_threeD.h5">
+    dmrpp:href="data/dmrpp/chunked_shuffled_threeD.h5">
 
   <Float32 name="d_8_shuffled_chunks">
     <Dim size="100"/>
@@ -17,136 +17,136 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_8_shuffled_chunks</Value>
     </Attribute>
-    <h4:chunks compressionType="shuffle">
-      <h4:chunkDimensionSizes>13 25 25</h4:chunkDimensionSizes>
-      <h4:byteStream chunkPositionInArray="[0,0,0]" offset="4208" nBytes="32500" md5="a571abdd22ff46081d9ec718e2d8917e" uuid="8059a66d-1c34-4dbd-82a7-24d0fd01a72c"/>
-      <h4:byteStream chunkPositionInArray="[0,0,25]" offset="36708" nBytes="32500" md5="8079e97665af9dfb791f41eebd060825" uuid="6bbe1240-2d4b-4920-924e-6837fe69a5c5"/>
-      <h4:byteStream chunkPositionInArray="[0,0,50]" offset="69208" nBytes="32500" md5="8a789e230d7ab95cf39a1bf8a79850e6" uuid="bbd4b3f0-67f5-410b-99f0-2cf429ca8f07"/>
-      <h4:byteStream chunkPositionInArray="[0,0,75]" offset="101708" nBytes="32500" md5="a2a4f5ea3ddc78a0d45e7b6370433725" uuid="706de901-f929-46b8-b956-cb9735f5bf65"/>
-      <h4:byteStream chunkPositionInArray="[0,25,0]" offset="134208" nBytes="32500" md5="4a05727d163a9970ea61cdc7f7da15b5" uuid="16e79eed-5b29-4f27-98ce-a94d717c6eeb"/>
-      <h4:byteStream chunkPositionInArray="[0,25,25]" offset="166708" nBytes="32500" md5="c8953f988c11b8a2f99261260c88abcc" uuid="b68cdbb8-ae01-4547-beff-ea36d08698b1"/>
-      <h4:byteStream chunkPositionInArray="[0,25,50]" offset="199208" nBytes="32500" md5="0475fedd59767cfe9b4bd5afa92ee99d" uuid="51fce60c-a019-424b-8b72-fd129ea7928d"/>
-      <h4:byteStream chunkPositionInArray="[0,25,75]" offset="231708" nBytes="32500" md5="c1f9d28b3dafbef06ac30478497d1682" uuid="fd5c023c-5115-40ee-9d14-e816b7223366"/>
-      <h4:byteStream chunkPositionInArray="[0,50,0]" offset="264208" nBytes="32500" md5="6c9d91f9540266e69bff2816ac79c3a1" uuid="b1d0f415-5168-4750-b0a9-39f81df109e3"/>
-      <h4:byteStream chunkPositionInArray="[0,50,25]" offset="296708" nBytes="32500" md5="79f820ecbb7937830b1eaeb048300b8f" uuid="3c60eae3-711c-4385-92f5-36daeb3c736b"/>
-      <h4:byteStream chunkPositionInArray="[0,50,50]" offset="329208" nBytes="32500" md5="1176653ac11e99874d7f76b74fc0db0f" uuid="c593a020-9db7-4a4b-993f-45d91fc36967"/>
-      <h4:byteStream chunkPositionInArray="[0,50,75]" offset="361708" nBytes="32500" md5="e74a82a960b76a1ee44b11b6af841c67" uuid="d6076bc8-4904-445d-a1f5-6351aafb7305"/>
-      <h4:byteStream chunkPositionInArray="[0,75,0]" offset="394208" nBytes="32500" md5="d4ec2656907acb5adf2e0414e1ea2549" uuid="f462b0b3-fb92-4630-87fd-91fcd573664f"/>
-      <h4:byteStream chunkPositionInArray="[0,75,25]" offset="426708" nBytes="32500" md5="a23892065fbfbbb6e7a5557f9d88985a" uuid="3a429bba-80ab-427b-b1d4-333a6eca56ea"/>
-      <h4:byteStream chunkPositionInArray="[0,75,50]" offset="459208" nBytes="32500" md5="9e6f07e80b1870e8dabd94184383f53e" uuid="b779db45-8ed2-49c8-beff-7a7619dcf37e"/>
-      <h4:byteStream chunkPositionInArray="[0,75,75]" offset="491708" nBytes="32500" md5="5a794c8ca002cb591c9c09e9b18d543a" uuid="f5c87c8e-39e0-4fb9-a5c8-e72458cee620"/>
-      <h4:byteStream chunkPositionInArray="[13,0,0]" offset="524208" nBytes="32500" md5="d19e71f9450e65f1b5827cf4d3febc1d" uuid="dab5374d-1083-441e-945d-895737a8f88b"/>
-      <h4:byteStream chunkPositionInArray="[13,0,25]" offset="556708" nBytes="32500" md5="f3a44a898332397cafda527e0939a62f" uuid="cbeaa083-1b0b-40ee-8c55-88facf7e4c67"/>
-      <h4:byteStream chunkPositionInArray="[13,0,50]" offset="589208" nBytes="32500" md5="6017b37f587aa1a1daa5c68734699000" uuid="49d3c516-d3a3-43d1-ad27-c995794a2790"/>
-      <h4:byteStream chunkPositionInArray="[13,0,75]" offset="621708" nBytes="32500" md5="dfa91cfea426b3e54ec06fd3033be7bd" uuid="5ddf6926-8cab-40c3-806d-ec6d3808c4e6"/>
-      <h4:byteStream chunkPositionInArray="[13,25,0]" offset="654208" nBytes="32500" md5="4141feaa10cf064f5c2a1dc3c97de4d0" uuid="e4abbba3-b306-4bad-9baa-c99687556c8b"/>
-      <h4:byteStream chunkPositionInArray="[13,25,25]" offset="686708" nBytes="32500" md5="456a76f2852e6bdec0252b18f7c44bc6" uuid="e09d68b0-8b9e-4eae-976a-89ceff60b0ef"/>
-      <h4:byteStream chunkPositionInArray="[13,25,50]" offset="719208" nBytes="32500" md5="f99d6e46e53bc1973dd1978c7155a265" uuid="16d18851-7d75-48ef-a0a1-5747d7073049"/>
-      <h4:byteStream chunkPositionInArray="[13,25,75]" offset="751708" nBytes="32500" md5="f8e5c4c395c3d600dac4f86b30a81933" uuid="4fb25a88-55fe-4d7c-86b5-5a9db49061f5"/>
-      <h4:byteStream chunkPositionInArray="[13,50,0]" offset="784208" nBytes="32500" md5="6d7398e932dc090fafe825c25cfc8229" uuid="d42a4415-9701-4ae6-aa1b-850ceb6d8177"/>
-      <h4:byteStream chunkPositionInArray="[13,50,25]" offset="816708" nBytes="32500" md5="8c50a7cd6f710eceacc3d681ec4c8502" uuid="2aa0cb1e-864c-46cf-8f23-852db9608999"/>
-      <h4:byteStream chunkPositionInArray="[13,50,50]" offset="849208" nBytes="32500" md5="6ddabbb1069d45ba4ad7b1856965b8a6" uuid="a35b4627-2fa8-452e-8452-b5fe86a0bc37"/>
-      <h4:byteStream chunkPositionInArray="[13,50,75]" offset="881708" nBytes="32500" md5="4f2d0943269e5ff299795bbd529f51c7" uuid="0069d7b8-4243-4fdf-a837-d7fe32f99417"/>
-      <h4:byteStream chunkPositionInArray="[13,75,0]" offset="914208" nBytes="32500" md5="64f74c354ff55405a530e598bd6b5db0" uuid="3fd63b18-41f9-4f22-85e4-90201009f28b"/>
-      <h4:byteStream chunkPositionInArray="[13,75,25]" offset="946708" nBytes="32500" md5="2c7972bb5abdcaaa56a8e65659efc2ac" uuid="4018376f-30e1-4f2b-859b-666eedd6f92d"/>
-      <h4:byteStream chunkPositionInArray="[13,75,50]" offset="979208" nBytes="32500" md5="b189ed2a260f3736a86f26e09337a4d1" uuid="335029b9-5556-4a80-a7d8-8b1966f2beb0"/>
-      <h4:byteStream chunkPositionInArray="[13,75,75]" offset="1011708" nBytes="32500" md5="26b4ca6df317b3564a5b7194ae9d71c2" uuid="1ef0dba3-0dd7-42f5-ad12-26276061b6b6"/>
-      <h4:byteStream chunkPositionInArray="[26,0,0]" offset="1044208" nBytes="32500" md5="98f3d20be29d58a46ab5467125d09f2b" uuid="9d44a301-5c5b-40ea-906c-a520a7129464"/>
-      <h4:byteStream chunkPositionInArray="[26,0,25]" offset="1076708" nBytes="32500" md5="968f7379b0201dcfc543810160342d47" uuid="494efc12-b0a8-4475-965c-08230dc1a2cc"/>
-      <h4:byteStream chunkPositionInArray="[26,0,50]" offset="1109208" nBytes="32500" md5="b69d08c20098e7133071b4dc142ae1eb" uuid="32dd1454-8d7f-42d9-8a59-2c230b302e03"/>
-      <h4:byteStream chunkPositionInArray="[26,0,75]" offset="1141708" nBytes="32500" md5="b57ce8b9202134d037574a781a0dd02e" uuid="e9edbde3-fc0f-496a-92ee-bd1d016bb373"/>
-      <h4:byteStream chunkPositionInArray="[26,25,0]" offset="1174208" nBytes="32500" md5="d20c3a1270304e39f4ca6bd187026c1e" uuid="26eb245b-3c91-497d-9a83-a35cfda60266"/>
-      <h4:byteStream chunkPositionInArray="[26,25,25]" offset="1206708" nBytes="32500" md5="2db5a1e8c50bfe4b09f2b9dc54c8b539" uuid="520646be-762b-4b65-9a0d-91c99159e56d"/>
-      <h4:byteStream chunkPositionInArray="[26,25,50]" offset="1239208" nBytes="32500" md5="8b2281967f888f1f67902121b52b0e7b" uuid="134bb176-200c-480b-a61f-5ee6b756978a"/>
-      <h4:byteStream chunkPositionInArray="[26,25,75]" offset="1271708" nBytes="32500" md5="dd2e86f61c97d4ceed5e13453bbdb19f" uuid="450b6b35-aa51-4597-b6b2-c8a7b8753ebf"/>
-      <h4:byteStream chunkPositionInArray="[26,50,0]" offset="1304208" nBytes="32500" md5="a2bdbda4f32d8ac500bdd5ce3355d360" uuid="70d10607-abdb-4173-ab23-13d1aca53019"/>
-      <h4:byteStream chunkPositionInArray="[26,50,25]" offset="1336708" nBytes="32500" md5="365d715b8d7057d1cd7c82e9450addff" uuid="ed0edfac-aa13-47dc-ba3e-1397c0ab0c8d"/>
-      <h4:byteStream chunkPositionInArray="[26,50,50]" offset="1369208" nBytes="32500" md5="5f4049597a5c9667a9a43a81edcf25a8" uuid="062db9e2-7bd6-470f-82db-787fb722ffe6"/>
-      <h4:byteStream chunkPositionInArray="[26,50,75]" offset="1401708" nBytes="32500" md5="00d524dfe18190239c71720fc77ef474" uuid="fe9445b5-9557-42c3-9729-b6edb50a6c13"/>
-      <h4:byteStream chunkPositionInArray="[26,75,0]" offset="1434208" nBytes="32500" md5="c7e292df31c10124c46ca3f9be1dd85a" uuid="b9130abd-a249-4891-9785-9aa366e0bee8"/>
-      <h4:byteStream chunkPositionInArray="[26,75,25]" offset="1466708" nBytes="32500" md5="95d0784d67cb70fa6cf338827837169b" uuid="4b1bba2b-feef-4d2f-838a-e70890f120af"/>
-      <h4:byteStream chunkPositionInArray="[26,75,50]" offset="1499208" nBytes="32500" md5="f29bbe61c35bc850d0f63ad57de2c461" uuid="7e090add-3555-4b50-954b-0e1b8037a40f"/>
-      <h4:byteStream chunkPositionInArray="[26,75,75]" offset="1531708" nBytes="32500" md5="aade4391058b65db7687c84970cd805c" uuid="47df46bf-1dbd-498e-b40a-08500903cc35"/>
-      <h4:byteStream chunkPositionInArray="[39,0,0]" offset="1564208" nBytes="32500" md5="0dd922e448022bc81eec050274b7b023" uuid="db4ed17b-70c1-4269-9784-3954a9fd2ae8"/>
-      <h4:byteStream chunkPositionInArray="[39,0,25]" offset="1596708" nBytes="32500" md5="959e2116b4d2414272ee3f8f731fd0a6" uuid="c3bfeadc-a15f-4df2-8200-2e86bcfaeb93"/>
-      <h4:byteStream chunkPositionInArray="[39,0,50]" offset="1629208" nBytes="32500" md5="194e3244801befd356f351356b123969" uuid="be3152a9-9726-43ac-b9b9-f7e69a9528ea"/>
-      <h4:byteStream chunkPositionInArray="[39,0,75]" offset="1661708" nBytes="32500" md5="50b9e694e01251290c3c04bb7f59cca8" uuid="94ac6b60-9a6f-4927-82e5-775329e85509"/>
-      <h4:byteStream chunkPositionInArray="[39,25,0]" offset="1694208" nBytes="32500" md5="d7b8b11fc6b359cb6fc047e4689fa9f4" uuid="71abee7b-6950-4943-bc3d-84845deca0a9"/>
-      <h4:byteStream chunkPositionInArray="[39,25,25]" offset="1726708" nBytes="32500" md5="328cf0ffa5c2d2220b13bf08537dc88c" uuid="411f669d-f55f-4cec-9d8b-7264658d7cb0"/>
-      <h4:byteStream chunkPositionInArray="[39,25,50]" offset="1759208" nBytes="32500" md5="be662154fb7b0a15f92af21b0e1da25a" uuid="3d7d423a-05f8-4034-b16d-d45eea21b987"/>
-      <h4:byteStream chunkPositionInArray="[39,25,75]" offset="1791708" nBytes="32500" md5="a149b498e53632cecdb6bc9307e7df04" uuid="99e527e7-e725-403e-aa5e-d77b428332bc"/>
-      <h4:byteStream chunkPositionInArray="[39,50,0]" offset="1824208" nBytes="32500" md5="135ad14de29526f722e47bd153991fe5" uuid="7e0bd216-5684-4799-83c0-8ccf951c3268"/>
-      <h4:byteStream chunkPositionInArray="[39,50,25]" offset="1856708" nBytes="32500" md5="a6aedffc5e14f019c56789f79d7d64de" uuid="99bf96bc-c9d6-4d2b-a02d-6d7d387fd121"/>
-      <h4:byteStream chunkPositionInArray="[39,50,50]" offset="1889208" nBytes="32500" md5="15ba4a963912188704155520ff1debb9" uuid="4b861d74-bf14-448c-8a78-1e6f0ca9261b"/>
-      <h4:byteStream chunkPositionInArray="[39,50,75]" offset="1921708" nBytes="32500" md5="32c429a044f25c5584ec4fbc64833237" uuid="ed44f770-3e0a-4523-8bb3-589415c7f8ab"/>
-      <h4:byteStream chunkPositionInArray="[39,75,0]" offset="1954208" nBytes="32500" md5="cbe56857d50ef8fdd27fbe5c5626664a" uuid="a6108cbe-8de0-4e81-9375-8b854dfee105"/>
-      <h4:byteStream chunkPositionInArray="[39,75,25]" offset="1986708" nBytes="32500" md5="00565e0d3477d8acce1dc83484e7c875" uuid="68cdb70e-34e4-4898-85fb-11d10e180686"/>
-      <h4:byteStream chunkPositionInArray="[39,75,50]" offset="2019208" nBytes="32500" md5="d78ef4ca5fcfdf6fb1718c7debe6266d" uuid="5e23e9f8-a00e-462b-a60b-118c944bf356"/>
-      <h4:byteStream chunkPositionInArray="[39,75,75]" offset="2051708" nBytes="32500" md5="1b8e8f45c6213b58a488c8c5611e57cc" uuid="18797d63-1597-41fb-b602-68cc78e65297"/>
-      <h4:byteStream chunkPositionInArray="[52,0,0]" offset="2084208" nBytes="32500" md5="09a161045eed5c6945ea551755b54145" uuid="5a04260d-36de-4fff-bf73-b97a4c6ed10d"/>
-      <h4:byteStream chunkPositionInArray="[52,0,25]" offset="2122980" nBytes="32500" md5="137aaf0dd356fe4f28090a062163c2f7" uuid="13da0301-60cb-46d0-b4f5-00efd80fde34"/>
-      <h4:byteStream chunkPositionInArray="[52,0,50]" offset="2155480" nBytes="32500" md5="e7ee28c05f056430fb35de385891f70e" uuid="19ab5c00-6a3a-4f5d-bdee-2cc715c120ee"/>
-      <h4:byteStream chunkPositionInArray="[52,0,75]" offset="2187980" nBytes="32500" md5="98dea70323a007f1dccb3e90020c5538" uuid="cc9675d9-6ccd-41e6-a337-14a7472bf04f"/>
-      <h4:byteStream chunkPositionInArray="[52,25,0]" offset="2220480" nBytes="32500" md5="301237f39daeebf5633d0e2f62010243" uuid="78251e6b-cb39-4d7c-b715-aeebe6cd794d"/>
-      <h4:byteStream chunkPositionInArray="[52,25,25]" offset="2252980" nBytes="32500" md5="95d601da98e964e8146ec2f3ac0d8570" uuid="ae5fc261-6deb-44b2-8f14-88bac1d598b6"/>
-      <h4:byteStream chunkPositionInArray="[52,25,50]" offset="2285480" nBytes="32500" md5="2524ae812d74870ac55d529fdb670805" uuid="936d8977-d69c-482d-924a-c3ce76638de1"/>
-      <h4:byteStream chunkPositionInArray="[52,25,75]" offset="2317980" nBytes="32500" md5="b781428cb589f467e48c61f2bc4cbe73" uuid="8702e657-825e-4e13-a90a-fa00f48ff4fa"/>
-      <h4:byteStream chunkPositionInArray="[52,50,0]" offset="2350480" nBytes="32500" md5="b9f4c9502c3cebcc740f0859dda612c6" uuid="46956769-d680-4dd8-843a-747e4db36643"/>
-      <h4:byteStream chunkPositionInArray="[52,50,25]" offset="2382980" nBytes="32500" md5="2532c91c538806c6c8c0f3801084db74" uuid="607e2022-c8bf-4f66-a4f7-e2a0f1751003"/>
-      <h4:byteStream chunkPositionInArray="[52,50,50]" offset="2415480" nBytes="32500" md5="e640487e2f08fa0bae81be1613932615" uuid="9eceb48b-27c7-44cd-8777-03c9ffa81a18"/>
-      <h4:byteStream chunkPositionInArray="[52,50,75]" offset="2447980" nBytes="32500" md5="4f84b4a2e713bfe6157bd4b395bdbe69" uuid="169a411e-8ff7-41a1-a3db-056dcedea2ed"/>
-      <h4:byteStream chunkPositionInArray="[52,75,0]" offset="2480480" nBytes="32500" md5="e4f8660ff188d6540c12b38e12ca634b" uuid="e1557764-42fb-4998-879a-c7b798739a3f"/>
-      <h4:byteStream chunkPositionInArray="[52,75,25]" offset="2512980" nBytes="32500" md5="530ce2981a28b02ebd85e6e0cf2488a5" uuid="ef35e9d0-4af0-4bff-a217-81fb1c12bf5f"/>
-      <h4:byteStream chunkPositionInArray="[52,75,50]" offset="2545480" nBytes="32500" md5="45f6747633eb76fcb6595cd330225fee" uuid="4b16fc2e-5c78-42bb-a7c0-6acc1fa89cf6"/>
-      <h4:byteStream chunkPositionInArray="[52,75,75]" offset="2577980" nBytes="32500" md5="be49e7ec5301b775d8c877aa7170f868" uuid="9a457d43-c7ae-44d0-8748-e2a52364792c"/>
-      <h4:byteStream chunkPositionInArray="[65,0,0]" offset="2610480" nBytes="32500" md5="3ed42c260609c5f1fab0a43fab571091" uuid="95edc7fe-62a8-4e71-9596-ec62dddb1089"/>
-      <h4:byteStream chunkPositionInArray="[65,0,25]" offset="2642980" nBytes="32500" md5="9b01e77e5b40ff673e67d162c58fef41" uuid="6684aed8-3074-4ebd-8b4c-f8ee13f3a6ac"/>
-      <h4:byteStream chunkPositionInArray="[65,0,50]" offset="2675480" nBytes="32500" md5="b6922cd8967ce7c0f01e401cfacd29d5" uuid="fdd7fe45-11f0-4ee2-ad82-2cf57e69d439"/>
-      <h4:byteStream chunkPositionInArray="[65,0,75]" offset="2707980" nBytes="32500" md5="cb16ccd5df018f780c2d98ca6eb05fec" uuid="295e138c-8376-4360-81fe-2d17b85cd9a1"/>
-      <h4:byteStream chunkPositionInArray="[65,25,0]" offset="2740480" nBytes="32500" md5="78fabe4596e3912eb7e974ff1e2ab9eb" uuid="ee41ed71-dd7d-4fee-a117-f110d1ca9079"/>
-      <h4:byteStream chunkPositionInArray="[65,25,25]" offset="2772980" nBytes="32500" md5="3b30838b136d0ae795416ab75458c6a3" uuid="0b75639b-9261-4d7f-baf7-afc30e821363"/>
-      <h4:byteStream chunkPositionInArray="[65,25,50]" offset="2805480" nBytes="32500" md5="75ad2787e22d46546422612ecbdc520a" uuid="a1010931-9e28-4fc9-937e-285c7b4cc2e9"/>
-      <h4:byteStream chunkPositionInArray="[65,25,75]" offset="2837980" nBytes="32500" md5="80ad944999ed9c1d5802da3ad3deadec" uuid="c781a1b8-50c3-4538-901e-d512b549b9c9"/>
-      <h4:byteStream chunkPositionInArray="[65,50,0]" offset="2870480" nBytes="32500" md5="dc2dae61aeb63ddb4b20107ebe3335c3" uuid="3451812d-26ca-4ff7-b895-9d279fc1b500"/>
-      <h4:byteStream chunkPositionInArray="[65,50,25]" offset="2902980" nBytes="32500" md5="7a4bd874c1c0a47a06d2c55d9b203797" uuid="515de1d9-ef20-4a85-ac82-8c36631f4e96"/>
-      <h4:byteStream chunkPositionInArray="[65,50,50]" offset="2935480" nBytes="32500" md5="58bbcd4078dd8dbabcde759ed2ecc4a5" uuid="5d3cd4dc-3e44-4f0a-9ff6-bdfe1b791806"/>
-      <h4:byteStream chunkPositionInArray="[65,50,75]" offset="2967980" nBytes="32500" md5="a27631bcf1b117a8c913e83ef8e7566d" uuid="17652063-45cc-42cb-b05d-b47754c24819"/>
-      <h4:byteStream chunkPositionInArray="[65,75,0]" offset="3000480" nBytes="32500" md5="571e46c112164e46a562a5f912ff2e04" uuid="8e769c83-80e8-4e94-8325-ac2b5792be31"/>
-      <h4:byteStream chunkPositionInArray="[65,75,25]" offset="3032980" nBytes="32500" md5="1cc2f3b5d611efa577175d232d6ca622" uuid="b5a792ef-b3fc-4b44-9e82-1d2a14131796"/>
-      <h4:byteStream chunkPositionInArray="[65,75,50]" offset="3065480" nBytes="32500" md5="68509f86ef4b82c0b01571a6fc360cec" uuid="c56be687-58ae-4ff1-8a4c-804d8cc90734"/>
-      <h4:byteStream chunkPositionInArray="[65,75,75]" offset="3097980" nBytes="32500" md5="a0a0761c96bbec4437bf61fcff4074e6" uuid="295eb56a-65af-4579-93d7-08bca2d49f31"/>
-      <h4:byteStream chunkPositionInArray="[78,0,0]" offset="3132528" nBytes="32500" md5="1644772ff1cc525d8e86501f831c8642" uuid="755d9de2-8ba6-4a3b-97f9-9042dab6e6f9"/>
-      <h4:byteStream chunkPositionInArray="[78,0,25]" offset="3165028" nBytes="32500" md5="fa427f706306fedd0a8e9ec904a49e03" uuid="82454943-d8ef-48f3-801d-c39e253a86c6"/>
-      <h4:byteStream chunkPositionInArray="[78,0,50]" offset="3197528" nBytes="32500" md5="b99ba1ab70a0e60a0819510348ccacc4" uuid="861cd459-dea2-4d33-81b0-c7e58bfb1295"/>
-      <h4:byteStream chunkPositionInArray="[78,0,75]" offset="3230028" nBytes="32500" md5="bd323bb2d20bcae84104bb618af2eebf" uuid="6c2474e5-7842-406a-b8e2-e2eec84f3023"/>
-      <h4:byteStream chunkPositionInArray="[78,25,0]" offset="3262528" nBytes="32500" md5="5eea264786176a0354e9fa13e01effa4" uuid="2f8692a4-8a4b-47ae-b171-8e42a654e64f"/>
-      <h4:byteStream chunkPositionInArray="[78,25,25]" offset="3295028" nBytes="32500" md5="ae7ba512a2ca81944dc1bd387938e069" uuid="c90516ed-6f03-4088-9623-6171cf5f1698"/>
-      <h4:byteStream chunkPositionInArray="[78,25,50]" offset="3327528" nBytes="32500" md5="cf802af012f277cd807c7343b5bcc801" uuid="5a884096-5005-4ebd-9140-f8a1b8f5d8a2"/>
-      <h4:byteStream chunkPositionInArray="[78,25,75]" offset="3360028" nBytes="32500" md5="66bc5c81bb82cc80cad10fae376b0453" uuid="a21b7000-670a-449f-9c95-c4aba65f2cc4"/>
-      <h4:byteStream chunkPositionInArray="[78,50,0]" offset="3392528" nBytes="32500" md5="1980c5f632a7284caa621486ad25b2b4" uuid="e8995330-c263-4790-80aa-d360825b1d55"/>
-      <h4:byteStream chunkPositionInArray="[78,50,25]" offset="3425028" nBytes="32500" md5="9ebc57446f907586b411eb4b47fa30f2" uuid="c94fdea0-af13-4b37-8c07-4512cd7ebea7"/>
-      <h4:byteStream chunkPositionInArray="[78,50,50]" offset="3457528" nBytes="32500" md5="4b2595e9dbe74dc8bc225673e7e4c9d8" uuid="d52243e9-da26-405d-8fe0-8c0efe3b6ac7"/>
-      <h4:byteStream chunkPositionInArray="[78,50,75]" offset="3490028" nBytes="32500" md5="e6048bb56217e6884ca66e21f035892a" uuid="059db96a-abc9-4739-8eb8-1cd7b232d689"/>
-      <h4:byteStream chunkPositionInArray="[78,75,0]" offset="3522528" nBytes="32500" md5="0101eddbdfdc5447dedb0e09f694343b" uuid="9ca30036-63d5-4c26-b20a-6b2017ec3a87"/>
-      <h4:byteStream chunkPositionInArray="[78,75,25]" offset="3555028" nBytes="32500" md5="73ea1bb4f9b470b441d52935221f2010" uuid="a0bb6740-3ea7-4980-8657-1e8e0dc1f775"/>
-      <h4:byteStream chunkPositionInArray="[78,75,50]" offset="3587528" nBytes="32500" md5="942c0a7b2c2d33d34387c0ecd951e6ea" uuid="2eca133b-41b2-482e-9b7c-aba5ca1a8119"/>
-      <h4:byteStream chunkPositionInArray="[78,75,75]" offset="3620028" nBytes="32500" md5="da2e002c91a5910d3d6a81376e75b15b" uuid="7879b379-4ef0-4350-a154-5b73f9f599a4"/>
-      <h4:byteStream chunkPositionInArray="[91,0,0]" offset="3652528" nBytes="32500" md5="c68d0059c67c12964641d5bf9affbe9c" uuid="3f8b6d90-d004-4b12-8616-e816213d0f75"/>
-      <h4:byteStream chunkPositionInArray="[91,0,25]" offset="3685028" nBytes="32500" md5="0315cb9c6950b5d656d7d4a4aa3cfc3e" uuid="502caf57-0d4a-4f8c-8ebb-7590635b2107"/>
-      <h4:byteStream chunkPositionInArray="[91,0,50]" offset="3717528" nBytes="32500" md5="c4eba9d2f0da3beee118431bbeab1801" uuid="0f0ca3a8-81c9-47fc-b8cd-a7d89732c282"/>
-      <h4:byteStream chunkPositionInArray="[91,0,75]" offset="3750028" nBytes="32500" md5="0cbcd4cb9af9c4d7d0ec72884d62dbfe" uuid="85783067-41ee-485e-b714-3faa952e686f"/>
-      <h4:byteStream chunkPositionInArray="[91,25,0]" offset="3782528" nBytes="32500" md5="b59e04c5f506cfe85f5bc588f5d6e5f2" uuid="a283b4c5-53ca-43e0-a6e8-fb955225d0ea"/>
-      <h4:byteStream chunkPositionInArray="[91,25,25]" offset="3815028" nBytes="32500" md5="c87b12e92ddfd0032e65e08cf0a241b2" uuid="87388edf-8dcb-49c5-96a2-443a92645929"/>
-      <h4:byteStream chunkPositionInArray="[91,25,50]" offset="3847528" nBytes="32500" md5="41802c35888f66d8919cbc1e9774e80c" uuid="d1603b85-5a81-4102-ade8-aeb25c77068e"/>
-      <h4:byteStream chunkPositionInArray="[91,25,75]" offset="3880028" nBytes="32500" md5="f2ba73a88ed999e50db1d98fcd582ff2" uuid="3e780490-0c15-4c85-8038-ff1aaad51b31"/>
-      <h4:byteStream chunkPositionInArray="[91,50,0]" offset="3912528" nBytes="32500" md5="6ed84b388e13c5ce59dea7a2600310d7" uuid="ba72251f-70a2-47ca-86b5-08aefb6b9536"/>
-      <h4:byteStream chunkPositionInArray="[91,50,25]" offset="3945028" nBytes="32500" md5="691938fe177527c41a67ec92aecb463d" uuid="31eb3765-0a19-4f49-8518-aea68448a81c"/>
-      <h4:byteStream chunkPositionInArray="[91,50,50]" offset="3980664" nBytes="32500" md5="df45abecd4f61559535c8779fdd967f7" uuid="3e259413-05e5-4363-88fc-288c864dcd7b"/>
-      <h4:byteStream chunkPositionInArray="[91,50,75]" offset="4013164" nBytes="32500" md5="9512c431d48da837549a6a563e87beb7" uuid="237e3f0e-5d2f-48c7-8bbc-e26b3ecb1748"/>
-      <h4:byteStream chunkPositionInArray="[91,75,0]" offset="4045664" nBytes="32500" md5="378ac5ed1c23fe9e124236870ef6da61" uuid="1f625acf-4373-40c6-b64b-9b5624538abf"/>
-      <h4:byteStream chunkPositionInArray="[91,75,25]" offset="4078164" nBytes="32500" md5="331a9020b8eea94f0a65828f27742024" uuid="565f416e-5bfd-4e39-acc7-533e82d3f45d"/>
-      <h4:byteStream chunkPositionInArray="[91,75,50]" offset="4110664" nBytes="32500" md5="be472be60e7af7f89574a24387e518ed" uuid="00bfb403-1adb-432c-9e65-d90b3b3eabad"/>
-      <h4:byteStream chunkPositionInArray="[91,75,75]" offset="4143164" nBytes="32500" md5="4fa35911caaac0adcb7d64db0ab0c01b" uuid="26e7c4a5-e016-4ba2-99a3-66dbab8343ed"/>
-    </h4:chunks>
+    <dmrpp:chunks compressionType="shuffle">
+      <dmrpp:chunkDimensionSizes>13 25 25</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk chunkPositionInArray="[0,0,0]" offset="4208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,0,25]" offset="36708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,0,50]" offset="69208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,0,75]" offset="101708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,25,0]" offset="134208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,25,25]" offset="166708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,25,50]" offset="199208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,25,75]" offset="231708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,50,0]" offset="264208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,50,25]" offset="296708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,50,50]" offset="329208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,50,75]" offset="361708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,75,0]" offset="394208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,75,25]" offset="426708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,75,50]" offset="459208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[0,75,75]" offset="491708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,0,0]" offset="524208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,0,25]" offset="556708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,0,50]" offset="589208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,0,75]" offset="621708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,25,0]" offset="654208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,25,25]" offset="686708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,25,50]" offset="719208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,25,75]" offset="751708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,50,0]" offset="784208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,50,25]" offset="816708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,50,50]" offset="849208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,50,75]" offset="881708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,75,0]" offset="914208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,75,25]" offset="946708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,75,50]" offset="979208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[13,75,75]" offset="1011708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,0,0]" offset="1044208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,0,25]" offset="1076708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,0,50]" offset="1109208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,0,75]" offset="1141708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,25,0]" offset="1174208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,25,25]" offset="1206708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,25,50]" offset="1239208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,25,75]" offset="1271708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,50,0]" offset="1304208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,50,25]" offset="1336708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,50,50]" offset="1369208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,50,75]" offset="1401708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,75,0]" offset="1434208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,75,25]" offset="1466708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,75,50]" offset="1499208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[26,75,75]" offset="1531708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,0,0]" offset="1564208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,0,25]" offset="1596708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,0,50]" offset="1629208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,0,75]" offset="1661708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,25,0]" offset="1694208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,25,25]" offset="1726708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,25,50]" offset="1759208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,25,75]" offset="1791708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,50,0]" offset="1824208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,50,25]" offset="1856708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,50,50]" offset="1889208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,50,75]" offset="1921708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,75,0]" offset="1954208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,75,25]" offset="1986708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,75,50]" offset="2019208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[39,75,75]" offset="2051708" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,0,0]" offset="2084208" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,0,25]" offset="2122980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,0,50]" offset="2155480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,0,75]" offset="2187980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,25,0]" offset="2220480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,25,25]" offset="2252980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,25,50]" offset="2285480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,25,75]" offset="2317980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,50,0]" offset="2350480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,50,25]" offset="2382980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,50,50]" offset="2415480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,50,75]" offset="2447980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,75,0]" offset="2480480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,75,25]" offset="2512980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,75,50]" offset="2545480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[52,75,75]" offset="2577980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,0,0]" offset="2610480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,0,25]" offset="2642980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,0,50]" offset="2675480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,0,75]" offset="2707980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,25,0]" offset="2740480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,25,25]" offset="2772980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,25,50]" offset="2805480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,25,75]" offset="2837980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,50,0]" offset="2870480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,50,25]" offset="2902980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,50,50]" offset="2935480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,50,75]" offset="2967980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,75,0]" offset="3000480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,75,25]" offset="3032980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,75,50]" offset="3065480" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[65,75,75]" offset="3097980" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,0,0]" offset="3132528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,0,25]" offset="3165028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,0,50]" offset="3197528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,0,75]" offset="3230028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,25,0]" offset="3262528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,25,25]" offset="3295028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,25,50]" offset="3327528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,25,75]" offset="3360028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,50,0]" offset="3392528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,50,25]" offset="3425028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,50,50]" offset="3457528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,50,75]" offset="3490028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,75,0]" offset="3522528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,75,25]" offset="3555028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,75,50]" offset="3587528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[78,75,75]" offset="3620028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,0,0]" offset="3652528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,0,25]" offset="3685028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,0,50]" offset="3717528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,0,75]" offset="3750028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,25,0]" offset="3782528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,25,25]" offset="3815028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,25,50]" offset="3847528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,25,75]" offset="3880028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,50,0]" offset="3912528" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,50,25]" offset="3945028" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,50,50]" offset="3980664" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,50,75]" offset="4013164" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,75,0]" offset="4045664" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,75,25]" offset="4078164" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,75,50]" offset="4110664" nBytes="32500"  />
+      <dmrpp:chunk chunkPositionInArray="[91,75,75]" offset="4143164" nBytes="32500"  />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_shuffled_threeD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shuffled_threeD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shuffled_threeD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shuffled_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shuffled_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shuffled_twoD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shuffled_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shuffled_twoD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shuffled_twoD.h5"
-    xml:base="data/dmrpp/chunked_shuffled_twoD.h5">
+    dmrpp:href="data/dmrpp/chunked_shuffled_twoD.h5">
         
   <Float32 name="d_4_shuffled_chunks">
     <Dim size="100"/>
@@ -16,12 +16,12 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_4_shuffled_chunks</Value>
     </Attribute>
-    <h4:chunks compressionType="shuffle">
-      <h4:chunkDimensionSizes>50 50</h4:chunkDimensionSizes>
-      <h4:byteStream chunkPositionInArray="[0,0]" uuid="f77d60ef-0791-4b44-bdc5-2c05b76c1532" md5="458b8df8ef37fc0065db49c059a2fc4e" offset="4016" nBytes="10000"/>
-      <h4:byteStream chunkPositionInArray="[0,50]" uuid="7b7d4faa-09f6-4cd9-a3c8-139ac040a98a" md5="59c546f719b0428cedc283b6901ecb72" offset="14016" nBytes="10000"/>
-      <h4:byteStream chunkPositionInArray="[50,0]" uuid="a508e0ea-87bc-4d8d-acb6-caa14f6811b2" md5="dfbe505c95a13be25c632f7aadf2c6e6" offset="24016" nBytes="10000"/>
-      <h4:byteStream chunkPositionInArray="[50,50]" uuid="e10cd675-d04c-4fab-9717-06f422a74fa3" md5="ca3e28167e7b46e55addce7337525eea" offset="34016" nBytes="10000"/>
-    </h4:chunks>
+    <dmrpp:chunks compressionType="shuffle">
+      <dmrpp:chunkDimensionSizes>50 50</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk chunkPositionInArray="[0,0]"   offset="4016" nBytes="10000"/>
+      <dmrpp:chunk chunkPositionInArray="[0,50]"   offset="14016" nBytes="10000"/>
+      <dmrpp:chunk chunkPositionInArray="[50,0]"   offset="24016" nBytes="10000"/>
+      <dmrpp:chunk chunkPositionInArray="[50,50]"   offset="34016" nBytes="10000"/>
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_shuffled_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shuffled_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shuffled_twoD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shufzip_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shufzip_fourD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shufzip_fourD.h5"     

--- a/modules/dmrpp_module/data/dmrpp/chunked_shufzip_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shufzip_fourD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shufzip_fourD.h5"     
-    xml:base="data/dmrpp/chunked_shufzip_fourD.h5">
+    dmrpp:href="data/dmrpp/chunked_shufzip_fourD.h5">
 
   <Float32 name="d_16_shufzip_chunks">
     <Dim size="40"/>
@@ -18,264 +18,264 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_16_shufzip_chunks</Value>
     </Attribute>
-    <h4:chunks deflate_level="6" compressionType="shuffle deflate">
-      <h4:chunkDimensionSizes>10 10 10 10</h4:chunkDimensionSizes>
-      <h4:byteStream offset="4728" md5="3970ace3017d4cec0d8df039117b1d7a" uuid="6d04d367-23c4-4b02-a914-58f3e6409a9d" nBytes="3860" chunkPositionInArray="[0,0,0,0]"/>
-      <h4:byteStream offset="8588" md5="66aed2cc3e1479047d71e8673ceb3176" uuid="be74df71-85fc-4707-b37e-5ab705e5b35c" nBytes="3903" chunkPositionInArray="[0,0,0,10]"/>
-      <h4:byteStream offset="12491" md5="5b00b0dc22311aa85e79d8d14aa90bc8" uuid="ae4fdbef-5160-4915-91c0-68f1ff36a5c1" nBytes="3789" chunkPositionInArray="[0,0,0,20]"/>
-      <h4:byteStream offset="16280" md5="02ccf0eeacf64e3fef28e82d534c6570" uuid="be49d223-5456-4728-a105-f8f0a776c4d4" nBytes="3578" chunkPositionInArray="[0,0,0,30]"/>
-      <h4:byteStream offset="19858" md5="5903b80ecad8559e54bf7c4a76c6a7eb" uuid="ec91e028-38a0-4849-bfea-2e925e063379" nBytes="3837" chunkPositionInArray="[0,0,10,0]"/>
-      <h4:byteStream offset="23695" md5="7f3b4ef55d7150d579ce9ab1f77318d9" uuid="f8b42452-a745-4df0-8cea-4cd494871968" nBytes="3875" chunkPositionInArray="[0,0,10,10]"/>
-      <h4:byteStream offset="27570" md5="318edde099ed103392c6762e5469a432" uuid="ba66d97d-0e59-4659-8495-68c24d1b3c91" nBytes="3765" chunkPositionInArray="[0,0,10,20]"/>
-      <h4:byteStream offset="31335" md5="ee3401d23cb57fba829a8180cfdcbbe8" uuid="3a47ffea-05b0-482c-a39b-fd8a5d0f9590" nBytes="3554" chunkPositionInArray="[0,0,10,30]"/>
-      <h4:byteStream offset="34889" md5="c724f34dde819552120236229e43ee29" uuid="f4e4ffe3-5fc3-4c27-802f-1b271d0c4544" nBytes="3870" chunkPositionInArray="[0,0,20,0]"/>
-      <h4:byteStream offset="38759" md5="55e19bea5e1620839b98cdab65c7be89" uuid="66b64b59-113b-4c5b-886b-4a90012960e6" nBytes="3908" chunkPositionInArray="[0,0,20,10]"/>
-      <h4:byteStream offset="42667" md5="3181b6d954582ea8311d19dedf496a5c" uuid="bc51e4ce-67c3-431d-a89e-65e41d5e2500" nBytes="3782" chunkPositionInArray="[0,0,20,20]"/>
-      <h4:byteStream offset="46449" md5="bad65a23881b6cb02967930af2ef3dc9" uuid="a56b23ce-6623-4f74-81af-5e93efceef9d" nBytes="3573" chunkPositionInArray="[0,0,20,30]"/>
-      <h4:byteStream offset="50022" md5="fa4caa7849e4ae7f35c8b6ef8daa2f69" uuid="562323bd-cffa-43d2-939b-abc47834d78f" nBytes="3860" chunkPositionInArray="[0,0,30,0]"/>
-      <h4:byteStream offset="53882" md5="9276af41059a7b2166d7e6660b60bde0" uuid="f1418ced-9c5d-4998-b4df-02c08a7a48d2" nBytes="3900" chunkPositionInArray="[0,0,30,10]"/>
-      <h4:byteStream offset="57782" md5="ef53802da23fe023238b548da164644e" uuid="b712210a-0603-42f3-9533-53f2cec8141d" nBytes="3740" chunkPositionInArray="[0,0,30,20]"/>
-      <h4:byteStream offset="61522" md5="c308e39c34830b24210486bacbe5cf21" uuid="bda7d15a-bd02-4d33-9fad-d8bdddb979ee" nBytes="3524" chunkPositionInArray="[0,0,30,30]"/>
-      <h4:byteStream offset="65046" md5="84e08f239efb0f38f98f240a43a32b73" uuid="77a3fccc-5348-447a-b348-353766851d3c" nBytes="3893" chunkPositionInArray="[0,10,0,0]"/>
-      <h4:byteStream offset="68939" md5="13275f75a41299c12aa6899228eccad4" uuid="da6d9c23-31b8-4248-917e-e60bb67e2435" nBytes="3975" chunkPositionInArray="[0,10,0,10]"/>
-      <h4:byteStream offset="72914" md5="a9b37d0c21575a7fae370744f9f07828" uuid="818e785d-4c06-41da-85b4-1f8ae818932c" nBytes="3865" chunkPositionInArray="[0,10,0,20]"/>
-      <h4:byteStream offset="76779" md5="55dc6ed62460dedf6857cad21dc0dbc5" uuid="47670b3c-57a4-43e9-808d-44374dd09014" nBytes="3665" chunkPositionInArray="[0,10,0,30]"/>
-      <h4:byteStream offset="80444" md5="aefdef8e24261e403f5c0fa90245a8d2" uuid="31f3f7ab-2cec-45de-b73b-25b2fe967077" nBytes="3795" chunkPositionInArray="[0,10,10,0]"/>
-      <h4:byteStream offset="84239" md5="2e02ed846b7ff0577b3c50c943962b6d" uuid="547fca42-42e2-4576-860b-05962549e8ac" nBytes="3857" chunkPositionInArray="[0,10,10,10]"/>
-      <h4:byteStream offset="88096" md5="3cfbf1fa5283d74c0ec0865dd0dc8e84" uuid="544ce026-002d-4449-8d0b-08e2ed2cc071" nBytes="3724" chunkPositionInArray="[0,10,10,20]"/>
-      <h4:byteStream offset="91820" md5="07be96f50d1d42ad730c02901832d02e" uuid="867ddeea-d1bf-4d7d-a4cc-b3371fc8d3d2" nBytes="3528" chunkPositionInArray="[0,10,10,30]"/>
-      <h4:byteStream offset="95348" md5="ed637d03ff5db52613e23780ef67c632" uuid="db51b991-704b-4b77-b4b0-a54e3fb8d244" nBytes="3803" chunkPositionInArray="[0,10,20,0]"/>
-      <h4:byteStream offset="99151" md5="54eeac456448a9615aecf9220beb7570" uuid="7fbd33e9-840f-4d31-bb0b-913132536a6e" nBytes="3882" chunkPositionInArray="[0,10,20,10]"/>
-      <h4:byteStream offset="103033" md5="62c11aa9fd117f9b58068e518b5fb8da" uuid="e1e93d27-5a59-4a1b-a6a8-05c41bc2069c" nBytes="3742" chunkPositionInArray="[0,10,20,20]"/>
-      <h4:byteStream offset="106775" md5="48a5db33cf9be9d489da9250efa9c056" uuid="6459ad45-ef97-49e8-b917-3499cb162f36" nBytes="3547" chunkPositionInArray="[0,10,20,30]"/>
-      <h4:byteStream offset="110322" md5="0dbba0d9cd65095f99111ceec667bf09" uuid="d1b0ae54-4e26-4a4b-9cc4-87e9966eaa52" nBytes="3824" chunkPositionInArray="[0,10,30,0]"/>
-      <h4:byteStream offset="114146" md5="32ec88ebd311b05a5e0f6278ecc5cf26" uuid="df17d651-59ab-460f-bca5-29a5b2338f14" nBytes="3900" chunkPositionInArray="[0,10,30,10]"/>
-      <h4:byteStream offset="118046" md5="a5263acd1a24a61b4dd7f507d23a04ee" uuid="e2097227-f3d3-4706-b492-4a3d191dd8be" nBytes="3751" chunkPositionInArray="[0,10,30,20]"/>
-      <h4:byteStream offset="121797" md5="06fd0fc5788d7aded6265bd1cb17e325" uuid="98b507a4-c87a-426c-9e2a-5c3736bc0d8c" nBytes="3538" chunkPositionInArray="[0,10,30,30]"/>
-      <h4:byteStream offset="125335" md5="07aedccaa2c3761e57f8b14c312702ab" uuid="26b2cc14-c8b4-48a8-bd93-6cf56cdaf3cc" nBytes="4031" chunkPositionInArray="[0,20,0,0]"/>
-      <h4:byteStream offset="129366" md5="d4c322bf323b1484cfcb70b95c9c02ea" uuid="968cf0cf-52ca-42c5-8f42-d8ec73a7ca47" nBytes="4117" chunkPositionInArray="[0,20,0,10]"/>
-      <h4:byteStream offset="133483" md5="8ffac83ea7214671cd21ba3ee214b33c" uuid="f9373cf2-64a2-48a3-8cfa-2dc2335c6060" nBytes="3999" chunkPositionInArray="[0,20,0,20]"/>
-      <h4:byteStream offset="137482" md5="d7889c9ca7552031167c0cde073ea861" uuid="1aa9422d-8334-4417-b192-71bb3de28745" nBytes="3806" chunkPositionInArray="[0,20,0,30]"/>
-      <h4:byteStream offset="141288" md5="3009f9de565a042ae739aa56a074c79c" uuid="d5c104ba-6e41-4b0c-b959-5334cb68d01a" nBytes="4050" chunkPositionInArray="[0,20,10,0]"/>
-      <h4:byteStream offset="145338" md5="f665fa1e77e780fd59c98bccdad28599" uuid="516f0ffd-faff-4c08-b724-57a6e6b78fcf" nBytes="4125" chunkPositionInArray="[0,20,10,10]"/>
-      <h4:byteStream offset="149463" md5="39ed9e0e2b4dd4f0c7d587a1c0771b7f" uuid="99c2bbeb-8331-4c0e-9655-3a43360d1f84" nBytes="3989" chunkPositionInArray="[0,20,10,20]"/>
-      <h4:byteStream offset="153452" md5="b225ad4947e4638b728332d05c463cff" uuid="cc85b4fd-e536-421e-8249-cedae09cb300" nBytes="3793" chunkPositionInArray="[0,20,10,30]"/>
-      <h4:byteStream offset="157245" md5="c62b1f26f48c746f15ea16f6ed4492ae" uuid="579b09c2-3870-41e8-841c-d829992e26fe" nBytes="3919" chunkPositionInArray="[0,20,20,0]"/>
-      <h4:byteStream offset="161164" md5="b25de8cdf9a1a4a78d09f63d3c7b9dd7" uuid="bd71f3d0-575b-40e2-8986-b095d3686c67" nBytes="4010" chunkPositionInArray="[0,20,20,10]"/>
-      <h4:byteStream offset="165174" md5="80378172ddeedaa078faf18801bd19ad" uuid="7e427bbf-f1fb-4929-b6d0-ba4094a34875" nBytes="3873" chunkPositionInArray="[0,20,20,20]"/>
-      <h4:byteStream offset="169047" md5="08d0513beb6fa4f55d10bda05cdef28f" uuid="ca76f5a2-fa01-48df-b2e4-7361b7f59676" nBytes="3670" chunkPositionInArray="[0,20,20,30]"/>
-      <h4:byteStream offset="172717" md5="ae1a533df85668eeb497e245646a9098" uuid="6efee212-13f9-4211-855f-593a54f837e4" nBytes="3940" chunkPositionInArray="[0,20,30,0]"/>
-      <h4:byteStream offset="176657" md5="c9a7e340d4ef001f7d235080e24b071c" uuid="eca57b2b-5164-49ff-ad4e-f6baa1f39fe6" nBytes="4010" chunkPositionInArray="[0,20,30,10]"/>
-      <h4:byteStream offset="180667" md5="01f5fe133cdcbebc384fd44f3459044f" uuid="1bf18269-0618-4f0e-9e57-bbebbbb09562" nBytes="3867" chunkPositionInArray="[0,20,30,20]"/>
-      <h4:byteStream offset="184534" md5="4c980546caf240636cf6f8aa9947b10e" uuid="c172ea86-963d-46ce-8842-78a8b32a344e" nBytes="3666" chunkPositionInArray="[0,20,30,30]"/>
-      <h4:byteStream offset="188200" md5="ff4407ac50173dde00b5a928539ecd8e" uuid="42a6a1b5-8804-4004-8a19-ca89b2ee07bc" nBytes="3926" chunkPositionInArray="[0,30,0,0]"/>
-      <h4:byteStream offset="192126" md5="b014630ffb1ffc9866fbb1399a216596" uuid="20333afc-73d0-4d76-af73-50bc4a41a984" nBytes="4007" chunkPositionInArray="[0,30,0,10]"/>
-      <h4:byteStream offset="196133" md5="a1da2d8a0215bc19b5aa06c29a91ff03" uuid="5f71e9b0-7aa6-451e-99df-ecc1f09dfb70" nBytes="3880" chunkPositionInArray="[0,30,0,20]"/>
-      <h4:byteStream offset="200013" md5="17ce916ff8db54d7d879103f8cd69b89" uuid="45b42f64-4f40-4a37-be8d-6d2c4ccb7f3c" nBytes="3692" chunkPositionInArray="[0,30,0,30]"/>
-      <h4:byteStream offset="203705" md5="da951a60f3d31302c5c31366e10d828c" uuid="900e547d-a2b9-4b41-825f-8494e531af74" nBytes="3932" chunkPositionInArray="[0,30,10,0]"/>
-      <h4:byteStream offset="207637" md5="61ae404893ea50a3f4a699acc6dc31e3" uuid="dfbb87b4-0bea-4ac6-bed2-310baa29acd1" nBytes="4020" chunkPositionInArray="[0,30,10,10]"/>
-      <h4:byteStream offset="211657" md5="fdf1d32069f65240cb28b694583642b0" uuid="28b06994-57d7-4a58-a567-bb5026f863d3" nBytes="3886" chunkPositionInArray="[0,30,10,20]"/>
-      <h4:byteStream offset="215543" md5="7387c9830e9a9c9a47229994d9e262eb" uuid="809063b1-128e-4b06-acb6-3ac0102a6665" nBytes="3693" chunkPositionInArray="[0,30,10,30]"/>
-      <h4:byteStream offset="219236" md5="3b5823f4698053b60b946b1a890adcda" uuid="bba88ac7-6827-43e4-bd51-1b1ea861e7d7" nBytes="3936" chunkPositionInArray="[0,30,20,0]"/>
-      <h4:byteStream offset="223172" md5="47654797f89b5569bc1812d3986b533e" uuid="d93d3b08-3c6c-42c5-b24d-274fbbd316a1" nBytes="4021" chunkPositionInArray="[0,30,20,10]"/>
-      <h4:byteStream offset="227193" md5="eeb89054c39ad4d0d110cf2f81518f76" uuid="0de3cec4-ce08-43f8-bd10-fe0ebf154354" nBytes="3878" chunkPositionInArray="[0,30,20,20]"/>
-      <h4:byteStream offset="231071" md5="6e677c5ba6ffde5f135e85f12a4e1e56" uuid="46b7d192-e1ec-491e-b75b-a77260cec4a8" nBytes="3690" chunkPositionInArray="[0,30,20,30]"/>
-      <h4:byteStream offset="234761" md5="47720b1a9573e796b3fb1d0d1ee4f07a" uuid="477a3658-7999-48b6-a043-12fb93b955ab" nBytes="3919" chunkPositionInArray="[0,30,30,0]"/>
-      <h4:byteStream offset="238680" md5="55e5e4bb9a9a8511aa55122a58a3eb96" uuid="179b14e1-1e88-43f3-ba6a-9b05d3543880" nBytes="3996" chunkPositionInArray="[0,30,30,10]"/>
-      <h4:byteStream offset="242676" md5="a2feaa6da19e092269daefc7aea5653d" uuid="bed38bd0-09ec-4f9d-9df5-03c8ffff6b4a" nBytes="3847" chunkPositionInArray="[0,30,30,20]"/>
-      <h4:byteStream offset="246523" md5="e42539c22f549a5c67ca0843029d48c1" uuid="584da7f2-76b0-4987-add8-4727fcacafe0" nBytes="3656" chunkPositionInArray="[0,30,30,30]"/>
-      <h4:byteStream offset="250179" md5="2b9d0016fae8f18a40c5d6f0e7a90e3d" uuid="b9f50d0f-69df-4c23-81dc-99a0c6d94a93" nBytes="2360" chunkPositionInArray="[10,0,0,0]"/>
-      <h4:byteStream offset="259851" md5="6ec3461501ac0a4ba8f4197d3bcf1428" uuid="0cd564e7-0c3b-4a73-a0c4-a4387f52cc09" nBytes="2299" chunkPositionInArray="[10,0,0,10]"/>
-      <h4:byteStream offset="262150" md5="c364d7dff593a5264d7e20e0187428b1" uuid="510fd97e-9e85-4fbe-9a6b-25828e54c3d8" nBytes="2266" chunkPositionInArray="[10,0,0,20]"/>
-      <h4:byteStream offset="264416" md5="32b01c06619006532a0da3aa5fa5e22e" uuid="68962324-fa40-4af5-beaf-4b1443e42402" nBytes="2328" chunkPositionInArray="[10,0,0,30]"/>
-      <h4:byteStream offset="266744" md5="e9c1ba4924c067ed5e9bde88c1fd68c9" uuid="daba738c-5e79-4f6b-8eed-62bcff19a603" nBytes="2367" chunkPositionInArray="[10,0,10,0]"/>
-      <h4:byteStream offset="269111" md5="6547351c240ffff0eeee47906caa32e4" uuid="aef99950-1b07-4b93-87ff-70f85903ccf4" nBytes="2313" chunkPositionInArray="[10,0,10,10]"/>
-      <h4:byteStream offset="271424" md5="fcf905ac21c9fe123f0119ec3c029310" uuid="dfd444bc-2317-44e5-83c8-7ef3e47956ec" nBytes="2249" chunkPositionInArray="[10,0,10,20]"/>
-      <h4:byteStream offset="273673" md5="abb90179a2d43cd3e327009fdc1d1d26" uuid="d32d1cb2-17f4-4bbd-9b0b-b8334953c41d" nBytes="2294" chunkPositionInArray="[10,0,10,30]"/>
-      <h4:byteStream offset="275967" md5="1b988de9612443ea1455f09e21098324" uuid="89170ab0-235d-4233-be73-4ecdffa4effe" nBytes="2330" chunkPositionInArray="[10,0,20,0]"/>
-      <h4:byteStream offset="278297" md5="da09b3c352d97e86979aa060a8bf6270" uuid="deb73997-e79c-4f43-8f54-a8679e77c02a" nBytes="2308" chunkPositionInArray="[10,0,20,10]"/>
-      <h4:byteStream offset="280605" md5="6140e88bd075efd001045720fece70c3" uuid="bf1ae320-d847-4203-b90d-a12536d2bd0b" nBytes="2286" chunkPositionInArray="[10,0,20,20]"/>
-      <h4:byteStream offset="282891" md5="956cf40494073338fb670673ad381798" uuid="0e69c085-8a1a-4644-81b9-b837d9683278" nBytes="2330" chunkPositionInArray="[10,0,20,30]"/>
-      <h4:byteStream offset="285221" md5="6bbb1ddaa809be387a39fffcc7a7c21c" uuid="b63fee73-6c72-4cf0-bbbd-a0b3a0f1b708" nBytes="2411" chunkPositionInArray="[10,0,30,0]"/>
-      <h4:byteStream offset="287632" md5="7a017b1c63816e50b50b7cb8c638e75c" uuid="03c674a7-2d8c-4043-a788-f5b1b6f57dab" nBytes="2351" chunkPositionInArray="[10,0,30,10]"/>
-      <h4:byteStream offset="289983" md5="1dc5b4b616f4b1214da05f43d842afa6" uuid="1ec4052a-d012-4d1a-9433-a84227dcacdc" nBytes="2275" chunkPositionInArray="[10,0,30,20]"/>
-      <h4:byteStream offset="292258" md5="fdb608eba5ec53ae81a1757a41d0c6cd" uuid="d3da9a3d-68ff-45f2-965f-93e57afada0e" nBytes="2321" chunkPositionInArray="[10,0,30,30]"/>
-      <h4:byteStream offset="294579" md5="4a58e0745f064703c5c50a9d78e4ced0" uuid="92340ef1-4b30-4331-b39b-db34e3c416dd" nBytes="2392" chunkPositionInArray="[10,10,0,0]"/>
-      <h4:byteStream offset="296971" md5="1ff70a3d12e663959f26f4c6b5a681a0" uuid="c29a9608-de72-4a15-b95f-e89581f38d68" nBytes="2353" chunkPositionInArray="[10,10,0,10]"/>
-      <h4:byteStream offset="299324" md5="a880f8554928c0efc16772b02a9a98cd" uuid="ac6ffc11-b936-4721-92fc-4a9ee87fefaf" nBytes="2326" chunkPositionInArray="[10,10,0,20]"/>
-      <h4:byteStream offset="301650" md5="51fb2a61fd361860c06e8275adcb1aae" uuid="be71113d-40ab-4e33-b64d-493540b9d538" nBytes="2378" chunkPositionInArray="[10,10,0,30]"/>
-      <h4:byteStream offset="304028" md5="98df0b292a1de49533bca0f9a07da040" uuid="ce8591be-676a-4093-aafb-933746cf6ae7" nBytes="2425" chunkPositionInArray="[10,10,10,0]"/>
-      <h4:byteStream offset="306453" md5="b2e749b1dfccf52f85e82f7943f2c6bc" uuid="dc6b70f2-bc2a-418f-aba2-ebd7c7202cc9" nBytes="2354" chunkPositionInArray="[10,10,10,10]"/>
-      <h4:byteStream offset="308807" md5="f7f3f212afa3b80ceb480b9776c76f59" uuid="1a644607-b3d0-4a96-8dd5-d0d574a2cabc" nBytes="2291" chunkPositionInArray="[10,10,10,20]"/>
-      <h4:byteStream offset="311098" md5="5571381e3560a8b828dc1d52272f0130" uuid="d988e969-3d28-4727-8f09-50d95a2e7abc" nBytes="2341" chunkPositionInArray="[10,10,10,30]"/>
-      <h4:byteStream offset="313439" md5="b2ec7a37e73337f2d05a19ff618a76c7" uuid="9ca55e3c-b98f-4584-8269-b9424cc52af6" nBytes="2354" chunkPositionInArray="[10,10,20,0]"/>
-      <h4:byteStream offset="315793" md5="eebf74fe44aeffcb96ef07c82338f338" uuid="d4237d2e-c3ed-421b-808d-2c8d194b5eea" nBytes="2311" chunkPositionInArray="[10,10,20,10]"/>
-      <h4:byteStream offset="318104" md5="94304796a6adf3ce13f1475d44b68cef" uuid="a457bc91-d806-46e1-a720-20f7ded06bd6" nBytes="2302" chunkPositionInArray="[10,10,20,20]"/>
-      <h4:byteStream offset="320406" md5="864a001e85cd75af4beb7bbbc2881cd2" uuid="5e88591d-c7f3-4265-bc8c-8725955e67f8" nBytes="2360" chunkPositionInArray="[10,10,20,30]"/>
-      <h4:byteStream offset="322766" md5="a2859b4a9769e2f1306b6b83be38703d" uuid="23dbc786-7125-42af-9a0d-99e8e83aea97" nBytes="2404" chunkPositionInArray="[10,10,30,0]"/>
-      <h4:byteStream offset="325170" md5="701f321300f2ff08f99233e83cf3454e" uuid="b63453ca-29b3-42ec-9aaf-7ba7bd0bb2e5" nBytes="2355" chunkPositionInArray="[10,10,30,10]"/>
-      <h4:byteStream offset="327525" md5="2c21966556cb9f38cac6756bc73827ee" uuid="f1261f13-8c94-4a2c-8bd6-818cccc14c90" nBytes="2298" chunkPositionInArray="[10,10,30,20]"/>
-      <h4:byteStream offset="329823" md5="818d328a9d872229443858aec25c3118" uuid="348b4226-d60a-4fe7-b7e6-5a55a60f8285" nBytes="2323" chunkPositionInArray="[10,10,30,30]"/>
-      <h4:byteStream offset="332146" md5="530df9e1ce7ac2889f2e78fc6fecb0dd" uuid="16495d70-9b43-4630-a6a7-b605260906bc" nBytes="2341" chunkPositionInArray="[10,20,0,0]"/>
-      <h4:byteStream offset="334487" md5="b7606aa6d65bc14eba618bccc748c282" uuid="0b7e9ce3-5221-4c4a-92ad-fe73b39a93e4" nBytes="2296" chunkPositionInArray="[10,20,0,10]"/>
-      <h4:byteStream offset="336783" md5="0d7d9c546e8b9447c3e0f6eb0a111732" uuid="c450474c-e89c-409c-8082-4eb8a206be12" nBytes="2282" chunkPositionInArray="[10,20,0,20]"/>
-      <h4:byteStream offset="339065" md5="bb4758237aab6504cfc51277e311858b" uuid="6bb28c4c-09a5-4c19-8907-9ae0aa09f6a3" nBytes="2326" chunkPositionInArray="[10,20,0,30]"/>
-      <h4:byteStream offset="341391" md5="36c14d4ce0de285ccc62da78a9e89f0c" uuid="a07ffea8-ad3d-413c-9bbb-1dee61d95eab" nBytes="2410" chunkPositionInArray="[10,20,10,0]"/>
-      <h4:byteStream offset="343801" md5="15d5b98c1681101a32edec07b9df123a" uuid="c18cd288-9916-4197-a7b6-44127f256216" nBytes="2335" chunkPositionInArray="[10,20,10,10]"/>
-      <h4:byteStream offset="346136" md5="35edef749bcbeb9be4333be3b62e9884" uuid="53a3be7c-fc41-4f40-ad6f-1ebdef09a039" nBytes="2267" chunkPositionInArray="[10,20,10,20]"/>
-      <h4:byteStream offset="348403" md5="d483151bea7971a258d2f33d4338e536" uuid="0848589d-bf71-4d86-a6f2-09eda92f5158" nBytes="2312" chunkPositionInArray="[10,20,10,30]"/>
-      <h4:byteStream offset="350715" md5="ef84c53a2d4f1f620fe3d973cb3a3d80" uuid="27a19c3b-a4f2-47c0-a0ae-505cca0db71c" nBytes="2341" chunkPositionInArray="[10,20,20,0]"/>
-      <h4:byteStream offset="353056" md5="e43e320be5be1e956608185def0f21d6" uuid="96b2adbb-965e-4f1e-9229-5181a1ca5e92" nBytes="2272" chunkPositionInArray="[10,20,20,10]"/>
-      <h4:byteStream offset="355328" md5="97c443d7f0dbb6892c3e06fe2db97dc0" uuid="b43f8b3b-01dd-40ed-aee7-2fa82753ef2e" nBytes="2312" chunkPositionInArray="[10,20,20,20]"/>
-      <h4:byteStream offset="357640" md5="53b18bb44034c6d9d402294cb11f6f1e" uuid="796cacd2-74bc-4884-9ded-8bd62854d0b6" nBytes="2354" chunkPositionInArray="[10,20,20,30]"/>
-      <h4:byteStream offset="359994" md5="5e1ade92ee39c88da1c01484c455f7fe" uuid="1f8ceeeb-fc1f-4469-b19f-b28b35330000" nBytes="2374" chunkPositionInArray="[10,20,30,0]"/>
-      <h4:byteStream offset="362368" md5="2f221daabd15db327f4dd34b76a3fc48" uuid="4cc80cf4-57a2-4341-9e8d-fcfba044e0c7" nBytes="2307" chunkPositionInArray="[10,20,30,10]"/>
-      <h4:byteStream offset="364675" md5="d21380470830a8dd75e437e23241b603" uuid="f35438ee-8796-4b4a-b253-b9cddfcc2986" nBytes="2242" chunkPositionInArray="[10,20,30,20]"/>
-      <h4:byteStream offset="366917" md5="6150e139380172d7c35185c4bcf87a20" uuid="4d42cf10-fcf7-4f77-b2d8-6fa12afc38eb" nBytes="2294" chunkPositionInArray="[10,20,30,30]"/>
-      <h4:byteStream offset="369211" md5="4399daef95078fb5b00aff7df4333ef1" uuid="567a23ec-b3ce-40de-b03d-565f2b6dcbeb" nBytes="2332" chunkPositionInArray="[10,30,0,0]"/>
-      <h4:byteStream offset="371543" md5="62c029756b7e10b5da0828945ed86ad5" uuid="49518448-44d4-42bc-974b-acb63de12292" nBytes="2289" chunkPositionInArray="[10,30,0,10]"/>
-      <h4:byteStream offset="373832" md5="9f5a5ab3dbfc6fe2f0c70f60e07f8057" uuid="0024f88d-ba0e-4abb-8785-a356fde4fb35" nBytes="2282" chunkPositionInArray="[10,30,0,20]"/>
-      <h4:byteStream offset="376114" md5="5e24bbd7ebc13993bca35e680faa8bd3" uuid="8eb07079-a391-4ae5-8d13-bb2780fba232" nBytes="2328" chunkPositionInArray="[10,30,0,30]"/>
-      <h4:byteStream offset="378442" md5="67348c3a540dc21fd0fa29472caec5c0" uuid="14e8c618-63ac-4d8f-8345-419ae9cdbd03" nBytes="2382" chunkPositionInArray="[10,30,10,0]"/>
-      <h4:byteStream offset="380824" md5="9bdb742e51ec0f7359b2a5252b71f1cc" uuid="14c87802-0b8d-4bfa-b0ed-03c252f79969" nBytes="2326" chunkPositionInArray="[10,30,10,10]"/>
-      <h4:byteStream offset="383150" md5="37e685968619191436d30c7f693d7045" uuid="c5789b37-c92b-45d3-86c8-38960fdedced" nBytes="2268" chunkPositionInArray="[10,30,10,20]"/>
-      <h4:byteStream offset="385418" md5="63c6f212639410d87ecc68918e3209a8" uuid="1b18a64b-0006-411a-a6c1-0c104a231f49" nBytes="2300" chunkPositionInArray="[10,30,10,30]"/>
-      <h4:byteStream offset="387718" md5="18a73faa1736a6b6feb14d7e14f09ca5" uuid="ed7c8164-93f0-4a92-bc1d-cb58f47b39ba" nBytes="2359" chunkPositionInArray="[10,30,20,0]"/>
-      <h4:byteStream offset="390077" md5="598d1668535235aee1b7821b5787c597" uuid="191f5847-3f56-4083-9d64-fbaf746127fe" nBytes="2307" chunkPositionInArray="[10,30,20,10]"/>
-      <h4:byteStream offset="396040" md5="cf6946448336146accd38bb48f3a0e9d" uuid="97921a4b-7e31-465e-b927-6fb5feb2f75f" nBytes="2324" chunkPositionInArray="[10,30,20,20]"/>
-      <h4:byteStream offset="398364" md5="b4c5c4e7d90a383a72c9701adf40ac32" uuid="adf91d0b-a645-498d-b5bd-dd890856ee86" nBytes="2358" chunkPositionInArray="[10,30,20,30]"/>
-      <h4:byteStream offset="400722" md5="db10f69cfbe959df33258fe4a5a26503" uuid="b8143407-2328-4758-8f24-126b38dedc2a" nBytes="2428" chunkPositionInArray="[10,30,30,0]"/>
-      <h4:byteStream offset="403150" md5="31cc2d9fbffe487a7f1398043f9b7226" uuid="80b08704-df6c-4f76-b586-3edfcd9f9693" nBytes="2339" chunkPositionInArray="[10,30,30,10]"/>
-      <h4:byteStream offset="405489" md5="762219acafe921365694bbff5575da40" uuid="dec8c06b-6e4e-459c-870e-09d9b5d5444b" nBytes="2268" chunkPositionInArray="[10,30,30,20]"/>
-      <h4:byteStream offset="407757" md5="725d51f3e83307f7e53a48bc1b2c5d6f" uuid="00d1ae7e-50cc-4768-9e13-e8732d9cff6b" nBytes="2305" chunkPositionInArray="[10,30,30,30]"/>
-      <h4:byteStream offset="410062" md5="b4d0f1293182506a4da11ab293905dc2" uuid="f043a030-b8fe-4e81-b5ca-ab3cccf0aafd" nBytes="1616" chunkPositionInArray="[20,0,0,0]"/>
-      <h4:byteStream offset="411678" md5="d199557f5755e39a7f822b7e2171a5f8" uuid="fce9352c-fb3b-48a2-954d-fcf238376806" nBytes="1561" chunkPositionInArray="[20,0,0,10]"/>
-      <h4:byteStream offset="413239" md5="63933fd96d3ac9eaf9e7d2b0d723341c" uuid="d815c92e-0dc0-4d21-af52-76bb62ca88c7" nBytes="1726" chunkPositionInArray="[20,0,0,20]"/>
-      <h4:byteStream offset="414965" md5="159d549aa49544f86fdf8d59920e8e7f" uuid="6aa7bfdf-6ca2-43f3-b6ae-544c2e831f8c" nBytes="1751" chunkPositionInArray="[20,0,0,30]"/>
-      <h4:byteStream offset="416716" md5="75d863329123f5cf7bd74f58c5edff76" uuid="52bb5219-5a77-4e4e-a17d-455d3ef809cf" nBytes="1789" chunkPositionInArray="[20,0,10,0]"/>
-      <h4:byteStream offset="418505" md5="4216a3a460ea5af3fb713f1a77b470dc" uuid="f9996679-9ae2-4e6a-aac7-1be4c0546f67" nBytes="1722" chunkPositionInArray="[20,0,10,10]"/>
-      <h4:byteStream offset="420227" md5="767a42f96cc406cf7915262abd904bcd" uuid="71526a89-579b-4bf2-91bd-208972aca490" nBytes="1617" chunkPositionInArray="[20,0,10,20]"/>
-      <h4:byteStream offset="421844" md5="bd26919fcce52cc212f7591d09fda802" uuid="a71c5ae8-5431-4d6e-ac55-ec8833047336" nBytes="1573" chunkPositionInArray="[20,0,10,30]"/>
-      <h4:byteStream offset="423417" md5="aeeea456e890d87d7e938eb652af2386" uuid="680282ce-3b72-4128-9009-abc99d254e1b" nBytes="1621" chunkPositionInArray="[20,0,20,0]"/>
-      <h4:byteStream offset="425038" md5="5fb02587cd7fb3f3322d3080f3c5966d" uuid="8b6f2583-0a03-44d7-bbfd-6ee7a9875c56" nBytes="1563" chunkPositionInArray="[20,0,20,10]"/>
-      <h4:byteStream offset="426601" md5="e951198a44da81c8d5f967b760850737" uuid="febf93d3-12d1-4c39-978b-75410cc3df61" nBytes="1727" chunkPositionInArray="[20,0,20,20]"/>
-      <h4:byteStream offset="428328" md5="058ba557d7f2185bf751cc5928d21f3a" uuid="d71148a1-f1da-46ff-85a5-b06eac3d6960" nBytes="1756" chunkPositionInArray="[20,0,20,30]"/>
-      <h4:byteStream offset="430084" md5="a531955915999c57130b08fcfc17fe4c" uuid="ab522b18-3eb2-4cba-888b-7a2ab7984c32" nBytes="1787" chunkPositionInArray="[20,0,30,0]"/>
-      <h4:byteStream offset="431871" md5="86f851a2352be2c74035a8655e743ca9" uuid="096a678c-d0b7-4589-ba29-83fbe311235e" nBytes="1723" chunkPositionInArray="[20,0,30,10]"/>
-      <h4:byteStream offset="433594" md5="002d555fa47e1b7a46760ad23b1b23d6" uuid="ea509df7-38a3-4bd9-8ab7-8cab22164485" nBytes="1618" chunkPositionInArray="[20,0,30,20]"/>
-      <h4:byteStream offset="435212" md5="1b969fbbe10e1438925f935fe9521819" uuid="0b0bae40-d2c6-46df-a55c-355b4ff9a41c" nBytes="1575" chunkPositionInArray="[20,0,30,30]"/>
-      <h4:byteStream offset="436787" md5="8201f77d86a136418324e7626aec40b4" uuid="533d1551-4448-41fb-b50f-ff0a32487bcf" nBytes="1614" chunkPositionInArray="[20,10,0,0]"/>
-      <h4:byteStream offset="438401" md5="e1aa76be83212a9747e846b2bab076b1" uuid="897df76a-8b24-4f69-9c77-d6d7531525d8" nBytes="1562" chunkPositionInArray="[20,10,0,10]"/>
-      <h4:byteStream offset="439963" md5="d86cb652f5f968a7a6134d10e60ece80" uuid="5427ab3c-7599-4b3b-847a-d06abde18b2b" nBytes="1725" chunkPositionInArray="[20,10,0,20]"/>
-      <h4:byteStream offset="441688" md5="507dcecb21f41d6d73a28ea64059baf4" uuid="aecd766b-5cf4-4e0f-8ad3-cf26dfbf17f8" nBytes="1752" chunkPositionInArray="[20,10,0,30]"/>
-      <h4:byteStream offset="443440" md5="8718b8d28b28b7aaa8ddf58add04fe64" uuid="e856ff96-9354-492a-b045-1e85b8bcae23" nBytes="1791" chunkPositionInArray="[20,10,10,0]"/>
-      <h4:byteStream offset="445231" md5="9433e7ce5ac60124e82866badd286f35" uuid="ca68b6ab-bfed-4f95-93e5-5eff25c7f338" nBytes="1725" chunkPositionInArray="[20,10,10,10]"/>
-      <h4:byteStream offset="446956" md5="8da7185d2b00389230284e37cce0e994" uuid="4a68df81-83bb-4d21-b284-d89b31311463" nBytes="1625" chunkPositionInArray="[20,10,10,20]"/>
-      <h4:byteStream offset="448581" md5="6b60dc5d1688c09cfb9269cc0b6f5e14" uuid="4fc7f674-de64-458b-b18c-f3d4e446c96b" nBytes="1573" chunkPositionInArray="[20,10,10,30]"/>
-      <h4:byteStream offset="450154" md5="93837b14e890495a2c94a62dddf2be56" uuid="19c70621-3616-4c7c-a6b6-03145b91d61e" nBytes="1617" chunkPositionInArray="[20,10,20,0]"/>
-      <h4:byteStream offset="451771" md5="a1ddfdabc536cc41dd171ade7baf3dbd" uuid="07e44bdf-2149-4e13-ae6f-1e5681e6c5fa" nBytes="1559" chunkPositionInArray="[20,10,20,10]"/>
-      <h4:byteStream offset="453330" md5="5ecdfc41782e46c71f1476a1c6e2a08f" uuid="5623e82a-8ce9-49b2-8a0a-59754c697481" nBytes="1723" chunkPositionInArray="[20,10,20,20]"/>
-      <h4:byteStream offset="455053" md5="a67fd9720ddd62727a5261728428337e" uuid="6a1ec5c4-8daf-4716-b7f2-ba972b1c2313" nBytes="1750" chunkPositionInArray="[20,10,20,30]"/>
-      <h4:byteStream offset="456803" md5="47d3d01f57fabaf85b2175714992622d" uuid="901de599-40ad-4c1b-9c92-fdb8205152fa" nBytes="1794" chunkPositionInArray="[20,10,30,0]"/>
-      <h4:byteStream offset="458597" md5="da9dd5f81e35e21ba3b1d7a0b2e83853" uuid="b915d134-b029-41c0-b5be-601901de3517" nBytes="1725" chunkPositionInArray="[20,10,30,10]"/>
-      <h4:byteStream offset="460322" md5="d3936d2486c7ff37b6cf009232c73682" uuid="58a2a5db-9e3e-4746-beeb-9470939b28ce" nBytes="1623" chunkPositionInArray="[20,10,30,20]"/>
-      <h4:byteStream offset="461945" md5="168c1dc332d513fbab240153ee7372c2" uuid="ddce62b2-c283-41eb-a3bb-4119eeb22045" nBytes="1576" chunkPositionInArray="[20,10,30,30]"/>
-      <h4:byteStream offset="463521" md5="bd4d30f198e6b39527239dfb105d7fd4" uuid="08bfacb5-3b3c-4612-9f9b-21b2543020c7" nBytes="1618" chunkPositionInArray="[20,20,0,0]"/>
-      <h4:byteStream offset="465139" md5="4ac5efbd19fc0ff4947e4a50ddcfb9dc" uuid="dbf1173c-6818-41da-8b76-ab4c2d20bafa" nBytes="1561" chunkPositionInArray="[20,20,0,10]"/>
-      <h4:byteStream offset="466700" md5="d1088c515dbca5ad7f2b3aaad5bfc1a5" uuid="6d16449c-1de9-4825-bdcb-cf5364073c42" nBytes="1727" chunkPositionInArray="[20,20,0,20]"/>
-      <h4:byteStream offset="468427" md5="089f00cfe6d8c741f44434673356e9ca" uuid="5f25cdcc-f501-449d-9a26-2333a3118783" nBytes="1753" chunkPositionInArray="[20,20,0,30]"/>
-      <h4:byteStream offset="470180" md5="2139f025c08a2b2f1010fd8af99ec680" uuid="ccdd7434-6d22-409e-90e3-2725b15588e1" nBytes="1790" chunkPositionInArray="[20,20,10,0]"/>
-      <h4:byteStream offset="471970" md5="7bfae071795e6260145e1388d41b5401" uuid="14d68634-5327-4c09-b34c-062eab106777" nBytes="1718" chunkPositionInArray="[20,20,10,10]"/>
-      <h4:byteStream offset="473688" md5="b6bd52c7a11876454efa4bfc6f647999" uuid="8b7e432e-4b4b-4a6d-acb5-4fc646d9701b" nBytes="1616" chunkPositionInArray="[20,20,10,20]"/>
-      <h4:byteStream offset="475304" md5="92ec3c6f92d14764dec5391dc7efb95d" uuid="aa3bee92-c3b0-4033-9384-809bd9a15a87" nBytes="1569" chunkPositionInArray="[20,20,10,30]"/>
-      <h4:byteStream offset="476873" md5="ba971f98a3d67e22aa1f11e5eaf85631" uuid="04b45894-61c1-4906-bf27-8b41aa91b2d4" nBytes="1619" chunkPositionInArray="[20,20,20,0]"/>
-      <h4:byteStream offset="478492" md5="dd3cc740b02bb8838dd0965ef0e9725a" uuid="a30eeae3-d97f-4475-9629-1cd9964cc540" nBytes="1561" chunkPositionInArray="[20,20,20,10]"/>
-      <h4:byteStream offset="480053" md5="be1f469f819fc65eafecbb3c700cbec3" uuid="cf00bc4f-9d9d-40bf-b998-4a760c6b8805" nBytes="1728" chunkPositionInArray="[20,20,20,20]"/>
-      <h4:byteStream offset="481781" md5="e48e62dc0a111de5b71cd8b7bfac5e08" uuid="52582ec8-c644-44fb-ae62-0c456e54386a" nBytes="1756" chunkPositionInArray="[20,20,20,30]"/>
-      <h4:byteStream offset="483537" md5="98a3ad8956b90fe54a75abba8e5b6802" uuid="12545b6e-0907-45cb-95ed-aed92166dde5" nBytes="1787" chunkPositionInArray="[20,20,30,0]"/>
-      <h4:byteStream offset="485324" md5="359056829b420c5a38d30ea1871972ce" uuid="ed8955e9-7966-4fb7-996f-cb29d998c935" nBytes="1720" chunkPositionInArray="[20,20,30,10]"/>
-      <h4:byteStream offset="487044" md5="6287fdade5f8173648cabc326b8c2ef3" uuid="e55cd326-85e9-45fb-8291-5152c572f565" nBytes="1617" chunkPositionInArray="[20,20,30,20]"/>
-      <h4:byteStream offset="488661" md5="8aba660ed6dc075d0d970a9f545dc8d3" uuid="5fd2d291-9b6a-4b47-8c70-e9b04de47fce" nBytes="1571" chunkPositionInArray="[20,20,30,30]"/>
-      <h4:byteStream offset="490232" md5="132678b0da494ab1e6651c80acfc370e" uuid="03461480-f221-4354-ab91-227411e5f52b" nBytes="1616" chunkPositionInArray="[20,30,0,0]"/>
-      <h4:byteStream offset="491848" md5="98236ae7d52429db7a3f54c29a1f1b77" uuid="65302050-8a89-489e-b9c7-1dab273a1791" nBytes="1558" chunkPositionInArray="[20,30,0,10]"/>
-      <h4:byteStream offset="493406" md5="e6141fe5e74b24961fd4f537d8254fd5" uuid="e8dfd501-f69d-425d-afe4-52a62380a17d" nBytes="1723" chunkPositionInArray="[20,30,0,20]"/>
-      <h4:byteStream offset="498785" md5="a4f47f18ba63e423126c079abf246e44" uuid="21973597-9d53-494c-b3b1-cfc2e59f98de" nBytes="1753" chunkPositionInArray="[20,30,0,30]"/>
-      <h4:byteStream offset="500538" md5="4fe03bf0abda460bf177634e5e3a691e" uuid="9f73f60a-7f3d-4587-9d2a-960c68b95388" nBytes="1791" chunkPositionInArray="[20,30,10,0]"/>
-      <h4:byteStream offset="502329" md5="e1c2c44682715ce6bbee954508af808a" uuid="bc46f2e5-4337-4826-ad14-eb2a43cf2c1a" nBytes="1725" chunkPositionInArray="[20,30,10,10]"/>
-      <h4:byteStream offset="504054" md5="82a36bf595ec15f25f4c0e436cefa26d" uuid="b494f867-1578-4753-9a8f-cf74eca76df4" nBytes="1621" chunkPositionInArray="[20,30,10,20]"/>
-      <h4:byteStream offset="505675" md5="fc7cdf113cfdb2af263afa71a0510c32" uuid="280758d5-cdfa-47d9-a092-e3443178df40" nBytes="1573" chunkPositionInArray="[20,30,10,30]"/>
-      <h4:byteStream offset="507248" md5="e9b7370d632abad5ad670588e0510097" uuid="3836c41a-10df-4351-a1a6-3f8a4ea33572" nBytes="1615" chunkPositionInArray="[20,30,20,0]"/>
-      <h4:byteStream offset="508863" md5="52384e8eeea203713d987ce30eb6341f" uuid="0af7effa-b530-4aa1-bed0-86855b791031" nBytes="1560" chunkPositionInArray="[20,30,20,10]"/>
-      <h4:byteStream offset="510423" md5="3fa57b8c407aae7ed4fe2cf20b1d286f" uuid="4acdb64a-4987-4161-8165-0f842d4d888d" nBytes="1725" chunkPositionInArray="[20,30,20,20]"/>
-      <h4:byteStream offset="512148" md5="203126f2b7c765daf26433246fcc0718" uuid="120ef1fb-4867-433d-8985-82d4dd81b99e" nBytes="1748" chunkPositionInArray="[20,30,20,30]"/>
-      <h4:byteStream offset="513896" md5="5b815a045b17d19d4cea04518ef3d105" uuid="c0a80125-36ee-4ed1-8914-f8165d3a3fca" nBytes="1789" chunkPositionInArray="[20,30,30,0]"/>
-      <h4:byteStream offset="515685" md5="43ad480ad22ae8149f86a65698a9dd73" uuid="11c6c17d-35b4-41d0-a085-5aed9fcd378a" nBytes="1725" chunkPositionInArray="[20,30,30,10]"/>
-      <h4:byteStream offset="517410" md5="5380b66621f65ce1a23abcd44d2662e3" uuid="d16d9bda-eb08-40c6-abd5-2bb6a8389e12" nBytes="1626" chunkPositionInArray="[20,30,30,20]"/>
-      <h4:byteStream offset="519036" md5="a6c5faeeeb8e4dddea209e708fd19d13" uuid="10bf036c-9deb-4b79-a93d-351d64dd2321" nBytes="1574" chunkPositionInArray="[20,30,30,30]"/>
-      <h4:byteStream offset="520610" md5="fba64281ae4e974a120b8b7084c3085f" uuid="9dffb100-f897-4ed0-910d-0cf338a3c5a8" nBytes="1678" chunkPositionInArray="[30,0,0,0]"/>
-      <h4:byteStream offset="522288" md5="edb291c6dc925dea632d5bde12f355aa" uuid="c5ab13eb-58c5-4f09-82ea-425f19af2d0e" nBytes="1689" chunkPositionInArray="[30,0,0,10]"/>
-      <h4:byteStream offset="523977" md5="e33323608018a335aba0a25336c138e7" uuid="a68d4b78-be05-463e-907d-8cccdf86b9fe" nBytes="1776" chunkPositionInArray="[30,0,0,20]"/>
-      <h4:byteStream offset="525753" md5="7c55774e09f3503cd6fa76255828bef9" uuid="5fd6d1c8-88ed-48a3-9353-f65fa86c6dc0" nBytes="1745" chunkPositionInArray="[30,0,0,30]"/>
-      <h4:byteStream offset="527498" md5="14e1f82066a6e0b3239baae0e054d43e" uuid="1e79a867-3a44-4efd-80d9-9f4fe73074e2" nBytes="1883" chunkPositionInArray="[30,0,10,0]"/>
-      <h4:byteStream offset="529381" md5="10fa8239901ba90f484085b9c85e1650" uuid="adf4a50b-0b5f-4ad6-aa02-49565c645b88" nBytes="1770" chunkPositionInArray="[30,0,10,10]"/>
-      <h4:byteStream offset="531151" md5="156eccf999b0b8b357b3c5ed49637040" uuid="dd445c52-ef01-4d6e-bf51-3b7ea47dd09d" nBytes="1721" chunkPositionInArray="[30,0,10,20]"/>
-      <h4:byteStream offset="532872" md5="5be720c765e791a5fbbd4a228ec23692" uuid="c1323ad0-4f21-46b6-b9c2-855fd8881736" nBytes="1637" chunkPositionInArray="[30,0,10,30]"/>
-      <h4:byteStream offset="534509" md5="b276a761a6277f1d5d33c1150c837553" uuid="85e5e0fd-b3a5-4d10-82cc-cdfad2965bb5" nBytes="1799" chunkPositionInArray="[30,0,20,0]"/>
-      <h4:byteStream offset="536308" md5="5a2f9713d7a402b8b91aa5c6fc1e423c" uuid="2bcfd17b-9e78-49ef-841d-49c0f96f12d1" nBytes="1674" chunkPositionInArray="[30,0,20,10]"/>
-      <h4:byteStream offset="537982" md5="04af370dd391eb382fe0c700624f00e8" uuid="50e0a67d-b498-40f3-927f-eabc24b8e188" nBytes="1743" chunkPositionInArray="[30,0,20,20]"/>
-      <h4:byteStream offset="539725" md5="6bea830aba4195c85db8449966050d89" uuid="b2a39594-1082-44b1-87c4-3756ff159b07" nBytes="1789" chunkPositionInArray="[30,0,20,30]"/>
-      <h4:byteStream offset="541514" md5="2d1790eb0261c71a81b80ce8ceedb378" uuid="61c22f19-176e-4889-9828-344a29d1a731" nBytes="1785" chunkPositionInArray="[30,0,30,0]"/>
-      <h4:byteStream offset="543299" md5="b3d5a6b89be8615622e9649b1a93326a" uuid="f56ade34-5a04-498f-a1c7-8e73f05b01fa" nBytes="1897" chunkPositionInArray="[30,0,30,10]"/>
-      <h4:byteStream offset="545196" md5="c45fafb0bf007b886ef8e45676ddf351" uuid="375dbe81-a21c-4dfb-89cf-9cb39c43488b" nBytes="1667" chunkPositionInArray="[30,0,30,20]"/>
-      <h4:byteStream offset="546863" md5="5dff25756a389e6d7f4a076ba0e838df" uuid="468ee7b0-0445-4d86-89e3-c8e0e0ce6b39" nBytes="1635" chunkPositionInArray="[30,0,30,30]"/>
-      <h4:byteStream offset="548498" md5="b7bedee5c9e61d59c0e93d06c68b80a0" uuid="62b905aa-35b9-49d3-bf94-1292320ca5aa" nBytes="1688" chunkPositionInArray="[30,10,0,0]"/>
-      <h4:byteStream offset="550186" md5="51f8eacf6fcf710ece24e92687faeef2" uuid="08b342c3-c8fb-47e5-866c-2a7df743d41b" nBytes="1698" chunkPositionInArray="[30,10,0,10]"/>
-      <h4:byteStream offset="551884" md5="af64d18dcc12b18e6fd462147743c621" uuid="0c6978bc-9126-472e-8a4d-8e7983117188" nBytes="1786" chunkPositionInArray="[30,10,0,20]"/>
-      <h4:byteStream offset="553670" md5="534b2f9f3d8b64993ed628c9ecd22536" uuid="1bcaacd2-f14e-40bb-9bc8-b752daf30596" nBytes="1753" chunkPositionInArray="[30,10,0,30]"/>
-      <h4:byteStream offset="555423" md5="e4822bb3dc8c27666e9c9fe980313311" uuid="f54559b2-b5a0-45c4-8f3c-9130a0f967f5" nBytes="1889" chunkPositionInArray="[30,10,10,0]"/>
-      <h4:byteStream offset="557312" md5="da5809b65a40b4d4c29fa2dfbab0e0a7" uuid="db593dcf-48c4-4a7c-bcc8-0d688603f790" nBytes="1760" chunkPositionInArray="[30,10,10,10]"/>
-      <h4:byteStream offset="559072" md5="9f60e8fabb4b864fe09fd3657f568dcc" uuid="ec526e22-8c1f-41ae-968d-fb8c65443afa" nBytes="1714" chunkPositionInArray="[30,10,10,20]"/>
-      <h4:byteStream offset="560786" md5="36da4e318f5acf9c2ce5c88982270f61" uuid="80b934c5-b326-4590-b76d-ea5146525e40" nBytes="1644" chunkPositionInArray="[30,10,10,30]"/>
-      <h4:byteStream offset="562430" md5="72f30be18aa2ee4a1b6b20b39418bf18" uuid="e7fc46fa-5a5a-4e77-8354-da8cd761dbec" nBytes="1800" chunkPositionInArray="[30,10,20,0]"/>
-      <h4:byteStream offset="564230" md5="b4efdef4d840b0e5087cf09fb9bbc58b" uuid="8a711290-de00-4e0f-aebe-a0d445826b6f" nBytes="1669" chunkPositionInArray="[30,10,20,10]"/>
-      <h4:byteStream offset="565899" md5="7ecb101e9fbaaaa74211822cd5f7a7c2" uuid="8c992f75-7926-4a49-ad32-27a35701f316" nBytes="1725" chunkPositionInArray="[30,10,20,20]"/>
-      <h4:byteStream offset="567624" md5="1920bd506f4073cdaa55deaeec806533" uuid="e8d3901f-bae3-46eb-a76c-83fa8714e67b" nBytes="1769" chunkPositionInArray="[30,10,20,30]"/>
-      <h4:byteStream offset="569393" md5="253dfa45ce3c4b61c66d9d665fcd205e" uuid="369f9e6b-45e1-4307-bf93-51af41cb7f96" nBytes="1781" chunkPositionInArray="[30,10,30,0]"/>
-      <h4:byteStream offset="571174" md5="e7ceb484b385a019852676508866dec2" uuid="288fefae-c120-44ba-985c-4265eeecc639" nBytes="1891" chunkPositionInArray="[30,10,30,10]"/>
-      <h4:byteStream offset="573065" md5="a7c93439f454a04def53c7c057d76933" uuid="b0e701e0-39cf-445e-9e06-966a18619128" nBytes="1665" chunkPositionInArray="[30,10,30,20]"/>
-      <h4:byteStream offset="574730" md5="9bc954c51d82f35d2a952c5b4f3ac98a" uuid="36e49a6d-dc2c-4948-82f3-558f69cbcf75" nBytes="1638" chunkPositionInArray="[30,10,30,30]"/>
-      <h4:byteStream offset="576368" md5="e0cb9546d8d4be4e255c097d2ffede7b" uuid="b8389823-7539-4a3c-aed5-e3caa294380f" nBytes="1679" chunkPositionInArray="[30,20,0,0]"/>
-      <h4:byteStream offset="578047" md5="e9f7b24bd241c87a78e37a888ed33551" uuid="7ff17579-46b0-446f-a656-a93ac87ac96c" nBytes="1701" chunkPositionInArray="[30,20,0,10]"/>
-      <h4:byteStream offset="579748" md5="3169a8db59f8815e1b3015f7e7258f5c" uuid="6e5a8314-93b6-4747-8269-8362ceef9f34" nBytes="1780" chunkPositionInArray="[30,20,0,20]"/>
-      <h4:byteStream offset="581528" md5="98e79aa5a447b2045cc7f7bb301e5079" uuid="a8efc960-605a-46bd-a250-599ca65f8dfe" nBytes="1731" chunkPositionInArray="[30,20,0,30]"/>
-      <h4:byteStream offset="583259" md5="6d86225e1704fbd06aa7a02130f70e8e" uuid="b6cc33ca-ab3e-4c3f-8f49-6f92a556976f" nBytes="1900" chunkPositionInArray="[30,20,10,0]"/>
-      <h4:byteStream offset="585159" md5="e48952553e40c261188406321a1c651f" uuid="2e7edf22-2296-4b66-a232-a317632a280d" nBytes="1770" chunkPositionInArray="[30,20,10,10]"/>
-      <h4:byteStream offset="588977" md5="d60b4122516d12401436ba9cfcb113ad" uuid="a0d154ce-a6a4-4266-864b-5fa19012f15d" nBytes="1732" chunkPositionInArray="[30,20,10,20]"/>
-      <h4:byteStream offset="590709" md5="1d899eed29bde53b51df0a864f54b9a1" uuid="7d258603-e499-422d-b71c-d94fbf001a40" nBytes="1648" chunkPositionInArray="[30,20,10,30]"/>
-      <h4:byteStream offset="592357" md5="da587074ccee8c607a34566ac118d057" uuid="c827090e-50f9-46b0-b003-fe8c96dd68e2" nBytes="1816" chunkPositionInArray="[30,20,20,0]"/>
-      <h4:byteStream offset="594173" md5="449e250eacdb1bd03f6dff58c837e540" uuid="4f7de168-e568-404b-bbae-9b117b7f734a" nBytes="1682" chunkPositionInArray="[30,20,20,10]"/>
-      <h4:byteStream offset="595855" md5="69e290e0e59a0679a9ae05ae3c8193f3" uuid="ed1591bb-97cc-41a5-bd4e-13ff1525155b" nBytes="1729" chunkPositionInArray="[30,20,20,20]"/>
-      <h4:byteStream offset="597584" md5="6bc18391308c16b99eb43207f40de1b5" uuid="614a5332-88be-4e8a-9e75-daf6cf4e8ce2" nBytes="1768" chunkPositionInArray="[30,20,20,30]"/>
-      <h4:byteStream offset="603008" md5="1f7215c21d2b9f0afd76d00d98c6a379" uuid="4fb975e3-0208-43ed-908c-571f31f7d5b7" nBytes="1768" chunkPositionInArray="[30,20,30,0]"/>
-      <h4:byteStream offset="604776" md5="e72d55bdefd2139a7067870ec944847f" uuid="de187ee7-f6f1-4cc7-84b0-34a06d72ba96" nBytes="1882" chunkPositionInArray="[30,20,30,10]"/>
-      <h4:byteStream offset="606658" md5="00514a3f07e9e83ecb4b6f164febf99c" uuid="d21b94eb-d930-43be-8dfe-89b6ade0784e" nBytes="1657" chunkPositionInArray="[30,20,30,20]"/>
-      <h4:byteStream offset="608315" md5="0e982d7b56029bf33971cbd81b0dacfa" uuid="e6614723-a2ec-42f2-854e-c242169d468c" nBytes="1629" chunkPositionInArray="[30,20,30,30]"/>
-      <h4:byteStream offset="609944" md5="354b569186bbe3f008f0b22b73cffc70" uuid="e706800c-b55f-4140-b867-a651950e0092" nBytes="1660" chunkPositionInArray="[30,30,0,0]"/>
-      <h4:byteStream offset="611604" md5="d46dd39ebb198a56212e069558473cdc" uuid="8a5337ba-5dd4-4524-afc1-3fd143634e73" nBytes="1689" chunkPositionInArray="[30,30,0,10]"/>
-      <h4:byteStream offset="613293" md5="d4eeb14bad2ff00ca7cad058a91d47a9" uuid="00f1b876-1730-4795-9781-65cc2a0680d7" nBytes="1744" chunkPositionInArray="[30,30,0,20]"/>
-      <h4:byteStream offset="615037" md5="457dfcdd135e9412d849f564b5856914" uuid="ec1f597d-1bf9-4419-95d5-0a6dfd9cd4c6" nBytes="1711" chunkPositionInArray="[30,30,0,30]"/>
-      <h4:byteStream offset="616748" md5="0a605b095fffcc4009e543268a1ec572" uuid="8067bf8f-d1e2-4ad1-b3ed-329acf740c9e" nBytes="1873" chunkPositionInArray="[30,30,10,0]"/>
-      <h4:byteStream offset="618621" md5="5fe4e0d06623c2c72ec0b1c753f3f222" uuid="51fab4ad-a127-4c8b-9ef9-eb2a000f72a4" nBytes="1718" chunkPositionInArray="[30,30,10,10]"/>
-      <h4:byteStream offset="620339" md5="d2c9448052cd49bc9efb7dcbcb6448ff" uuid="5ac05825-9867-4616-ad17-af1801b9048b" nBytes="1712" chunkPositionInArray="[30,30,10,20]"/>
-      <h4:byteStream offset="622051" md5="43abe0ae7be9804b7bbcb818158f4f4a" uuid="abe65e3f-4db9-4f01-8bdd-ac77e04b64e8" nBytes="1639" chunkPositionInArray="[30,30,10,30]"/>
-      <h4:byteStream offset="623690" md5="dc0712ef3392bf63dda2a507c343d40d" uuid="d3698a9e-604e-4000-9c18-bbe613a36894" nBytes="1832" chunkPositionInArray="[30,30,20,0]"/>
-      <h4:byteStream offset="625522" md5="70499d509d5b9900e328efef1e58a26f" uuid="9dd2fba6-6b21-4534-9946-7717eb4c1b5c" nBytes="1672" chunkPositionInArray="[30,30,20,10]"/>
-      <h4:byteStream offset="627194" md5="2e9b22273716512d859fbafb3c38a780" uuid="8e1f214c-4f51-45aa-8ef7-6a5b93d3bca0" nBytes="1710" chunkPositionInArray="[30,30,20,20]"/>
-      <h4:byteStream offset="628904" md5="459888b5e63d31078e65237852f55522" uuid="29161fcd-c9d4-4d57-9b0e-4eb93fee9571" nBytes="1743" chunkPositionInArray="[30,30,20,30]"/>
-      <h4:byteStream offset="630647" md5="61bacc2fc65e432d5613cefc05df8b28" uuid="6d0ce989-e2dd-4b47-ad19-e70a47a9e156" nBytes="1713" chunkPositionInArray="[30,30,30,0]"/>
-      <h4:byteStream offset="632360" md5="6a798763d818a307592c16deece3d17f" uuid="9efba5e8-8a8e-48b1-a1bf-fec67f5bfadc" nBytes="1860" chunkPositionInArray="[30,30,30,10]"/>
-      <h4:byteStream offset="634220" md5="d37a0e2fb56a22801c39b451a991dc1f" uuid="023c3d3e-8d10-494b-827d-578db7e3490e" nBytes="1622" chunkPositionInArray="[30,30,30,20]"/>
-      <h4:byteStream offset="635842" md5="64dc4133a199970f545e442b13dc1166" uuid="d5c2273c-9ac3-4750-b205-62f2e050bd5b" nBytes="1588" chunkPositionInArray="[30,30,30,30]"/>
-    </h4:chunks>
+    <dmrpp:chunks deflate_level="6" compressionType="shuffle deflate">
+      <dmrpp:chunkDimensionSizes>10 10 10 10</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk offset="4728"   nBytes="3860" chunkPositionInArray="[0,0,0,0]"/>
+      <dmrpp:chunk offset="8588"   nBytes="3903" chunkPositionInArray="[0,0,0,10]"/>
+      <dmrpp:chunk offset="12491"   nBytes="3789" chunkPositionInArray="[0,0,0,20]"/>
+      <dmrpp:chunk offset="16280"   nBytes="3578" chunkPositionInArray="[0,0,0,30]"/>
+      <dmrpp:chunk offset="19858"   nBytes="3837" chunkPositionInArray="[0,0,10,0]"/>
+      <dmrpp:chunk offset="23695"   nBytes="3875" chunkPositionInArray="[0,0,10,10]"/>
+      <dmrpp:chunk offset="27570"   nBytes="3765" chunkPositionInArray="[0,0,10,20]"/>
+      <dmrpp:chunk offset="31335"   nBytes="3554" chunkPositionInArray="[0,0,10,30]"/>
+      <dmrpp:chunk offset="34889"   nBytes="3870" chunkPositionInArray="[0,0,20,0]"/>
+      <dmrpp:chunk offset="38759"   nBytes="3908" chunkPositionInArray="[0,0,20,10]"/>
+      <dmrpp:chunk offset="42667"   nBytes="3782" chunkPositionInArray="[0,0,20,20]"/>
+      <dmrpp:chunk offset="46449"   nBytes="3573" chunkPositionInArray="[0,0,20,30]"/>
+      <dmrpp:chunk offset="50022"   nBytes="3860" chunkPositionInArray="[0,0,30,0]"/>
+      <dmrpp:chunk offset="53882"   nBytes="3900" chunkPositionInArray="[0,0,30,10]"/>
+      <dmrpp:chunk offset="57782"   nBytes="3740" chunkPositionInArray="[0,0,30,20]"/>
+      <dmrpp:chunk offset="61522"   nBytes="3524" chunkPositionInArray="[0,0,30,30]"/>
+      <dmrpp:chunk offset="65046"   nBytes="3893" chunkPositionInArray="[0,10,0,0]"/>
+      <dmrpp:chunk offset="68939"   nBytes="3975" chunkPositionInArray="[0,10,0,10]"/>
+      <dmrpp:chunk offset="72914"   nBytes="3865" chunkPositionInArray="[0,10,0,20]"/>
+      <dmrpp:chunk offset="76779"   nBytes="3665" chunkPositionInArray="[0,10,0,30]"/>
+      <dmrpp:chunk offset="80444"   nBytes="3795" chunkPositionInArray="[0,10,10,0]"/>
+      <dmrpp:chunk offset="84239"   nBytes="3857" chunkPositionInArray="[0,10,10,10]"/>
+      <dmrpp:chunk offset="88096"   nBytes="3724" chunkPositionInArray="[0,10,10,20]"/>
+      <dmrpp:chunk offset="91820"   nBytes="3528" chunkPositionInArray="[0,10,10,30]"/>
+      <dmrpp:chunk offset="95348"   nBytes="3803" chunkPositionInArray="[0,10,20,0]"/>
+      <dmrpp:chunk offset="99151"   nBytes="3882" chunkPositionInArray="[0,10,20,10]"/>
+      <dmrpp:chunk offset="103033"   nBytes="3742" chunkPositionInArray="[0,10,20,20]"/>
+      <dmrpp:chunk offset="106775"   nBytes="3547" chunkPositionInArray="[0,10,20,30]"/>
+      <dmrpp:chunk offset="110322"   nBytes="3824" chunkPositionInArray="[0,10,30,0]"/>
+      <dmrpp:chunk offset="114146"   nBytes="3900" chunkPositionInArray="[0,10,30,10]"/>
+      <dmrpp:chunk offset="118046"   nBytes="3751" chunkPositionInArray="[0,10,30,20]"/>
+      <dmrpp:chunk offset="121797"   nBytes="3538" chunkPositionInArray="[0,10,30,30]"/>
+      <dmrpp:chunk offset="125335"   nBytes="4031" chunkPositionInArray="[0,20,0,0]"/>
+      <dmrpp:chunk offset="129366"   nBytes="4117" chunkPositionInArray="[0,20,0,10]"/>
+      <dmrpp:chunk offset="133483"   nBytes="3999" chunkPositionInArray="[0,20,0,20]"/>
+      <dmrpp:chunk offset="137482"   nBytes="3806" chunkPositionInArray="[0,20,0,30]"/>
+      <dmrpp:chunk offset="141288"   nBytes="4050" chunkPositionInArray="[0,20,10,0]"/>
+      <dmrpp:chunk offset="145338"   nBytes="4125" chunkPositionInArray="[0,20,10,10]"/>
+      <dmrpp:chunk offset="149463"   nBytes="3989" chunkPositionInArray="[0,20,10,20]"/>
+      <dmrpp:chunk offset="153452"   nBytes="3793" chunkPositionInArray="[0,20,10,30]"/>
+      <dmrpp:chunk offset="157245"   nBytes="3919" chunkPositionInArray="[0,20,20,0]"/>
+      <dmrpp:chunk offset="161164"   nBytes="4010" chunkPositionInArray="[0,20,20,10]"/>
+      <dmrpp:chunk offset="165174"   nBytes="3873" chunkPositionInArray="[0,20,20,20]"/>
+      <dmrpp:chunk offset="169047"   nBytes="3670" chunkPositionInArray="[0,20,20,30]"/>
+      <dmrpp:chunk offset="172717"   nBytes="3940" chunkPositionInArray="[0,20,30,0]"/>
+      <dmrpp:chunk offset="176657"   nBytes="4010" chunkPositionInArray="[0,20,30,10]"/>
+      <dmrpp:chunk offset="180667"   nBytes="3867" chunkPositionInArray="[0,20,30,20]"/>
+      <dmrpp:chunk offset="184534"   nBytes="3666" chunkPositionInArray="[0,20,30,30]"/>
+      <dmrpp:chunk offset="188200"   nBytes="3926" chunkPositionInArray="[0,30,0,0]"/>
+      <dmrpp:chunk offset="192126"   nBytes="4007" chunkPositionInArray="[0,30,0,10]"/>
+      <dmrpp:chunk offset="196133"   nBytes="3880" chunkPositionInArray="[0,30,0,20]"/>
+      <dmrpp:chunk offset="200013"   nBytes="3692" chunkPositionInArray="[0,30,0,30]"/>
+      <dmrpp:chunk offset="203705"   nBytes="3932" chunkPositionInArray="[0,30,10,0]"/>
+      <dmrpp:chunk offset="207637"   nBytes="4020" chunkPositionInArray="[0,30,10,10]"/>
+      <dmrpp:chunk offset="211657"   nBytes="3886" chunkPositionInArray="[0,30,10,20]"/>
+      <dmrpp:chunk offset="215543"   nBytes="3693" chunkPositionInArray="[0,30,10,30]"/>
+      <dmrpp:chunk offset="219236"   nBytes="3936" chunkPositionInArray="[0,30,20,0]"/>
+      <dmrpp:chunk offset="223172"   nBytes="4021" chunkPositionInArray="[0,30,20,10]"/>
+      <dmrpp:chunk offset="227193"   nBytes="3878" chunkPositionInArray="[0,30,20,20]"/>
+      <dmrpp:chunk offset="231071"   nBytes="3690" chunkPositionInArray="[0,30,20,30]"/>
+      <dmrpp:chunk offset="234761"   nBytes="3919" chunkPositionInArray="[0,30,30,0]"/>
+      <dmrpp:chunk offset="238680"   nBytes="3996" chunkPositionInArray="[0,30,30,10]"/>
+      <dmrpp:chunk offset="242676"   nBytes="3847" chunkPositionInArray="[0,30,30,20]"/>
+      <dmrpp:chunk offset="246523"   nBytes="3656" chunkPositionInArray="[0,30,30,30]"/>
+      <dmrpp:chunk offset="250179"   nBytes="2360" chunkPositionInArray="[10,0,0,0]"/>
+      <dmrpp:chunk offset="259851"   nBytes="2299" chunkPositionInArray="[10,0,0,10]"/>
+      <dmrpp:chunk offset="262150"   nBytes="2266" chunkPositionInArray="[10,0,0,20]"/>
+      <dmrpp:chunk offset="264416"   nBytes="2328" chunkPositionInArray="[10,0,0,30]"/>
+      <dmrpp:chunk offset="266744"   nBytes="2367" chunkPositionInArray="[10,0,10,0]"/>
+      <dmrpp:chunk offset="269111"   nBytes="2313" chunkPositionInArray="[10,0,10,10]"/>
+      <dmrpp:chunk offset="271424"   nBytes="2249" chunkPositionInArray="[10,0,10,20]"/>
+      <dmrpp:chunk offset="273673"   nBytes="2294" chunkPositionInArray="[10,0,10,30]"/>
+      <dmrpp:chunk offset="275967"   nBytes="2330" chunkPositionInArray="[10,0,20,0]"/>
+      <dmrpp:chunk offset="278297"   nBytes="2308" chunkPositionInArray="[10,0,20,10]"/>
+      <dmrpp:chunk offset="280605"   nBytes="2286" chunkPositionInArray="[10,0,20,20]"/>
+      <dmrpp:chunk offset="282891"   nBytes="2330" chunkPositionInArray="[10,0,20,30]"/>
+      <dmrpp:chunk offset="285221"   nBytes="2411" chunkPositionInArray="[10,0,30,0]"/>
+      <dmrpp:chunk offset="287632"   nBytes="2351" chunkPositionInArray="[10,0,30,10]"/>
+      <dmrpp:chunk offset="289983"   nBytes="2275" chunkPositionInArray="[10,0,30,20]"/>
+      <dmrpp:chunk offset="292258"   nBytes="2321" chunkPositionInArray="[10,0,30,30]"/>
+      <dmrpp:chunk offset="294579"   nBytes="2392" chunkPositionInArray="[10,10,0,0]"/>
+      <dmrpp:chunk offset="296971"   nBytes="2353" chunkPositionInArray="[10,10,0,10]"/>
+      <dmrpp:chunk offset="299324"   nBytes="2326" chunkPositionInArray="[10,10,0,20]"/>
+      <dmrpp:chunk offset="301650"   nBytes="2378" chunkPositionInArray="[10,10,0,30]"/>
+      <dmrpp:chunk offset="304028"   nBytes="2425" chunkPositionInArray="[10,10,10,0]"/>
+      <dmrpp:chunk offset="306453"   nBytes="2354" chunkPositionInArray="[10,10,10,10]"/>
+      <dmrpp:chunk offset="308807"   nBytes="2291" chunkPositionInArray="[10,10,10,20]"/>
+      <dmrpp:chunk offset="311098"   nBytes="2341" chunkPositionInArray="[10,10,10,30]"/>
+      <dmrpp:chunk offset="313439"   nBytes="2354" chunkPositionInArray="[10,10,20,0]"/>
+      <dmrpp:chunk offset="315793"   nBytes="2311" chunkPositionInArray="[10,10,20,10]"/>
+      <dmrpp:chunk offset="318104"   nBytes="2302" chunkPositionInArray="[10,10,20,20]"/>
+      <dmrpp:chunk offset="320406"   nBytes="2360" chunkPositionInArray="[10,10,20,30]"/>
+      <dmrpp:chunk offset="322766"   nBytes="2404" chunkPositionInArray="[10,10,30,0]"/>
+      <dmrpp:chunk offset="325170"   nBytes="2355" chunkPositionInArray="[10,10,30,10]"/>
+      <dmrpp:chunk offset="327525"   nBytes="2298" chunkPositionInArray="[10,10,30,20]"/>
+      <dmrpp:chunk offset="329823"   nBytes="2323" chunkPositionInArray="[10,10,30,30]"/>
+      <dmrpp:chunk offset="332146"   nBytes="2341" chunkPositionInArray="[10,20,0,0]"/>
+      <dmrpp:chunk offset="334487"   nBytes="2296" chunkPositionInArray="[10,20,0,10]"/>
+      <dmrpp:chunk offset="336783"   nBytes="2282" chunkPositionInArray="[10,20,0,20]"/>
+      <dmrpp:chunk offset="339065"   nBytes="2326" chunkPositionInArray="[10,20,0,30]"/>
+      <dmrpp:chunk offset="341391"   nBytes="2410" chunkPositionInArray="[10,20,10,0]"/>
+      <dmrpp:chunk offset="343801"   nBytes="2335" chunkPositionInArray="[10,20,10,10]"/>
+      <dmrpp:chunk offset="346136"   nBytes="2267" chunkPositionInArray="[10,20,10,20]"/>
+      <dmrpp:chunk offset="348403"   nBytes="2312" chunkPositionInArray="[10,20,10,30]"/>
+      <dmrpp:chunk offset="350715"   nBytes="2341" chunkPositionInArray="[10,20,20,0]"/>
+      <dmrpp:chunk offset="353056"   nBytes="2272" chunkPositionInArray="[10,20,20,10]"/>
+      <dmrpp:chunk offset="355328"   nBytes="2312" chunkPositionInArray="[10,20,20,20]"/>
+      <dmrpp:chunk offset="357640"   nBytes="2354" chunkPositionInArray="[10,20,20,30]"/>
+      <dmrpp:chunk offset="359994"   nBytes="2374" chunkPositionInArray="[10,20,30,0]"/>
+      <dmrpp:chunk offset="362368"   nBytes="2307" chunkPositionInArray="[10,20,30,10]"/>
+      <dmrpp:chunk offset="364675"   nBytes="2242" chunkPositionInArray="[10,20,30,20]"/>
+      <dmrpp:chunk offset="366917"   nBytes="2294" chunkPositionInArray="[10,20,30,30]"/>
+      <dmrpp:chunk offset="369211"   nBytes="2332" chunkPositionInArray="[10,30,0,0]"/>
+      <dmrpp:chunk offset="371543"   nBytes="2289" chunkPositionInArray="[10,30,0,10]"/>
+      <dmrpp:chunk offset="373832"   nBytes="2282" chunkPositionInArray="[10,30,0,20]"/>
+      <dmrpp:chunk offset="376114"   nBytes="2328" chunkPositionInArray="[10,30,0,30]"/>
+      <dmrpp:chunk offset="378442"   nBytes="2382" chunkPositionInArray="[10,30,10,0]"/>
+      <dmrpp:chunk offset="380824"   nBytes="2326" chunkPositionInArray="[10,30,10,10]"/>
+      <dmrpp:chunk offset="383150"   nBytes="2268" chunkPositionInArray="[10,30,10,20]"/>
+      <dmrpp:chunk offset="385418"   nBytes="2300" chunkPositionInArray="[10,30,10,30]"/>
+      <dmrpp:chunk offset="387718"   nBytes="2359" chunkPositionInArray="[10,30,20,0]"/>
+      <dmrpp:chunk offset="390077"   nBytes="2307" chunkPositionInArray="[10,30,20,10]"/>
+      <dmrpp:chunk offset="396040"   nBytes="2324" chunkPositionInArray="[10,30,20,20]"/>
+      <dmrpp:chunk offset="398364"   nBytes="2358" chunkPositionInArray="[10,30,20,30]"/>
+      <dmrpp:chunk offset="400722"   nBytes="2428" chunkPositionInArray="[10,30,30,0]"/>
+      <dmrpp:chunk offset="403150"   nBytes="2339" chunkPositionInArray="[10,30,30,10]"/>
+      <dmrpp:chunk offset="405489"   nBytes="2268" chunkPositionInArray="[10,30,30,20]"/>
+      <dmrpp:chunk offset="407757"   nBytes="2305" chunkPositionInArray="[10,30,30,30]"/>
+      <dmrpp:chunk offset="410062"   nBytes="1616" chunkPositionInArray="[20,0,0,0]"/>
+      <dmrpp:chunk offset="411678"   nBytes="1561" chunkPositionInArray="[20,0,0,10]"/>
+      <dmrpp:chunk offset="413239"   nBytes="1726" chunkPositionInArray="[20,0,0,20]"/>
+      <dmrpp:chunk offset="414965"   nBytes="1751" chunkPositionInArray="[20,0,0,30]"/>
+      <dmrpp:chunk offset="416716"   nBytes="1789" chunkPositionInArray="[20,0,10,0]"/>
+      <dmrpp:chunk offset="418505"   nBytes="1722" chunkPositionInArray="[20,0,10,10]"/>
+      <dmrpp:chunk offset="420227"   nBytes="1617" chunkPositionInArray="[20,0,10,20]"/>
+      <dmrpp:chunk offset="421844"   nBytes="1573" chunkPositionInArray="[20,0,10,30]"/>
+      <dmrpp:chunk offset="423417"   nBytes="1621" chunkPositionInArray="[20,0,20,0]"/>
+      <dmrpp:chunk offset="425038"   nBytes="1563" chunkPositionInArray="[20,0,20,10]"/>
+      <dmrpp:chunk offset="426601"   nBytes="1727" chunkPositionInArray="[20,0,20,20]"/>
+      <dmrpp:chunk offset="428328"   nBytes="1756" chunkPositionInArray="[20,0,20,30]"/>
+      <dmrpp:chunk offset="430084"   nBytes="1787" chunkPositionInArray="[20,0,30,0]"/>
+      <dmrpp:chunk offset="431871"   nBytes="1723" chunkPositionInArray="[20,0,30,10]"/>
+      <dmrpp:chunk offset="433594"   nBytes="1618" chunkPositionInArray="[20,0,30,20]"/>
+      <dmrpp:chunk offset="435212"   nBytes="1575" chunkPositionInArray="[20,0,30,30]"/>
+      <dmrpp:chunk offset="436787"   nBytes="1614" chunkPositionInArray="[20,10,0,0]"/>
+      <dmrpp:chunk offset="438401"   nBytes="1562" chunkPositionInArray="[20,10,0,10]"/>
+      <dmrpp:chunk offset="439963"   nBytes="1725" chunkPositionInArray="[20,10,0,20]"/>
+      <dmrpp:chunk offset="441688"   nBytes="1752" chunkPositionInArray="[20,10,0,30]"/>
+      <dmrpp:chunk offset="443440"   nBytes="1791" chunkPositionInArray="[20,10,10,0]"/>
+      <dmrpp:chunk offset="445231"   nBytes="1725" chunkPositionInArray="[20,10,10,10]"/>
+      <dmrpp:chunk offset="446956"   nBytes="1625" chunkPositionInArray="[20,10,10,20]"/>
+      <dmrpp:chunk offset="448581"   nBytes="1573" chunkPositionInArray="[20,10,10,30]"/>
+      <dmrpp:chunk offset="450154"   nBytes="1617" chunkPositionInArray="[20,10,20,0]"/>
+      <dmrpp:chunk offset="451771"   nBytes="1559" chunkPositionInArray="[20,10,20,10]"/>
+      <dmrpp:chunk offset="453330"   nBytes="1723" chunkPositionInArray="[20,10,20,20]"/>
+      <dmrpp:chunk offset="455053"   nBytes="1750" chunkPositionInArray="[20,10,20,30]"/>
+      <dmrpp:chunk offset="456803"   nBytes="1794" chunkPositionInArray="[20,10,30,0]"/>
+      <dmrpp:chunk offset="458597"   nBytes="1725" chunkPositionInArray="[20,10,30,10]"/>
+      <dmrpp:chunk offset="460322"   nBytes="1623" chunkPositionInArray="[20,10,30,20]"/>
+      <dmrpp:chunk offset="461945"   nBytes="1576" chunkPositionInArray="[20,10,30,30]"/>
+      <dmrpp:chunk offset="463521"   nBytes="1618" chunkPositionInArray="[20,20,0,0]"/>
+      <dmrpp:chunk offset="465139"   nBytes="1561" chunkPositionInArray="[20,20,0,10]"/>
+      <dmrpp:chunk offset="466700"   nBytes="1727" chunkPositionInArray="[20,20,0,20]"/>
+      <dmrpp:chunk offset="468427"   nBytes="1753" chunkPositionInArray="[20,20,0,30]"/>
+      <dmrpp:chunk offset="470180"   nBytes="1790" chunkPositionInArray="[20,20,10,0]"/>
+      <dmrpp:chunk offset="471970"   nBytes="1718" chunkPositionInArray="[20,20,10,10]"/>
+      <dmrpp:chunk offset="473688"   nBytes="1616" chunkPositionInArray="[20,20,10,20]"/>
+      <dmrpp:chunk offset="475304"   nBytes="1569" chunkPositionInArray="[20,20,10,30]"/>
+      <dmrpp:chunk offset="476873"   nBytes="1619" chunkPositionInArray="[20,20,20,0]"/>
+      <dmrpp:chunk offset="478492"   nBytes="1561" chunkPositionInArray="[20,20,20,10]"/>
+      <dmrpp:chunk offset="480053"   nBytes="1728" chunkPositionInArray="[20,20,20,20]"/>
+      <dmrpp:chunk offset="481781"   nBytes="1756" chunkPositionInArray="[20,20,20,30]"/>
+      <dmrpp:chunk offset="483537"   nBytes="1787" chunkPositionInArray="[20,20,30,0]"/>
+      <dmrpp:chunk offset="485324"   nBytes="1720" chunkPositionInArray="[20,20,30,10]"/>
+      <dmrpp:chunk offset="487044"   nBytes="1617" chunkPositionInArray="[20,20,30,20]"/>
+      <dmrpp:chunk offset="488661"   nBytes="1571" chunkPositionInArray="[20,20,30,30]"/>
+      <dmrpp:chunk offset="490232"   nBytes="1616" chunkPositionInArray="[20,30,0,0]"/>
+      <dmrpp:chunk offset="491848"   nBytes="1558" chunkPositionInArray="[20,30,0,10]"/>
+      <dmrpp:chunk offset="493406"   nBytes="1723" chunkPositionInArray="[20,30,0,20]"/>
+      <dmrpp:chunk offset="498785"   nBytes="1753" chunkPositionInArray="[20,30,0,30]"/>
+      <dmrpp:chunk offset="500538"   nBytes="1791" chunkPositionInArray="[20,30,10,0]"/>
+      <dmrpp:chunk offset="502329"   nBytes="1725" chunkPositionInArray="[20,30,10,10]"/>
+      <dmrpp:chunk offset="504054"   nBytes="1621" chunkPositionInArray="[20,30,10,20]"/>
+      <dmrpp:chunk offset="505675"   nBytes="1573" chunkPositionInArray="[20,30,10,30]"/>
+      <dmrpp:chunk offset="507248"   nBytes="1615" chunkPositionInArray="[20,30,20,0]"/>
+      <dmrpp:chunk offset="508863"   nBytes="1560" chunkPositionInArray="[20,30,20,10]"/>
+      <dmrpp:chunk offset="510423"   nBytes="1725" chunkPositionInArray="[20,30,20,20]"/>
+      <dmrpp:chunk offset="512148"   nBytes="1748" chunkPositionInArray="[20,30,20,30]"/>
+      <dmrpp:chunk offset="513896"   nBytes="1789" chunkPositionInArray="[20,30,30,0]"/>
+      <dmrpp:chunk offset="515685"   nBytes="1725" chunkPositionInArray="[20,30,30,10]"/>
+      <dmrpp:chunk offset="517410"   nBytes="1626" chunkPositionInArray="[20,30,30,20]"/>
+      <dmrpp:chunk offset="519036"   nBytes="1574" chunkPositionInArray="[20,30,30,30]"/>
+      <dmrpp:chunk offset="520610"   nBytes="1678" chunkPositionInArray="[30,0,0,0]"/>
+      <dmrpp:chunk offset="522288"   nBytes="1689" chunkPositionInArray="[30,0,0,10]"/>
+      <dmrpp:chunk offset="523977"   nBytes="1776" chunkPositionInArray="[30,0,0,20]"/>
+      <dmrpp:chunk offset="525753"   nBytes="1745" chunkPositionInArray="[30,0,0,30]"/>
+      <dmrpp:chunk offset="527498"   nBytes="1883" chunkPositionInArray="[30,0,10,0]"/>
+      <dmrpp:chunk offset="529381"   nBytes="1770" chunkPositionInArray="[30,0,10,10]"/>
+      <dmrpp:chunk offset="531151"   nBytes="1721" chunkPositionInArray="[30,0,10,20]"/>
+      <dmrpp:chunk offset="532872"   nBytes="1637" chunkPositionInArray="[30,0,10,30]"/>
+      <dmrpp:chunk offset="534509"   nBytes="1799" chunkPositionInArray="[30,0,20,0]"/>
+      <dmrpp:chunk offset="536308"   nBytes="1674" chunkPositionInArray="[30,0,20,10]"/>
+      <dmrpp:chunk offset="537982"   nBytes="1743" chunkPositionInArray="[30,0,20,20]"/>
+      <dmrpp:chunk offset="539725"   nBytes="1789" chunkPositionInArray="[30,0,20,30]"/>
+      <dmrpp:chunk offset="541514"   nBytes="1785" chunkPositionInArray="[30,0,30,0]"/>
+      <dmrpp:chunk offset="543299"   nBytes="1897" chunkPositionInArray="[30,0,30,10]"/>
+      <dmrpp:chunk offset="545196"   nBytes="1667" chunkPositionInArray="[30,0,30,20]"/>
+      <dmrpp:chunk offset="546863"   nBytes="1635" chunkPositionInArray="[30,0,30,30]"/>
+      <dmrpp:chunk offset="548498"   nBytes="1688" chunkPositionInArray="[30,10,0,0]"/>
+      <dmrpp:chunk offset="550186"   nBytes="1698" chunkPositionInArray="[30,10,0,10]"/>
+      <dmrpp:chunk offset="551884"   nBytes="1786" chunkPositionInArray="[30,10,0,20]"/>
+      <dmrpp:chunk offset="553670"   nBytes="1753" chunkPositionInArray="[30,10,0,30]"/>
+      <dmrpp:chunk offset="555423"   nBytes="1889" chunkPositionInArray="[30,10,10,0]"/>
+      <dmrpp:chunk offset="557312"   nBytes="1760" chunkPositionInArray="[30,10,10,10]"/>
+      <dmrpp:chunk offset="559072"   nBytes="1714" chunkPositionInArray="[30,10,10,20]"/>
+      <dmrpp:chunk offset="560786"   nBytes="1644" chunkPositionInArray="[30,10,10,30]"/>
+      <dmrpp:chunk offset="562430"   nBytes="1800" chunkPositionInArray="[30,10,20,0]"/>
+      <dmrpp:chunk offset="564230"   nBytes="1669" chunkPositionInArray="[30,10,20,10]"/>
+      <dmrpp:chunk offset="565899"   nBytes="1725" chunkPositionInArray="[30,10,20,20]"/>
+      <dmrpp:chunk offset="567624"   nBytes="1769" chunkPositionInArray="[30,10,20,30]"/>
+      <dmrpp:chunk offset="569393"   nBytes="1781" chunkPositionInArray="[30,10,30,0]"/>
+      <dmrpp:chunk offset="571174"   nBytes="1891" chunkPositionInArray="[30,10,30,10]"/>
+      <dmrpp:chunk offset="573065"   nBytes="1665" chunkPositionInArray="[30,10,30,20]"/>
+      <dmrpp:chunk offset="574730"   nBytes="1638" chunkPositionInArray="[30,10,30,30]"/>
+      <dmrpp:chunk offset="576368"   nBytes="1679" chunkPositionInArray="[30,20,0,0]"/>
+      <dmrpp:chunk offset="578047"   nBytes="1701" chunkPositionInArray="[30,20,0,10]"/>
+      <dmrpp:chunk offset="579748"   nBytes="1780" chunkPositionInArray="[30,20,0,20]"/>
+      <dmrpp:chunk offset="581528"   nBytes="1731" chunkPositionInArray="[30,20,0,30]"/>
+      <dmrpp:chunk offset="583259"   nBytes="1900" chunkPositionInArray="[30,20,10,0]"/>
+      <dmrpp:chunk offset="585159"   nBytes="1770" chunkPositionInArray="[30,20,10,10]"/>
+      <dmrpp:chunk offset="588977"   nBytes="1732" chunkPositionInArray="[30,20,10,20]"/>
+      <dmrpp:chunk offset="590709"   nBytes="1648" chunkPositionInArray="[30,20,10,30]"/>
+      <dmrpp:chunk offset="592357"   nBytes="1816" chunkPositionInArray="[30,20,20,0]"/>
+      <dmrpp:chunk offset="594173"   nBytes="1682" chunkPositionInArray="[30,20,20,10]"/>
+      <dmrpp:chunk offset="595855"   nBytes="1729" chunkPositionInArray="[30,20,20,20]"/>
+      <dmrpp:chunk offset="597584"   nBytes="1768" chunkPositionInArray="[30,20,20,30]"/>
+      <dmrpp:chunk offset="603008"   nBytes="1768" chunkPositionInArray="[30,20,30,0]"/>
+      <dmrpp:chunk offset="604776"   nBytes="1882" chunkPositionInArray="[30,20,30,10]"/>
+      <dmrpp:chunk offset="606658"   nBytes="1657" chunkPositionInArray="[30,20,30,20]"/>
+      <dmrpp:chunk offset="608315"   nBytes="1629" chunkPositionInArray="[30,20,30,30]"/>
+      <dmrpp:chunk offset="609944"   nBytes="1660" chunkPositionInArray="[30,30,0,0]"/>
+      <dmrpp:chunk offset="611604"   nBytes="1689" chunkPositionInArray="[30,30,0,10]"/>
+      <dmrpp:chunk offset="613293"   nBytes="1744" chunkPositionInArray="[30,30,0,20]"/>
+      <dmrpp:chunk offset="615037"   nBytes="1711" chunkPositionInArray="[30,30,0,30]"/>
+      <dmrpp:chunk offset="616748"   nBytes="1873" chunkPositionInArray="[30,30,10,0]"/>
+      <dmrpp:chunk offset="618621"   nBytes="1718" chunkPositionInArray="[30,30,10,10]"/>
+      <dmrpp:chunk offset="620339"   nBytes="1712" chunkPositionInArray="[30,30,10,20]"/>
+      <dmrpp:chunk offset="622051"   nBytes="1639" chunkPositionInArray="[30,30,10,30]"/>
+      <dmrpp:chunk offset="623690"   nBytes="1832" chunkPositionInArray="[30,30,20,0]"/>
+      <dmrpp:chunk offset="625522"   nBytes="1672" chunkPositionInArray="[30,30,20,10]"/>
+      <dmrpp:chunk offset="627194"   nBytes="1710" chunkPositionInArray="[30,30,20,20]"/>
+      <dmrpp:chunk offset="628904"   nBytes="1743" chunkPositionInArray="[30,30,20,30]"/>
+      <dmrpp:chunk offset="630647"   nBytes="1713" chunkPositionInArray="[30,30,30,0]"/>
+      <dmrpp:chunk offset="632360"   nBytes="1860" chunkPositionInArray="[30,30,30,10]"/>
+      <dmrpp:chunk offset="634220"   nBytes="1622" chunkPositionInArray="[30,30,30,20]"/>
+      <dmrpp:chunk offset="635842"   nBytes="1588" chunkPositionInArray="[30,30,30,30]"/>
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_shufzip_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shufzip_fourD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shufzip_fourD.h5"     

--- a/modules/dmrpp_module/data/dmrpp/chunked_shufzip_oneD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shufzip_oneD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shufzip_oneD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shufzip_oneD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shufzip_oneD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shufzip_oneD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shufzip_oneD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shufzip_oneD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shufzip_oneD.h5"
-    xml:base="data/dmrpp/chunked_shufzip_oneD.h5">
+    dmrpp:href="data/dmrpp/chunked_shufzip_oneD.h5">
     
   <Float32 name="d_4_shufzip_chunks">
     <Dim size="40000"/>
@@ -15,12 +15,12 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_4_shufzip_chunks</Value>
     </Attribute>
-    <h4:chunks deflate_level="6" compressionType="shuffle deflate">
-      <h4:chunkDimensionSizes>10000</h4:chunkDimensionSizes>
-      <h4:byteStream nBytes="1865" chunkPositionInArray="[0]" md5="3cd1695926e4880c9bde7fe9d95fa6c2" uuid="64803167-11f5-4436-8a52-586d36c09e6b" offset="3496"/>
-      <h4:byteStream nBytes="624" chunkPositionInArray="[10000]" md5="1324066f9fa26734cf32e7c930628e02" uuid="dfb06222-305f-4337-b1c3-2d50fad8194c" offset="5361"/>
-      <h4:byteStream nBytes="450" chunkPositionInArray="[20000]" md5="8584ff225fba3bd98e71a7d0427735b7" uuid="8700429e-40a4-4021-b8f8-a753acfeb058" offset="5985"/>
-      <h4:byteStream nBytes="697" chunkPositionInArray="[30000]" md5="dc6ea70ba670e6be7ad29d4f5e5e8267" uuid="1f6028f1-70b8-4036-94f1-9b1051228737" offset="6435"/>
-    </h4:chunks>
+    <dmrpp:chunks deflate_level="6" compressionType="shuffle deflate">
+      <dmrpp:chunkDimensionSizes>10000</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk nBytes="1865" chunkPositionInArray="[0]"   offset="3496"/>
+      <dmrpp:chunk nBytes="624" chunkPositionInArray="[10000]"   offset="5361"/>
+      <dmrpp:chunk nBytes="450" chunkPositionInArray="[20000]"   offset="5985"/>
+      <dmrpp:chunk nBytes="697" chunkPositionInArray="[30000]"   offset="6435"/>
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_shufzip_threeD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shufzip_threeD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shufzip_threeD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shufzip_threeD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shufzip_threeD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shufzip_threeD.h5"
-    xml:base="data/dmrpp/chunked_shufzip_threeD.h5">
+    dmrpp:href="data/dmrpp/chunked_shufzip_threeD.h5">
 
   <Float32 name="d_8_shufzip_chunks">
     <Dim size="100"/>
@@ -17,136 +17,136 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_8_shufzip_chunks</Value>
     </Attribute>
-    <h4:chunks deflate_level="6" compressionType="shuffle deflate">
-      <h4:chunkDimensionSizes>13 25 25</h4:chunkDimensionSizes>
-      <h4:byteStream md5="0709b7691a6488b9de4d925573fa47a6" uuid="77059358-0912-4821-b35a-55391aa56c54" nBytes="2617" chunkPositionInArray="[0,0,0]" offset="4208"/>
-      <h4:byteStream md5="ff03e4c3d9c3a4302d5215c93ecae008" uuid="16dfae79-79a1-4004-acd4-4480242fce2f" nBytes="2594" chunkPositionInArray="[0,0,25]" offset="6825"/>
-      <h4:byteStream md5="bb12efb14fd4d4c7929ac5afcff1eb83" uuid="a375f2c7-e78a-4123-8dc8-fb50cf9caa59" nBytes="2598" chunkPositionInArray="[0,0,50]" offset="9419"/>
-      <h4:byteStream md5="08867555dc35cce2ddc1eb3630eaa2d3" uuid="a655be3e-700c-469e-92ee-c10a4c9b7d87" nBytes="2603" chunkPositionInArray="[0,0,75]" offset="12017"/>
-      <h4:byteStream md5="29f4b065b25adefbf32d7a6d75275fce" uuid="b411ecc1-f9b2-495c-a24d-022947fc2cda" nBytes="2516" chunkPositionInArray="[0,25,0]" offset="14620"/>
-      <h4:byteStream md5="3994fcdd7a83d030bf9c358dae80dffd" uuid="1eb74fb9-6d05-4ed8-9477-4a2b97f22178" nBytes="2507" chunkPositionInArray="[0,25,25]" offset="17136"/>
-      <h4:byteStream md5="bf0357fa2cc73cb0cf804862785d0f91" uuid="7aea8e0e-1655-493f-b907-872442354032" nBytes="2515" chunkPositionInArray="[0,25,50]" offset="19643"/>
-      <h4:byteStream md5="bab9e6a48e4e57067c7dbb58e23e5687" uuid="d9672fdd-0e6a-449c-9123-5c640ba8416a" nBytes="2511" chunkPositionInArray="[0,25,75]" offset="22158"/>
-      <h4:byteStream md5="c37504f54b9f49e90e9aafc5084e5134" uuid="22d371ad-9eac-49ad-aff2-388bbdebb109" nBytes="2423" chunkPositionInArray="[0,50,0]" offset="24669"/>
-      <h4:byteStream md5="809481d32c337e5d316c1478e21aa7ab" uuid="067693a5-1939-426c-9031-0025af188520" nBytes="2425" chunkPositionInArray="[0,50,25]" offset="27092"/>
-      <h4:byteStream md5="48eb5f970d292d8ef5a975ecf77d4a45" uuid="8d735949-bd63-4d62-96e8-51512339d255" nBytes="2419" chunkPositionInArray="[0,50,50]" offset="29517"/>
-      <h4:byteStream md5="b9111f25afa68d69a772e61273f195c1" uuid="147a0b36-d442-4001-88be-27b7e8892cc3" nBytes="2424" chunkPositionInArray="[0,50,75]" offset="31936"/>
-      <h4:byteStream md5="31cb03b0f4bcd9cb03476ba5daeb61a8" uuid="2bdad168-0c01-4083-9247-062edab6935d" nBytes="2418" chunkPositionInArray="[0,75,0]" offset="34360"/>
-      <h4:byteStream md5="c9b99a38f7469b72ca474ac9ecc90b76" uuid="27fd16cb-45e6-4bef-a826-e05fce7aa731" nBytes="2404" chunkPositionInArray="[0,75,25]" offset="36778"/>
-      <h4:byteStream md5="e3537806656ce3d1934b3ab6dcb09636" uuid="b7019e3a-eca8-4552-b924-3ac901bd1b70" nBytes="2401" chunkPositionInArray="[0,75,50]" offset="39182"/>
-      <h4:byteStream md5="6ed6bc0f038dea53695b586874508ef7" uuid="76f2f993-c160-4592-a23f-eeb733babab8" nBytes="2410" chunkPositionInArray="[0,75,75]" offset="41583"/>
-      <h4:byteStream md5="ed3ac380ef2694870aa74304ce9bd232" uuid="e033cbd6-afe0-44e4-8409-336209c1fa68" nBytes="1796" chunkPositionInArray="[13,0,0]" offset="43993"/>
-      <h4:byteStream md5="a60d7b6596fce33d42524b5e9888f15f" uuid="68a486ba-2482-4edc-a967-fa2a7d9ff3bd" nBytes="1854" chunkPositionInArray="[13,0,25]" offset="45789"/>
-      <h4:byteStream md5="c8968f79d97303d815e5075a11f474ee" uuid="c1dc0f05-9d31-4964-ad13-ea455db58cc4" nBytes="1870" chunkPositionInArray="[13,0,50]" offset="47643"/>
-      <h4:byteStream md5="38e32b54a28078414946657ea3d4c077" uuid="b08fc621-8159-4827-af0d-51e619b3b11f" nBytes="1785" chunkPositionInArray="[13,0,75]" offset="49513"/>
-      <h4:byteStream md5="7e339b66cf32d8f2c690f7187225e16c" uuid="ca608e73-cc29-475e-8a85-e8a70f5c8ba6" nBytes="1479" chunkPositionInArray="[13,25,0]" offset="51298"/>
-      <h4:byteStream md5="e2118acff90a6a35d133b2c16c2f2656" uuid="d57b6a60-bb8a-4ce5-b72e-4724ccd34b79" nBytes="1640" chunkPositionInArray="[13,25,25]" offset="52777"/>
-      <h4:byteStream md5="e0ef96a19469864f549173b7ded075f5" uuid="f80f3014-62fe-498b-83ee-142c8e248ec4" nBytes="1636" chunkPositionInArray="[13,25,50]" offset="54417"/>
-      <h4:byteStream md5="e378fe46c80a59af58c774b661ead7e4" uuid="de99d3cb-cc9e-43f2-8d39-1d25d6301400" nBytes="1501" chunkPositionInArray="[13,25,75]" offset="56053"/>
-      <h4:byteStream md5="d5852b985d175f9ffcb106b92302060a" uuid="8e85bcdf-73b4-4bc1-9d69-5d5c5a93bb4a" nBytes="1478" chunkPositionInArray="[13,50,0]" offset="57554"/>
-      <h4:byteStream md5="cb1fbe092955b9de523bb6c7b0162cae" uuid="90469d41-d561-4c58-9f93-e0c791c6902c" nBytes="1638" chunkPositionInArray="[13,50,25]" offset="59032"/>
-      <h4:byteStream md5="8ef446926c7a37339da3d91e06ea5b08" uuid="b6118ce6-a529-4b18-8223-2aa38092ba28" nBytes="1639" chunkPositionInArray="[13,50,50]" offset="60670"/>
-      <h4:byteStream md5="c18b8c642f364e4ed57c67e2497d2c2f" uuid="ef2406fd-ce0d-4e38-acda-5a2f75b754e0" nBytes="1498" chunkPositionInArray="[13,50,75]" offset="62309"/>
-      <h4:byteStream md5="14b2c705b2acd4eb5eac487362e2fedd" uuid="b2664a7e-6f7f-4aed-bd84-d267f4bacfa9" nBytes="1474" chunkPositionInArray="[13,75,0]" offset="63807"/>
-      <h4:byteStream md5="a5325e18536dd54898875ca3f563df36" uuid="ce999e45-3d3b-4a18-a9a4-70a9b29e9d62" nBytes="1639" chunkPositionInArray="[13,75,25]" offset="65281"/>
-      <h4:byteStream md5="16dd593cddc2f373dfd67cd6a75f0201" uuid="4d1b9d0a-c03a-4185-a1f6-d11984d06693" nBytes="1635" chunkPositionInArray="[13,75,50]" offset="66920"/>
-      <h4:byteStream md5="d479c4fd5f8414c8be149e7c3a4727f2" uuid="26dd4942-649e-458d-b0bc-c8ca82177e44" nBytes="1496" chunkPositionInArray="[13,75,75]" offset="68555"/>
-      <h4:byteStream md5="60c2f134550957d4c51c1af642a4f6b9" uuid="bffdf4ef-f76b-4ae3-9748-a043a5f13fbd" nBytes="1689" chunkPositionInArray="[26,0,0]" offset="70051"/>
-      <h4:byteStream md5="51985807e08b864a3703c51031b8ffc0" uuid="40d5deb7-1481-4e73-94bb-95b04b17ba8b" nBytes="1932" chunkPositionInArray="[26,0,25]" offset="71740"/>
-      <h4:byteStream md5="d839bb776b150f37a522ce9b7074b12d" uuid="758eb13e-8ce5-49e3-b029-9891370eaea8" nBytes="1905" chunkPositionInArray="[26,0,50]" offset="73672"/>
-      <h4:byteStream md5="c08c4a5d05f85d1e93adc9e5dc6e8805" uuid="c5e4fb4b-6137-4230-8db2-e784e8ab9727" nBytes="1736" chunkPositionInArray="[26,0,75]" offset="75577"/>
-      <h4:byteStream md5="ca0fc7bb45d492e86151677c6a9d0581" uuid="f0d2f987-ec62-4719-af8d-0e5143cbd8e9" nBytes="1435" chunkPositionInArray="[26,25,0]" offset="77313"/>
-      <h4:byteStream md5="3dc850568f69ae088dd67e62751fa7ba" uuid="dfa094d6-5643-4263-8027-0f5019288eb4" nBytes="1624" chunkPositionInArray="[26,25,25]" offset="78748"/>
-      <h4:byteStream md5="cf9c0c2bc1e731dd470cde39583442e2" uuid="8c40a66f-8eae-4b48-8487-7282cb61699e" nBytes="1618" chunkPositionInArray="[26,25,50]" offset="80372"/>
-      <h4:byteStream md5="62004214ab2f6c8cd4f02b6216af1737" uuid="882ea9a1-471d-469a-8745-bdeeb1a15e5e" nBytes="1469" chunkPositionInArray="[26,25,75]" offset="81990"/>
-      <h4:byteStream md5="54d23498ee4fde34cff9996e24207976" uuid="beb64481-3314-4ac1-93e2-f713270af8f4" nBytes="1426" chunkPositionInArray="[26,50,0]" offset="83459"/>
-      <h4:byteStream md5="bfbf97c49bc880617abb048968c61554" uuid="44ba5f9d-2cf2-4539-a60e-7e73e73fad59" nBytes="1613" chunkPositionInArray="[26,50,25]" offset="84885"/>
-      <h4:byteStream md5="55ab28b18d0e086f21a26e61cd8f1b13" uuid="02605002-da63-4dc9-8a5b-38f0aed19764" nBytes="1624" chunkPositionInArray="[26,50,50]" offset="86498"/>
-      <h4:byteStream md5="e2a2a9680d13382986cd599144273f11" uuid="07ea7a95-dc76-4e3a-b174-f5eb8dfd7db7" nBytes="1478" chunkPositionInArray="[26,50,75]" offset="88122"/>
-      <h4:byteStream md5="a6371a04982e65661325cdb0c95279b1" uuid="e72f6394-ed03-42b3-b4ba-5505ec382cfe" nBytes="1426" chunkPositionInArray="[26,75,0]" offset="89600"/>
-      <h4:byteStream md5="7429d8f04c7723665ab724ee109dd721" uuid="50be1b71-c40b-46f8-b1ec-ab8ef61b30e3" nBytes="1616" chunkPositionInArray="[26,75,25]" offset="91026"/>
-      <h4:byteStream md5="2331a55b41703e5f2fe19df14d8a52ad" uuid="1ba065c0-6b87-4c84-8214-49875b06e4ae" nBytes="1618" chunkPositionInArray="[26,75,50]" offset="92642"/>
-      <h4:byteStream md5="f8ebf7addc479eca2eb9fb56c9f83da5" uuid="e133f056-3483-475f-975c-1e1517259ee1" nBytes="1472" chunkPositionInArray="[26,75,75]" offset="94260"/>
-      <h4:byteStream md5="b90f2208e9586be21e55c09733cbc221" uuid="a576cf7d-f863-4294-815a-b34d1351fad3" nBytes="1427" chunkPositionInArray="[39,0,0]" offset="95732"/>
-      <h4:byteStream md5="83752e8de2b3913441c6da41d4196f33" uuid="f1bcc9a6-af4c-4323-bab0-ad52d0a9ec05" nBytes="1612" chunkPositionInArray="[39,0,25]" offset="97159"/>
-      <h4:byteStream md5="a32b9e1e6220c81fe291008dd77fb501" uuid="099e33f9-3ac9-4b97-86e3-3fe333bc0177" nBytes="1626" chunkPositionInArray="[39,0,50]" offset="98771"/>
-      <h4:byteStream md5="20c7547c4f7e76a30a4b0adce3b7df38" uuid="b6219dff-77fa-42a9-84b0-1258975fb9c6" nBytes="1473" chunkPositionInArray="[39,0,75]" offset="100397"/>
-      <h4:byteStream md5="19e342822070a72c326e32fb51de0e20" uuid="4d9cf1c3-842e-43f4-b39f-ac22ce33dfd0" nBytes="1432" chunkPositionInArray="[39,25,0]" offset="101870"/>
-      <h4:byteStream md5="7d9e3017e1f02a76d5b0bc208596048d" uuid="09b0aa13-bae4-4b97-86a7-a8e17ef994d9" nBytes="1619" chunkPositionInArray="[39,25,25]" offset="103302"/>
-      <h4:byteStream md5="efc38a5f700b1c72a50d3398694dec29" uuid="6e093222-6e0c-46a7-aa63-64853a060557" nBytes="1617" chunkPositionInArray="[39,25,50]" offset="104921"/>
-      <h4:byteStream md5="ccb280f06807e32bce9aa9d56d159e05" uuid="07bec4ba-f8de-4da1-9760-64230c273e54" nBytes="1470" chunkPositionInArray="[39,25,75]" offset="106538"/>
-      <h4:byteStream md5="14284b5960ec1ba5554c4a235c59e2f8" uuid="c6955168-0da4-4f61-bef3-7e443af68a61" nBytes="1426" chunkPositionInArray="[39,50,0]" offset="108008"/>
-      <h4:byteStream md5="c7191e7776309ea646b17015306706ff" uuid="51a38621-afff-41b3-819a-44a4011b5679" nBytes="1617" chunkPositionInArray="[39,50,25]" offset="109434"/>
-      <h4:byteStream md5="2359b0a76e8f4561e9ce9978b7bec340" uuid="c23e439a-8609-4ca4-aaba-a9dc5d416f6b" nBytes="1627" chunkPositionInArray="[39,50,50]" offset="111051"/>
-      <h4:byteStream md5="894f4cb673b66466689d09d2d82f586c" uuid="b98dd61c-f145-4ae0-a7b2-07fc5f3f841f" nBytes="1478" chunkPositionInArray="[39,50,75]" offset="112678"/>
-      <h4:byteStream md5="40452c7f316257c6f9c61ab5ee56ac91" uuid="37b20070-18f6-401c-9d99-880d57623f6f" nBytes="1438" chunkPositionInArray="[39,75,0]" offset="114156"/>
-      <h4:byteStream md5="6a189f176f2f0327285d9bc465f1545a" uuid="ba0aeb04-2dd6-4b52-94d3-27711c4c40e0" nBytes="1623" chunkPositionInArray="[39,75,25]" offset="115594"/>
-      <h4:byteStream md5="a8ef04cdcc90e00c9e5ec671f8da4322" uuid="48f9843e-83d6-40bc-916b-127fe38d7b8f" nBytes="1618" chunkPositionInArray="[39,75,50]" offset="117217"/>
-      <h4:byteStream md5="25f6e49baa3d1990868bb70b7c445ef3" uuid="80f0c4df-c2ef-4877-a31b-aec55835f98f" nBytes="1470" chunkPositionInArray="[39,75,75]" offset="118835"/>
-      <h4:byteStream md5="726923384fc7043f04cdd5733327368a" uuid="d57a7015-91d0-41a8-b160-6050c5e7389e" nBytes="1774" chunkPositionInArray="[52,0,0]" offset="120305"/>
-      <h4:byteStream md5="5366f0dccc8c8bc330f780350e3424b6" uuid="b9b7a2b9-baae-4e36-9a31-9153bffd8985" nBytes="1957" chunkPositionInArray="[52,0,25]" offset="128351"/>
-      <h4:byteStream md5="ee2ecec6fc2cceb9f394f99faeeac7b0" uuid="4231961e-dcb4-4669-b12b-50934f5d8637" nBytes="1992" chunkPositionInArray="[52,0,50]" offset="130308"/>
-      <h4:byteStream md5="0620a6a44741e8d0b417ec8e62efa40e" uuid="45bbebaa-5c60-4cf7-b3a0-3b15e3224bf3" nBytes="1820" chunkPositionInArray="[52,0,75]" offset="132300"/>
-      <h4:byteStream md5="3fade09e69f4559d03f2ff74775d24d7" uuid="f00e531c-f0e0-4d6b-a42f-edc9c47bca6d" nBytes="1769" chunkPositionInArray="[52,25,0]" offset="134120"/>
-      <h4:byteStream md5="6037784e63c98a0fdcf619c88e4b3ec8" uuid="01890d71-0392-4b1a-9860-e4cae8dc2f6f" nBytes="1935" chunkPositionInArray="[52,25,25]" offset="135889"/>
-      <h4:byteStream md5="0b1a43bdfacdcc52d0863bd55537c51d" uuid="42987150-b5a5-45f6-b142-874c6f124047" nBytes="1991" chunkPositionInArray="[52,25,50]" offset="137824"/>
-      <h4:byteStream md5="cf2f4f9f427fecdcea02592c0d95fc12" uuid="22c6837f-a403-49d0-ab2b-21b992d4dccf" nBytes="1789" chunkPositionInArray="[52,25,75]" offset="139815"/>
-      <h4:byteStream md5="87e0d2294f67fb7dc9d2321edb9b54ea" uuid="8ac8148e-b144-411e-bfd1-2b1bfd05f609" nBytes="1652" chunkPositionInArray="[52,50,0]" offset="141604"/>
-      <h4:byteStream md5="aec4a6c48a5755ead2b168ac1538919d" uuid="4b4212d7-b4f0-4a79-bc9c-ed4a7211362b" nBytes="1800" chunkPositionInArray="[52,50,25]" offset="143256"/>
-      <h4:byteStream md5="c7788e6a0037a0e9a7a5bd3724484658" uuid="3d437193-5f33-4eb4-a3f4-30a0b3ae699c" nBytes="1881" chunkPositionInArray="[52,50,50]" offset="145056"/>
-      <h4:byteStream md5="6d6f2aa83c8da506ff02bef7c6dfa8ed" uuid="0f6b4438-35a4-4476-ab7a-a5209a1d99be" nBytes="1708" chunkPositionInArray="[52,50,75]" offset="146937"/>
-      <h4:byteStream md5="cf2374ebc99944290cb6662f09eec657" uuid="42696d0c-9321-44b5-967d-b8ce78692889" nBytes="1656" chunkPositionInArray="[52,75,0]" offset="148645"/>
-      <h4:byteStream md5="73d266465107f6b27038dcf5cbde03ce" uuid="04c4cb58-a695-470a-8396-070f91a3bf27" nBytes="1810" chunkPositionInArray="[52,75,25]" offset="150301"/>
-      <h4:byteStream md5="07e4ce5ff477ec3548756d843dda8aba" uuid="aba9b232-0838-4f27-bc57-1ea32422714b" nBytes="1866" chunkPositionInArray="[52,75,50]" offset="152111"/>
-      <h4:byteStream md5="fa0a875edb9032d71eca28d1037caf2f" uuid="33c2cc47-f188-4eda-b471-de565616e6ae" nBytes="1697" chunkPositionInArray="[52,75,75]" offset="153977"/>
-      <h4:byteStream md5="f9eea2de712723b5d920991e784ea80b" uuid="58b8870c-cec7-4f1b-98df-9fc365e3e041" nBytes="1649" chunkPositionInArray="[65,0,0]" offset="155674"/>
-      <h4:byteStream md5="6f2a6f81291ce217b803a1ca85f90831" uuid="27f53e3a-56d7-4b62-b575-2d6bf9cf47d3" nBytes="1820" chunkPositionInArray="[65,0,25]" offset="157323"/>
-      <h4:byteStream md5="80318b53c04935c21be4ba76db7f006a" uuid="c3ca1206-0a96-4d36-80ee-3156c5abd9c1" nBytes="1872" chunkPositionInArray="[65,0,50]" offset="159143"/>
-      <h4:byteStream md5="c6fec50f4ec7b02da01943b255f3f86d" uuid="2bcbc7d0-8757-4e1b-9fd3-8288c44a29ed" nBytes="1702" chunkPositionInArray="[65,0,75]" offset="161015"/>
-      <h4:byteStream md5="e1d093a35fc5f0a93f5569ae39e48e4e" uuid="495cabcf-c5f2-46c7-8f2d-eaac022ac4e5" nBytes="1640" chunkPositionInArray="[65,25,0]" offset="162717"/>
-      <h4:byteStream md5="0cfe8be68ceb8f53394629bba8258bee" uuid="e1df0f49-6556-4606-b585-5d18d65e94b1" nBytes="1817" chunkPositionInArray="[65,25,25]" offset="164357"/>
-      <h4:byteStream md5="df986fa051c5b3994d6e993a695ab2b5" uuid="df882c84-fe07-421d-ab9a-9d21064a14ea" nBytes="1874" chunkPositionInArray="[65,25,50]" offset="166174"/>
-      <h4:byteStream md5="b416101a153b26f8d9746610537c32a5" uuid="500fb226-06d1-440d-9327-2364df7980a6" nBytes="1695" chunkPositionInArray="[65,25,75]" offset="168048"/>
-      <h4:byteStream md5="ad253d5fc1c0db4c331b05368586b6c0" uuid="c9b22d31-d726-44b1-ab00-d39f06880037" nBytes="1651" chunkPositionInArray="[65,50,0]" offset="169743"/>
-      <h4:byteStream md5="998489bdbcdf51c49d8677444f0c9b0b" uuid="1c8bbd6d-3b7b-4347-aace-0377d473bbb7" nBytes="1794" chunkPositionInArray="[65,50,25]" offset="171394"/>
-      <h4:byteStream md5="49128205ec867299594008f3872c8375" uuid="d49d4644-d21e-419f-a58d-b995fa1ec940" nBytes="1880" chunkPositionInArray="[65,50,50]" offset="173188"/>
-      <h4:byteStream md5="a9210e84ea69a0cc1b3b6d137893e959" uuid="c5facbc9-bb28-4fc4-8958-0dfbc721bdad" nBytes="1709" chunkPositionInArray="[65,50,75]" offset="175068"/>
-      <h4:byteStream md5="57632e8235dd4c1390491b90f89cbc70" uuid="dd73da96-a0c7-4034-a726-330f68abc016" nBytes="1669" chunkPositionInArray="[65,75,0]" offset="176777"/>
-      <h4:byteStream md5="991b245d287ab02a4f0beed5a89c0381" uuid="fdec719e-0a7a-46c4-ae6a-d10686437e6c" nBytes="1818" chunkPositionInArray="[65,75,25]" offset="178446"/>
-      <h4:byteStream md5="0b7c8c9b2993efe6b5c370d35bacdb51" uuid="c98c178c-0422-4d5a-9cd5-ba09b0c424f3" nBytes="1871" chunkPositionInArray="[65,75,50]" offset="180264"/>
-      <h4:byteStream md5="a53efa450a390f56b38b20aebcd612d3" uuid="96511985-5deb-4cdc-8ebc-8d11dfdc6e3f" nBytes="1703" chunkPositionInArray="[65,75,75]" offset="182135"/>
-      <h4:byteStream md5="b636ca7b206f207b61873cea13e9380a" uuid="55939560-c140-4190-809b-10f51d848b64" nBytes="1648" chunkPositionInArray="[78,0,0]" offset="185886"/>
-      <h4:byteStream md5="501fc9ba219d17eb30b3df4d5393f99a" uuid="e711a716-e6c0-429c-8abc-877e31ec43c5" nBytes="1822" chunkPositionInArray="[78,0,25]" offset="187534"/>
-      <h4:byteStream md5="d43abee4ce92ee3d4a2c4fbc1bb16604" uuid="8d8bed90-676d-4bde-9346-22ec1db8cb5d" nBytes="1874" chunkPositionInArray="[78,0,50]" offset="189356"/>
-      <h4:byteStream md5="8d0efcf057c3bb366d227e3cb4ee9b4f" uuid="d5729074-e535-4e95-a39e-9429dfed2cee" nBytes="1712" chunkPositionInArray="[78,0,75]" offset="191230"/>
-      <h4:byteStream md5="0556f1ac8cc5bc8073c76fd37d98968f" uuid="78c7a7dc-3cc9-46b7-b2de-c130494510fa" nBytes="1641" chunkPositionInArray="[78,25,0]" offset="192942"/>
-      <h4:byteStream md5="76eecfc341bb8c69a4e9ba6fceb5615f" uuid="dc55ddf7-6db9-4c8c-a05e-56da25ceba2a" nBytes="1813" chunkPositionInArray="[78,25,25]" offset="194583"/>
-      <h4:byteStream md5="87a3d00fc2e03d01f1267231998cb49f" uuid="c1f2a432-dd37-4326-97e9-55d991e9011e" nBytes="1873" chunkPositionInArray="[78,25,50]" offset="196396"/>
-      <h4:byteStream md5="26f19bd71ffe94895669724df967ebe2" uuid="d3726a07-ba59-4373-90ef-7953d8dec26f" nBytes="1696" chunkPositionInArray="[78,25,75]" offset="198269"/>
-      <h4:byteStream md5="058d48e8ec4bcd34e8ac01ff01bb7a72" uuid="4ce0bce3-27d4-4f32-b5da-6de2832310f7" nBytes="1650" chunkPositionInArray="[78,50,0]" offset="199965"/>
-      <h4:byteStream md5="542918a79642a6515e802869e046f3fa" uuid="4b374676-2595-4889-864f-6d7f3e5ae86e" nBytes="1805" chunkPositionInArray="[78,50,25]" offset="201615"/>
-      <h4:byteStream md5="baa7dbc61332a4ff770ac24528e25de7" uuid="63e17f37-23c5-42b6-8413-9fecdcaffca1" nBytes="1882" chunkPositionInArray="[78,50,50]" offset="203420"/>
-      <h4:byteStream md5="58b165fd6b5edb04c528d3d79d007c17" uuid="fc76c686-d4ca-45df-a4f3-cece8ff263c9" nBytes="1719" chunkPositionInArray="[78,50,75]" offset="205302"/>
-      <h4:byteStream md5="d74f331e6028a6558786bbaba4c4719f" uuid="d4e7ad4f-4096-41d0-9d31-c180325cce2e" nBytes="1659" chunkPositionInArray="[78,75,0]" offset="207021"/>
-      <h4:byteStream md5="7a41cf6ffebea6882182def819f1cdc8" uuid="411d614f-13ed-4ebb-bfb4-44360f1a7444" nBytes="1811" chunkPositionInArray="[78,75,25]" offset="208680"/>
-      <h4:byteStream md5="ddcf880e972fb6f751b81d3cd0e70982" uuid="8d1b9585-cf60-496c-ae10-4052df3df20f" nBytes="1861" chunkPositionInArray="[78,75,50]" offset="210491"/>
-      <h4:byteStream md5="c25261a042aea0c984b6f24e514f27de" uuid="112ef767-6d5f-4064-b0c8-92a14d30d703" nBytes="1700" chunkPositionInArray="[78,75,75]" offset="212352"/>
-      <h4:byteStream md5="9e821a1a8a6ce3edb24670bd9d4f92e3" uuid="39830efd-0f2c-40fb-8349-875f11c94453" nBytes="1215" chunkPositionInArray="[91,0,0]" offset="214052"/>
-      <h4:byteStream md5="ac0bb57eab2bc425bfa7f674e03e02c1" uuid="83af5f29-f2bb-4cec-a365-948533f50de0" nBytes="1349" chunkPositionInArray="[91,0,25]" offset="215267"/>
-      <h4:byteStream md5="d566bcd48ab2bb4f1f177144de866280" uuid="dfa9b504-3ada-4bc3-bdd4-28a07bc6ed7d" nBytes="1350" chunkPositionInArray="[91,0,50]" offset="216616"/>
-      <h4:byteStream md5="d247beaa6545ad215ceedd7d0c9b5a3c" uuid="3d19c014-b1b4-4402-94a2-0a0714a443f7" nBytes="1252" chunkPositionInArray="[91,0,75]" offset="217966"/>
-      <h4:byteStream md5="df6865761377e26cef2dde00be5d2cda" uuid="6d69f124-f425-4ac3-b6d2-8c4ac1dfbe0c" nBytes="1211" chunkPositionInArray="[91,25,0]" offset="219218"/>
-      <h4:byteStream md5="c9b0f1c23b322502a60fe6c9bff41711" uuid="83cc2b67-9b12-44f8-9762-bf1807e53d57" nBytes="1351" chunkPositionInArray="[91,25,25]" offset="220429"/>
-      <h4:byteStream md5="abbdcae41611198906c0c309c0ae0c64" uuid="bb918812-8a7a-4fc6-864b-fd8e2388c608" nBytes="1358" chunkPositionInArray="[91,25,50]" offset="221780"/>
-      <h4:byteStream md5="9174bca6ba277c1bd16716c88784c77d" uuid="71dde421-2c6a-4218-9c1d-5a00fe6279e8" nBytes="1253" chunkPositionInArray="[91,25,75]" offset="223138"/>
-      <h4:byteStream md5="6fb40b5282400cb9a3338d829c32f8d4" uuid="342b642a-3c3a-4822-b9ee-536dc0cbc3a7" nBytes="1217" chunkPositionInArray="[91,50,0]" offset="224391"/>
-      <h4:byteStream md5="fe501dbed3c9803b3ef7430a22dccfb8" uuid="be16f24d-54ef-434f-bf05-8e53737c0e50" nBytes="1335" chunkPositionInArray="[91,50,25]" offset="225608"/>
-      <h4:byteStream md5="25e17886b77a5e16992d7128a449ce13" uuid="c1b06e9b-394e-4dd9-a177-23cbbc38bf88" nBytes="1375" chunkPositionInArray="[91,50,50]" offset="230079"/>
-      <h4:byteStream md5="2a9dc3e7852c5c80dc831ade028e5a02" uuid="69563a4d-1765-4ffb-8609-8e84baa2021b" nBytes="1253" chunkPositionInArray="[91,50,75]" offset="231454"/>
-      <h4:byteStream md5="d2b86157029ab23272f3d9d64606fd54" uuid="f0dae53e-3f1f-43c8-9962-3f3c362049c6" nBytes="1224" chunkPositionInArray="[91,75,0]" offset="232707"/>
-      <h4:byteStream md5="288403975e0f3ae665342c8cca6266c9" uuid="6829fcd7-f104-4ea5-9a5c-0b53cb4f3fc9" nBytes="1353" chunkPositionInArray="[91,75,25]" offset="233931"/>
-      <h4:byteStream md5="b53be0d89d02379df8aa9e41fb5305e8" uuid="0aea2ee7-68c9-4360-9985-f23e16211346" nBytes="1363" chunkPositionInArray="[91,75,50]" offset="235284"/>
-      <h4:byteStream md5="93e59b5b0e56ef0c4ecb978970a1440b" uuid="9a779c64-1cc0-4b8d-ad89-e969fb4a47b7" nBytes="1241" chunkPositionInArray="[91,75,75]" offset="236647"/>
-    </h4:chunks>
+    <dmrpp:chunks deflate_level="6" compressionType="shuffle deflate">
+      <dmrpp:chunkDimensionSizes>13 25 25</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk   nBytes="2617" chunkPositionInArray="[0,0,0]" offset="4208"/>
+      <dmrpp:chunk   nBytes="2594" chunkPositionInArray="[0,0,25]" offset="6825"/>
+      <dmrpp:chunk   nBytes="2598" chunkPositionInArray="[0,0,50]" offset="9419"/>
+      <dmrpp:chunk   nBytes="2603" chunkPositionInArray="[0,0,75]" offset="12017"/>
+      <dmrpp:chunk   nBytes="2516" chunkPositionInArray="[0,25,0]" offset="14620"/>
+      <dmrpp:chunk   nBytes="2507" chunkPositionInArray="[0,25,25]" offset="17136"/>
+      <dmrpp:chunk   nBytes="2515" chunkPositionInArray="[0,25,50]" offset="19643"/>
+      <dmrpp:chunk   nBytes="2511" chunkPositionInArray="[0,25,75]" offset="22158"/>
+      <dmrpp:chunk   nBytes="2423" chunkPositionInArray="[0,50,0]" offset="24669"/>
+      <dmrpp:chunk   nBytes="2425" chunkPositionInArray="[0,50,25]" offset="27092"/>
+      <dmrpp:chunk   nBytes="2419" chunkPositionInArray="[0,50,50]" offset="29517"/>
+      <dmrpp:chunk   nBytes="2424" chunkPositionInArray="[0,50,75]" offset="31936"/>
+      <dmrpp:chunk   nBytes="2418" chunkPositionInArray="[0,75,0]" offset="34360"/>
+      <dmrpp:chunk   nBytes="2404" chunkPositionInArray="[0,75,25]" offset="36778"/>
+      <dmrpp:chunk   nBytes="2401" chunkPositionInArray="[0,75,50]" offset="39182"/>
+      <dmrpp:chunk   nBytes="2410" chunkPositionInArray="[0,75,75]" offset="41583"/>
+      <dmrpp:chunk   nBytes="1796" chunkPositionInArray="[13,0,0]" offset="43993"/>
+      <dmrpp:chunk   nBytes="1854" chunkPositionInArray="[13,0,25]" offset="45789"/>
+      <dmrpp:chunk   nBytes="1870" chunkPositionInArray="[13,0,50]" offset="47643"/>
+      <dmrpp:chunk   nBytes="1785" chunkPositionInArray="[13,0,75]" offset="49513"/>
+      <dmrpp:chunk   nBytes="1479" chunkPositionInArray="[13,25,0]" offset="51298"/>
+      <dmrpp:chunk   nBytes="1640" chunkPositionInArray="[13,25,25]" offset="52777"/>
+      <dmrpp:chunk   nBytes="1636" chunkPositionInArray="[13,25,50]" offset="54417"/>
+      <dmrpp:chunk   nBytes="1501" chunkPositionInArray="[13,25,75]" offset="56053"/>
+      <dmrpp:chunk   nBytes="1478" chunkPositionInArray="[13,50,0]" offset="57554"/>
+      <dmrpp:chunk   nBytes="1638" chunkPositionInArray="[13,50,25]" offset="59032"/>
+      <dmrpp:chunk   nBytes="1639" chunkPositionInArray="[13,50,50]" offset="60670"/>
+      <dmrpp:chunk   nBytes="1498" chunkPositionInArray="[13,50,75]" offset="62309"/>
+      <dmrpp:chunk   nBytes="1474" chunkPositionInArray="[13,75,0]" offset="63807"/>
+      <dmrpp:chunk   nBytes="1639" chunkPositionInArray="[13,75,25]" offset="65281"/>
+      <dmrpp:chunk   nBytes="1635" chunkPositionInArray="[13,75,50]" offset="66920"/>
+      <dmrpp:chunk   nBytes="1496" chunkPositionInArray="[13,75,75]" offset="68555"/>
+      <dmrpp:chunk   nBytes="1689" chunkPositionInArray="[26,0,0]" offset="70051"/>
+      <dmrpp:chunk   nBytes="1932" chunkPositionInArray="[26,0,25]" offset="71740"/>
+      <dmrpp:chunk   nBytes="1905" chunkPositionInArray="[26,0,50]" offset="73672"/>
+      <dmrpp:chunk   nBytes="1736" chunkPositionInArray="[26,0,75]" offset="75577"/>
+      <dmrpp:chunk   nBytes="1435" chunkPositionInArray="[26,25,0]" offset="77313"/>
+      <dmrpp:chunk   nBytes="1624" chunkPositionInArray="[26,25,25]" offset="78748"/>
+      <dmrpp:chunk   nBytes="1618" chunkPositionInArray="[26,25,50]" offset="80372"/>
+      <dmrpp:chunk   nBytes="1469" chunkPositionInArray="[26,25,75]" offset="81990"/>
+      <dmrpp:chunk   nBytes="1426" chunkPositionInArray="[26,50,0]" offset="83459"/>
+      <dmrpp:chunk   nBytes="1613" chunkPositionInArray="[26,50,25]" offset="84885"/>
+      <dmrpp:chunk   nBytes="1624" chunkPositionInArray="[26,50,50]" offset="86498"/>
+      <dmrpp:chunk   nBytes="1478" chunkPositionInArray="[26,50,75]" offset="88122"/>
+      <dmrpp:chunk   nBytes="1426" chunkPositionInArray="[26,75,0]" offset="89600"/>
+      <dmrpp:chunk   nBytes="1616" chunkPositionInArray="[26,75,25]" offset="91026"/>
+      <dmrpp:chunk   nBytes="1618" chunkPositionInArray="[26,75,50]" offset="92642"/>
+      <dmrpp:chunk   nBytes="1472" chunkPositionInArray="[26,75,75]" offset="94260"/>
+      <dmrpp:chunk   nBytes="1427" chunkPositionInArray="[39,0,0]" offset="95732"/>
+      <dmrpp:chunk   nBytes="1612" chunkPositionInArray="[39,0,25]" offset="97159"/>
+      <dmrpp:chunk   nBytes="1626" chunkPositionInArray="[39,0,50]" offset="98771"/>
+      <dmrpp:chunk   nBytes="1473" chunkPositionInArray="[39,0,75]" offset="100397"/>
+      <dmrpp:chunk   nBytes="1432" chunkPositionInArray="[39,25,0]" offset="101870"/>
+      <dmrpp:chunk   nBytes="1619" chunkPositionInArray="[39,25,25]" offset="103302"/>
+      <dmrpp:chunk   nBytes="1617" chunkPositionInArray="[39,25,50]" offset="104921"/>
+      <dmrpp:chunk   nBytes="1470" chunkPositionInArray="[39,25,75]" offset="106538"/>
+      <dmrpp:chunk   nBytes="1426" chunkPositionInArray="[39,50,0]" offset="108008"/>
+      <dmrpp:chunk   nBytes="1617" chunkPositionInArray="[39,50,25]" offset="109434"/>
+      <dmrpp:chunk   nBytes="1627" chunkPositionInArray="[39,50,50]" offset="111051"/>
+      <dmrpp:chunk   nBytes="1478" chunkPositionInArray="[39,50,75]" offset="112678"/>
+      <dmrpp:chunk   nBytes="1438" chunkPositionInArray="[39,75,0]" offset="114156"/>
+      <dmrpp:chunk   nBytes="1623" chunkPositionInArray="[39,75,25]" offset="115594"/>
+      <dmrpp:chunk   nBytes="1618" chunkPositionInArray="[39,75,50]" offset="117217"/>
+      <dmrpp:chunk   nBytes="1470" chunkPositionInArray="[39,75,75]" offset="118835"/>
+      <dmrpp:chunk   nBytes="1774" chunkPositionInArray="[52,0,0]" offset="120305"/>
+      <dmrpp:chunk   nBytes="1957" chunkPositionInArray="[52,0,25]" offset="128351"/>
+      <dmrpp:chunk   nBytes="1992" chunkPositionInArray="[52,0,50]" offset="130308"/>
+      <dmrpp:chunk   nBytes="1820" chunkPositionInArray="[52,0,75]" offset="132300"/>
+      <dmrpp:chunk   nBytes="1769" chunkPositionInArray="[52,25,0]" offset="134120"/>
+      <dmrpp:chunk   nBytes="1935" chunkPositionInArray="[52,25,25]" offset="135889"/>
+      <dmrpp:chunk   nBytes="1991" chunkPositionInArray="[52,25,50]" offset="137824"/>
+      <dmrpp:chunk   nBytes="1789" chunkPositionInArray="[52,25,75]" offset="139815"/>
+      <dmrpp:chunk   nBytes="1652" chunkPositionInArray="[52,50,0]" offset="141604"/>
+      <dmrpp:chunk   nBytes="1800" chunkPositionInArray="[52,50,25]" offset="143256"/>
+      <dmrpp:chunk   nBytes="1881" chunkPositionInArray="[52,50,50]" offset="145056"/>
+      <dmrpp:chunk   nBytes="1708" chunkPositionInArray="[52,50,75]" offset="146937"/>
+      <dmrpp:chunk   nBytes="1656" chunkPositionInArray="[52,75,0]" offset="148645"/>
+      <dmrpp:chunk   nBytes="1810" chunkPositionInArray="[52,75,25]" offset="150301"/>
+      <dmrpp:chunk   nBytes="1866" chunkPositionInArray="[52,75,50]" offset="152111"/>
+      <dmrpp:chunk   nBytes="1697" chunkPositionInArray="[52,75,75]" offset="153977"/>
+      <dmrpp:chunk   nBytes="1649" chunkPositionInArray="[65,0,0]" offset="155674"/>
+      <dmrpp:chunk   nBytes="1820" chunkPositionInArray="[65,0,25]" offset="157323"/>
+      <dmrpp:chunk   nBytes="1872" chunkPositionInArray="[65,0,50]" offset="159143"/>
+      <dmrpp:chunk   nBytes="1702" chunkPositionInArray="[65,0,75]" offset="161015"/>
+      <dmrpp:chunk   nBytes="1640" chunkPositionInArray="[65,25,0]" offset="162717"/>
+      <dmrpp:chunk   nBytes="1817" chunkPositionInArray="[65,25,25]" offset="164357"/>
+      <dmrpp:chunk   nBytes="1874" chunkPositionInArray="[65,25,50]" offset="166174"/>
+      <dmrpp:chunk   nBytes="1695" chunkPositionInArray="[65,25,75]" offset="168048"/>
+      <dmrpp:chunk   nBytes="1651" chunkPositionInArray="[65,50,0]" offset="169743"/>
+      <dmrpp:chunk   nBytes="1794" chunkPositionInArray="[65,50,25]" offset="171394"/>
+      <dmrpp:chunk   nBytes="1880" chunkPositionInArray="[65,50,50]" offset="173188"/>
+      <dmrpp:chunk   nBytes="1709" chunkPositionInArray="[65,50,75]" offset="175068"/>
+      <dmrpp:chunk   nBytes="1669" chunkPositionInArray="[65,75,0]" offset="176777"/>
+      <dmrpp:chunk   nBytes="1818" chunkPositionInArray="[65,75,25]" offset="178446"/>
+      <dmrpp:chunk   nBytes="1871" chunkPositionInArray="[65,75,50]" offset="180264"/>
+      <dmrpp:chunk   nBytes="1703" chunkPositionInArray="[65,75,75]" offset="182135"/>
+      <dmrpp:chunk   nBytes="1648" chunkPositionInArray="[78,0,0]" offset="185886"/>
+      <dmrpp:chunk   nBytes="1822" chunkPositionInArray="[78,0,25]" offset="187534"/>
+      <dmrpp:chunk   nBytes="1874" chunkPositionInArray="[78,0,50]" offset="189356"/>
+      <dmrpp:chunk   nBytes="1712" chunkPositionInArray="[78,0,75]" offset="191230"/>
+      <dmrpp:chunk   nBytes="1641" chunkPositionInArray="[78,25,0]" offset="192942"/>
+      <dmrpp:chunk   nBytes="1813" chunkPositionInArray="[78,25,25]" offset="194583"/>
+      <dmrpp:chunk   nBytes="1873" chunkPositionInArray="[78,25,50]" offset="196396"/>
+      <dmrpp:chunk   nBytes="1696" chunkPositionInArray="[78,25,75]" offset="198269"/>
+      <dmrpp:chunk   nBytes="1650" chunkPositionInArray="[78,50,0]" offset="199965"/>
+      <dmrpp:chunk   nBytes="1805" chunkPositionInArray="[78,50,25]" offset="201615"/>
+      <dmrpp:chunk   nBytes="1882" chunkPositionInArray="[78,50,50]" offset="203420"/>
+      <dmrpp:chunk   nBytes="1719" chunkPositionInArray="[78,50,75]" offset="205302"/>
+      <dmrpp:chunk   nBytes="1659" chunkPositionInArray="[78,75,0]" offset="207021"/>
+      <dmrpp:chunk   nBytes="1811" chunkPositionInArray="[78,75,25]" offset="208680"/>
+      <dmrpp:chunk   nBytes="1861" chunkPositionInArray="[78,75,50]" offset="210491"/>
+      <dmrpp:chunk   nBytes="1700" chunkPositionInArray="[78,75,75]" offset="212352"/>
+      <dmrpp:chunk   nBytes="1215" chunkPositionInArray="[91,0,0]" offset="214052"/>
+      <dmrpp:chunk   nBytes="1349" chunkPositionInArray="[91,0,25]" offset="215267"/>
+      <dmrpp:chunk   nBytes="1350" chunkPositionInArray="[91,0,50]" offset="216616"/>
+      <dmrpp:chunk   nBytes="1252" chunkPositionInArray="[91,0,75]" offset="217966"/>
+      <dmrpp:chunk   nBytes="1211" chunkPositionInArray="[91,25,0]" offset="219218"/>
+      <dmrpp:chunk   nBytes="1351" chunkPositionInArray="[91,25,25]" offset="220429"/>
+      <dmrpp:chunk   nBytes="1358" chunkPositionInArray="[91,25,50]" offset="221780"/>
+      <dmrpp:chunk   nBytes="1253" chunkPositionInArray="[91,25,75]" offset="223138"/>
+      <dmrpp:chunk   nBytes="1217" chunkPositionInArray="[91,50,0]" offset="224391"/>
+      <dmrpp:chunk   nBytes="1335" chunkPositionInArray="[91,50,25]" offset="225608"/>
+      <dmrpp:chunk   nBytes="1375" chunkPositionInArray="[91,50,50]" offset="230079"/>
+      <dmrpp:chunk   nBytes="1253" chunkPositionInArray="[91,50,75]" offset="231454"/>
+      <dmrpp:chunk   nBytes="1224" chunkPositionInArray="[91,75,0]" offset="232707"/>
+      <dmrpp:chunk   nBytes="1353" chunkPositionInArray="[91,75,25]" offset="233931"/>
+      <dmrpp:chunk   nBytes="1363" chunkPositionInArray="[91,75,50]" offset="235284"/>
+      <dmrpp:chunk   nBytes="1241" chunkPositionInArray="[91,75,75]" offset="236647"/>
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_shufzip_threeD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shufzip_threeD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_shufzip_threeD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shufzip_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shufzip_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0"
     dmrVersion="1.0"
     name="chunked_shufzip_twoD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shufzip_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shufzip_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0"
     dmrVersion="1.0"
     name="chunked_shufzip_twoD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_shufzip_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_shufzip_twoD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1"
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0"
     dmrVersion="1.0"
     name="chunked_shufzip_twoD.h5"
-    xml:base="data/dmrpp/chunked_shufzip_twoD.h5">
+    dmrpp:href="data/dmrpp/chunked_shufzip_twoD.h5">
   <Float32 name="d_4_shufzip_chunks">
     <Dim size="100"/>
     <Dim size="100"/>
@@ -15,12 +15,12 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_4_shufzip_chunks</Value>
     </Attribute>
-    <h4:chunks deflate_level="6" compressionType="shuffle deflate">
-      <h4:chunkDimensionSizes>50 50</h4:chunkDimensionSizes>
-      <h4:byteStream chunkPositionInArray="[0,0]" nBytes="976" md5="a6fee7e3efc727e4b43ae9daf881cb58" offset="4016" uuid="fdb9ab5b-3847-401b-9607-b27dab10956f"/>
-      <h4:byteStream chunkPositionInArray="[0,50]" nBytes="978" md5="63004b2080d84a81469dc0f113a3c843" offset="4992" uuid="71ae8820-7128-4e6c-89c9-0be546dd490a"/>
-      <h4:byteStream chunkPositionInArray="[50,0]" nBytes="532" md5="52310773dfe8f711ca3ad4a95cbd65d8" offset="5970" uuid="d1f06001-3413-4e0f-acb7-3a996d0e09c1"/>
-      <h4:byteStream chunkPositionInArray="[50,50]" nBytes="530" md5="3980492644c726c40d98833e277e02da" offset="6502" uuid="8d04d293-06f6-4637-bf11-92f9e7e4af6d"/>
-    </h4:chunks>
+    <dmrpp:chunks deflate_level="6" compressionType="shuffle deflate">
+      <dmrpp:chunkDimensionSizes>50 50</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk chunkPositionInArray="[0,0]" nBytes="976"  offset="4016" />
+      <dmrpp:chunk chunkPositionInArray="[0,50]" nBytes="978"  offset="4992" />
+      <dmrpp:chunk chunkPositionInArray="[50,0]" nBytes="532"  offset="5970" />
+      <dmrpp:chunk chunkPositionInArray="[50,50]" nBytes="530"  offset="6502" />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_threeD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_threeD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_threeD.h5"
-    xml:base="data/dmrpp/chunked_threeD.h5">
+    dmrpp:href="data/dmrpp/chunked_threeD.h5">
   <Float32 name="d_8_chunks">
     <Dim size="100"/>
     <Dim size="100"/>
@@ -16,16 +16,16 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_8_chunks</Value>
     </Attribute>
-    <h4:chunks>
-      <h4:chunkDimensionSizes>50 50 50</h4:chunkDimensionSizes>
-      <h4:byteStream offset="4208" uuid="8a10b9da-8fa3-49e1-b675-720e98cd9431" nBytes="500000" chunkPositionInArray="[0,0,0]" md5="bc77f320af6c34abf7d645297940afce"/>
-      <h4:byteStream offset="504208" uuid="34542407-8531-4f10-974f-6a48654073c4" nBytes="500000" chunkPositionInArray="[0,0,50]" md5="10a5cffc73e2ca3a66fa01eafc7b9db8"/>
-      <h4:byteStream offset="1004208" uuid="5887f966-11f8-4094-92ac-822dcc090a1b" nBytes="500000" chunkPositionInArray="[0,50,0]" md5="0bfc29686af0b7b8c693cdd4306a5567"/>
-      <h4:byteStream offset="1504208" uuid="402ef07f-ea51-4a25-a04a-e3e463d85cb8" nBytes="500000" chunkPositionInArray="[0,50,50]" md5="2a3771f0a5a03403af5d92c98c0a287f"/>
-      <h4:byteStream offset="2004208" uuid="a58087e1-c3f4-4f05-913a-2a38a310ae8a" nBytes="500000" chunkPositionInArray="[50,0,0]" md5="a04512a18fc80136f1e1564eb683ced2"/>
-      <h4:byteStream offset="2504208" uuid="d38fbfc9-59fd-4847-b6bb-851a1e28997e" nBytes="500000" chunkPositionInArray="[50,0,50]" md5="b15753f22fc12b8ac5e4fd55c7b27965"/>
-      <h4:byteStream offset="3006256" uuid="dfc2adc9-1dfa-4c93-a0f0-f9dcf3a2b409" nBytes="500000" chunkPositionInArray="[50,50,0]" md5="47a3d0164f787f0daa3fb5b753ba89e7"/>
-      <h4:byteStream offset="3506256" uuid="38396183-72dc-4fba-904b-a1483d6a1e05" nBytes="500000" chunkPositionInArray="[50,50,50]" md5="d4757eb10dd9da2d5eba0cdab708921b"/>
-    </h4:chunks>
+    <dmrpp:chunks>
+      <dmrpp:chunkDimensionSizes>50 50 50</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk offset="4208"  nBytes="500000" chunkPositionInArray="[0,0,0]" />
+      <dmrpp:chunk offset="504208"  nBytes="500000" chunkPositionInArray="[0,0,50]" />
+      <dmrpp:chunk offset="1004208"  nBytes="500000" chunkPositionInArray="[0,50,0]" />
+      <dmrpp:chunk offset="1504208"  nBytes="500000" chunkPositionInArray="[0,50,50]" />
+      <dmrpp:chunk offset="2004208"  nBytes="500000" chunkPositionInArray="[50,0,0]" />
+      <dmrpp:chunk offset="2504208"  nBytes="500000" chunkPositionInArray="[50,0,50]" />
+      <dmrpp:chunk offset="3006256"  nBytes="500000" chunkPositionInArray="[50,50,0]" />
+      <dmrpp:chunk offset="3506256"  nBytes="500000" chunkPositionInArray="[50,50,50]" />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_threeD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_threeD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_threeD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_threeD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_threeD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_threeD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_threeD_asymmetric.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_threeD_asymmetric.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0"
     dmrVersion="1.0" 
     name="chunked_threeD_asymmetric.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_threeD_asymmetric.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_threeD_asymmetric.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0"
     dmrVersion="1.0" 
     name="chunked_threeD_asymmetric.h5"
-    xml:base="data/dmrpp/chunked_threeD_asymmetric.h5">
+    dmrpp:href="data/dmrpp/chunked_threeD_asymmetric.h5">
   <Float32 name="d_8_chunks">
     <Dim size="100"/>
     <Dim size="50"/>
@@ -16,16 +16,16 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_8_chunks</Value>
     </Attribute>
-    <h4:chunks>
-      <h4:chunkDimensionSizes>50 50 50</h4:chunkDimensionSizes>
-      <h4:byteStream nBytes="500000" md5="364279d20f73733a41cb613ca118ddab" offset="4208" uuid="adfe2e7d-6d01-4610-81a0-82b882bee5c2" chunkPositionInArray="[0,0,0]"/>
-      <h4:byteStream nBytes="500000" md5="51f4935de20d34f17d6e3c4764394223" offset="504208" uuid="7a24fb5c-af1d-4713-8809-4153f2e511ed" chunkPositionInArray="[0,0,50]"/>
-      <h4:byteStream nBytes="500000" md5="4e5a9187dd68d1bd5d388d47c720ee6b" offset="1004208" uuid="6ce116c3-8628-4acb-94bd-d37e63166468" chunkPositionInArray="[0,0,100]"/>
-      <h4:byteStream nBytes="500000" md5="40b7eef7075820c2d35861200d52e000" offset="1504208" uuid="1f44b125-b6cd-4c7a-8b87-f929983dbdb1" chunkPositionInArray="[0,0,150]"/>
-      <h4:byteStream nBytes="500000" md5="4305f88bac9ae2e37d8071f337adee84" offset="2004208" uuid="e4953bed-5496-4774-a414-67dfc194c85a" chunkPositionInArray="[50,0,0]"/>
-      <h4:byteStream nBytes="500000" md5="05b51765f7e3789cab55ccd352105458" offset="2504208" uuid="691297ff-7f60-453f-83fb-55bd508e008d" chunkPositionInArray="[50,0,50]"/>
-      <h4:byteStream nBytes="500000" md5="e14e4ff01f9645862f2d6e92ac318bcf" offset="3006256" uuid="738d0418-7063-40d1-b065-d0dec144134d" chunkPositionInArray="[50,0,100]"/>
-      <h4:byteStream nBytes="500000" md5="e70566f96ed4f4990c4a156e6cfca47b" offset="3506256" uuid="1d403418-12af-41e5-b68c-ffe87593c134" chunkPositionInArray="[50,0,150]"/>
-    </h4:chunks>
+    <dmrpp:chunks>
+      <dmrpp:chunkDimensionSizes>50 50 50</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk nBytes="500000"  offset="4208"  chunkPositionInArray="[0,0,0]"/>
+      <dmrpp:chunk nBytes="500000"  offset="504208"  chunkPositionInArray="[0,0,50]"/>
+      <dmrpp:chunk nBytes="500000"  offset="1004208"  chunkPositionInArray="[0,0,100]"/>
+      <dmrpp:chunk nBytes="500000"  offset="1504208"  chunkPositionInArray="[0,0,150]"/>
+      <dmrpp:chunk nBytes="500000"  offset="2004208"  chunkPositionInArray="[50,0,0]"/>
+      <dmrpp:chunk nBytes="500000"  offset="2504208"  chunkPositionInArray="[50,0,50]"/>
+      <dmrpp:chunk nBytes="500000"  offset="3006256"  chunkPositionInArray="[50,0,100]"/>
+      <dmrpp:chunk nBytes="500000"  offset="3506256"  chunkPositionInArray="[50,0,150]"/>
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_threeD_asymmetric.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_threeD_asymmetric.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0"
     dmrVersion="1.0" 
     name="chunked_threeD_asymmetric.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_threeD_asymmetric_uneven.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_threeD_asymmetric_uneven.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_threeD_asymmetric_uneven.h5"
-    xml:base="data/dmrpp/chunked_threeD_asymmetric_uneven.h5">
+    dmrpp:href="data/dmrpp/chunked_threeD_asymmetric_uneven.h5">
 
   <Float32 name="d_odd_chunks">
     <Dim size="100"/>
@@ -17,20 +17,20 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_odd_chunks</Value>
     </Attribute>
-    <h4:chunks>
-      <h4:chunkDimensionSizes>41 50 53</h4:chunkDimensionSizes>
-      <h4:byteStream md5="a27bf8339ec59e7c1a923a868514951b" nBytes="434600" uuid="3b7baab0-1c78-47b3-a52b-a212bf684607" chunkPositionInArray="[0,0,0]" offset="4208"/>
-      <h4:byteStream md5="05694a69643a4acfe6837b712fbca6ce" nBytes="434600" uuid="e69901c6-c6bb-4b9a-b1e7-bd685e6f734c" chunkPositionInArray="[0,0,53]" offset="438808"/>
-      <h4:byteStream md5="892615d4feb04600a943b90af9e2d377" nBytes="434600" uuid="fcceaade-75df-471b-9c0a-dddcc440110d" chunkPositionInArray="[0,0,106]" offset="873408"/>
-      <h4:byteStream md5="974fb6a8aa969f734de2b135a83e9564" nBytes="434600" uuid="f9db3622-0652-498b-8f7a-817d5f250c30" chunkPositionInArray="[0,0,159]" offset="2611808"/>
-      <h4:byteStream md5="2b5e87bf9d19605496243fb31985ab2b" nBytes="434600" uuid="1fecf015-4c35-4e97-8724-f41ae5548516" chunkPositionInArray="[41,0,0]" offset="1308008"/>
-      <h4:byteStream md5="fc7e7c1dcbf24cacb04928c90f715feb" nBytes="434600" uuid="84a56b2a-d67e-4758-94e0-9b0af19c9b5b" chunkPositionInArray="[41,0,53]" offset="1742608"/>
-      <h4:byteStream md5="c1b3103d1672816e4cdabd88ef594143" nBytes="434600" uuid="12d82b45-fb1e-4b7a-84b5-7830b14ac976" chunkPositionInArray="[41,0,106]" offset="2177208"/>
-      <h4:byteStream md5="3ea4f412c906d2c54f6684f641b0183a" nBytes="434600" uuid="59b1b3ad-f5e9-4554-8ece-048a28f80679" chunkPositionInArray="[41,0,159]" offset="3046408"/>
-      <h4:byteStream md5="b1532a5487079d969f45762d9a2c4427" nBytes="434600" uuid="e1a247ff-137d-4a76-9248-d4bb9f1f03d4" chunkPositionInArray="[82,0,0]" offset="3481008"/>
-      <h4:byteStream md5="4c67867275d126c8a55238a4457958b5" nBytes="434600" uuid="dae41373-bc0e-4908-b2bc-272e7c278872" chunkPositionInArray="[82,0,53]" offset="3915608"/>
-      <h4:byteStream md5="3734ef07f4c0a791af8ef578b74bac3d" nBytes="434600" uuid="d4250d95-d3be-4a78-8c0d-77488c8b2c61" chunkPositionInArray="[82,0,106]" offset="4352256"/>
-      <h4:byteStream md5="8eab81b61ba2db02c6f3d34d6013fdde" nBytes="434600" uuid="11955520-66f3-48fb-8345-0754bdaa66b2" chunkPositionInArray="[82,0,159]" offset="4786856"/>
-    </h4:chunks>
+    <dmrpp:chunks>
+      <dmrpp:chunkDimensionSizes>41 50 53</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk  nBytes="434600"  chunkPositionInArray="[0,0,0]" offset="4208"/>
+      <dmrpp:chunk  nBytes="434600"  chunkPositionInArray="[0,0,53]" offset="438808"/>
+      <dmrpp:chunk  nBytes="434600"  chunkPositionInArray="[0,0,106]" offset="873408"/>
+      <dmrpp:chunk  nBytes="434600"  chunkPositionInArray="[0,0,159]" offset="2611808"/>
+      <dmrpp:chunk  nBytes="434600"  chunkPositionInArray="[41,0,0]" offset="1308008"/>
+      <dmrpp:chunk  nBytes="434600"  chunkPositionInArray="[41,0,53]" offset="1742608"/>
+      <dmrpp:chunk  nBytes="434600"  chunkPositionInArray="[41,0,106]" offset="2177208"/>
+      <dmrpp:chunk  nBytes="434600"  chunkPositionInArray="[41,0,159]" offset="3046408"/>
+      <dmrpp:chunk  nBytes="434600"  chunkPositionInArray="[82,0,0]" offset="3481008"/>
+      <dmrpp:chunk  nBytes="434600"  chunkPositionInArray="[82,0,53]" offset="3915608"/>
+      <dmrpp:chunk  nBytes="434600"  chunkPositionInArray="[82,0,106]" offset="4352256"/>
+      <dmrpp:chunk  nBytes="434600"  chunkPositionInArray="[82,0,159]" offset="4786856"/>
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_threeD_asymmetric_uneven.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_threeD_asymmetric_uneven.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_threeD_asymmetric_uneven.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_threeD_asymmetric_uneven.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_threeD_asymmetric_uneven.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_threeD_asymmetric_uneven.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_twoD.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_twoD.h5"
-    xml:base="data/dmrpp/chunked_twoD.h5">
+    dmrpp:href="data/dmrpp/chunked_twoD.h5">
   <Float32 name="d_4_chunks">
     <Dim size="100"/>
     <Dim size="100"/>
@@ -15,12 +15,12 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_4_chunks</Value>
     </Attribute>
-    <h4:chunks>
-      <h4:chunkDimensionSizes>50 50</h4:chunkDimensionSizes>
-      <h4:byteStream nBytes="10000" offset="4016" chunkPositionInArray="[0,0]" uuid="dfb35a6e-9a2a-489b-8db4-0ac6e72024ac" md5="e9fe1c46d8972badd0a9fc63ac20b9c8"/>
-      <h4:byteStream nBytes="10000" offset="14016" chunkPositionInArray="[0,50]" uuid="7ee1dcec-0281-463e-b916-6a25ba71e583" md5="44c89fb4f22581458713fbb694d3a5a5"/>
-      <h4:byteStream nBytes="10000" offset="24016" chunkPositionInArray="[50,0]" uuid="f2104e92-1775-488d-a2a2-dc487c49c35b" md5="f289b3eb40673d17d23fefcab6b8b7b2"/>
-      <h4:byteStream nBytes="10000" offset="34016" chunkPositionInArray="[50,50]" uuid="3aff561a-460e-49ba-9219-e0df6129d0f1" md5="b539d5234abdfc314935f548f28a7330"/>
-    </h4:chunks>
+    <dmrpp:chunks>
+      <dmrpp:chunkDimensionSizes>50 50</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk nBytes="10000" offset="4016" chunkPositionInArray="[0,0]"  />
+      <dmrpp:chunk nBytes="10000" offset="14016" chunkPositionInArray="[0,50]"  />
+      <dmrpp:chunk nBytes="10000" offset="24016" chunkPositionInArray="[50,0]"  />
+      <dmrpp:chunk nBytes="10000" offset="34016" chunkPositionInArray="[50,50]"  />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_twoD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_twoD.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_twoD.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_twoD.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_twoD_asymmetric.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_twoD_asymmetric.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0"
     name="chunked_twoD_asymmetric.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_twoD_asymmetric.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_twoD_asymmetric.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0"
     name="chunked_twoD_asymmetric.h5"
-    xml:base="data/dmrpp/chunked_twoD_asymmetric.h5">
+    dmrpp:href="data/dmrpp/chunked_twoD_asymmetric.h5">
   <Float32 name="d_8_chunks">
     <Dim size="100"/>
     <Dim size="200"/>
@@ -15,16 +15,16 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_8_chunks</Value>
     </Attribute>
-    <h4:chunks>
-      <h4:chunkDimensionSizes>50 50</h4:chunkDimensionSizes>
-      <h4:byteStream offset="4016" uuid="58cd02fd-2ebf-45af-b4c4-c6992fb9ab24" nBytes="10000" md5="73b277caf6a74b95ca3d2d3a46860ced" chunkPositionInArray="[0,0]"/>
-      <h4:byteStream offset="14016" uuid="5ac8e242-938f-4381-a86d-8dab67c5489e" nBytes="10000" md5="107f71e46cf54bb23a3b3db6ae928a40" chunkPositionInArray="[0,50]"/>
-      <h4:byteStream offset="24016" uuid="ec90ef69-5cb3-4694-8b5d-ec4815fb0d77" nBytes="10000" md5="ba8ba63b8ee7c6c4a46708f1c7268779" chunkPositionInArray="[0,100]"/>
-      <h4:byteStream offset="34016" uuid="f1b3d378-399e-48a1-96ec-b72808a5dccf" nBytes="10000" md5="01f643baa860280544fc8ea4d19ca488" chunkPositionInArray="[0,150]"/>
-      <h4:byteStream offset="44016" uuid="a1780059-3690-4ef9-b25f-fbf3cf469e20" nBytes="10000" md5="daa7f1a8a003595098c57ecd030bc16b" chunkPositionInArray="[50,0]"/>
-      <h4:byteStream offset="54016" uuid="caaf30b9-65fe-4721-b5dc-a92dd7f380ff" nBytes="10000" md5="4e17ebcf348add178c1b508404dd8860" chunkPositionInArray="[50,50]"/>
-      <h4:byteStream offset="64016" uuid="03ee32d5-1d2c-4bd5-981e-8f1f3dec9bd4" nBytes="10000" md5="c2dd2eace89a201665417fd71c34897d" chunkPositionInArray="[50,100]"/>
-      <h4:byteStream offset="74016" uuid="a26ae74b-65ad-4fea-acbd-43eb5f271565" nBytes="10000" md5="10ca0aadb13134a6f6a8b30d59812ee7" chunkPositionInArray="[50,150]"/>
-    </h4:chunks>
+    <dmrpp:chunks>
+      <dmrpp:chunkDimensionSizes>50 50</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk offset="4016"  nBytes="10000"  chunkPositionInArray="[0,0]"/>
+      <dmrpp:chunk offset="14016"  nBytes="10000"  chunkPositionInArray="[0,50]"/>
+      <dmrpp:chunk offset="24016"  nBytes="10000"  chunkPositionInArray="[0,100]"/>
+      <dmrpp:chunk offset="34016"  nBytes="10000"  chunkPositionInArray="[0,150]"/>
+      <dmrpp:chunk offset="44016"  nBytes="10000"  chunkPositionInArray="[50,0]"/>
+      <dmrpp:chunk offset="54016"  nBytes="10000"  chunkPositionInArray="[50,50]"/>
+      <dmrpp:chunk offset="64016"  nBytes="10000"  chunkPositionInArray="[50,100]"/>
+      <dmrpp:chunk offset="74016"  nBytes="10000"  chunkPositionInArray="[50,150]"/>
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_twoD_asymmetric.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_twoD_asymmetric.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0"
     name="chunked_twoD_asymmetric.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_twoD_uneven.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_twoD_uneven.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_twoD_uneven.h5"

--- a/modules/dmrpp_module/data/dmrpp/chunked_twoD_uneven.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_twoD_uneven.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_twoD_uneven.h5"
-    xml:base="data/dmrpp/chunked_twoD_uneven.h5">
+    dmrpp:href="data/dmrpp/chunked_twoD_uneven.h5">
     
   <Float32 name="d_10_odd_chunks">
     <Dim size="100"/>
@@ -16,14 +16,14 @@
     <Attribute name="fullnamepath" type="String">
       <Value>/d_10_odd_chunks</Value>
     </Attribute>
-    <h4:chunks>
-      <h4:chunkDimensionSizes>50 41</h4:chunkDimensionSizes>
-      <h4:byteStream offset="4016" nBytes="8200" chunkPositionInArray="[0,0]" uuid="c0e05824-5b86-4599-a21c-7a737509703c" md5="99d345cb5088ed06781296669829b526"/>
-      <h4:byteStream offset="12216" nBytes="8200" chunkPositionInArray="[0,41]" uuid="090e37e8-5803-4537-bf51-d1e5f6819ba5" md5="34a8232789a6bc122807cfe4b033fb0f"/>
-      <h4:byteStream offset="20416" nBytes="8200" chunkPositionInArray="[0,82]" uuid="887d1809-77b3-45c9-a295-2ac5bfa3d6f1" md5="723d9ee4af651b57e720c62e9053b131"/>
-      <h4:byteStream offset="28616" nBytes="8200" chunkPositionInArray="[50,0]" uuid="2a60ae99-a3d8-48b1-aba8-ce26a313bc13" md5="fce2ebc41b635e97d7da1daad51fe7c4"/>
-      <h4:byteStream offset="36816" nBytes="8200" chunkPositionInArray="[50,41]" uuid="68d963a5-7791-4f46-abd8-c9f93b01a602" md5="50367239f2a5399d9f9b496fe18b12d2"/>
-      <h4:byteStream offset="45016" nBytes="8200" chunkPositionInArray="[50,82]" uuid="eadc2dbf-7af1-46b1-bce4-e069acfcf46b" md5="b1cc0488a7f8db93d78db6a81c9b14f1"/>
-    </h4:chunks>
+    <dmrpp:chunks>
+      <dmrpp:chunkDimensionSizes>50 41</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk offset="4016" nBytes="8200" chunkPositionInArray="[0,0]"  />
+      <dmrpp:chunk offset="12216" nBytes="8200" chunkPositionInArray="[0,41]"  />
+      <dmrpp:chunk offset="20416" nBytes="8200" chunkPositionInArray="[0,82]"  />
+      <dmrpp:chunk offset="28616" nBytes="8200" chunkPositionInArray="[50,0]"  />
+      <dmrpp:chunk offset="36816" nBytes="8200" chunkPositionInArray="[50,41]"  />
+      <dmrpp:chunk offset="45016" nBytes="8200" chunkPositionInArray="[50,82]"  />
+    </dmrpp:chunks>
   </Float32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/chunked_twoD_uneven.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/chunked_twoD_uneven.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="chunked_twoD_uneven.h5"

--- a/modules/dmrpp_module/data/dmrpp/coads_climatology.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/coads_climatology.dmrpp
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#"
-    xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="coads_climatology"

--- a/modules/dmrpp_module/data/dmrpp/coads_climatology.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/coads_climatology.dmrpp
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#"
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+    xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="coads_climatology"
-    xml:base="data/dmrpp/coads_climatology.bin">
+    dmrpp:href="data/dmrpp/coads_climatology.bin">
         
     <Dimension name="COADSX" size="180"/>
     <Dimension name="COADSY" size="90"/>
@@ -21,8 +21,8 @@
         <Attribute name="point_spacing" type="String">
             <Value>even</Value>
         </Attribute>
-        <!-- h4:byteStream offset="0" nBytes="1440" uuid="COADSX.COADSX" md5="foo"/ -->
-        <h4:byteStream offset="3110400" nBytes="1440" uuid="COADSX.COADSX" md5="foo"/>
+        <!-- dmrpp:byteStream offset="0" nBytes="1440" uuid="COADSX.COADSX" md5="foo"/ -->
+        <dmrpp:chunk offset="3110400" nBytes="1440"  />
     </Float64>
     <Float64 name="COADSY">
         <Dim name="/COADSY"/>
@@ -32,7 +32,7 @@
         <Attribute name="point_spacing" type="String">
             <Value>even</Value>
         </Attribute>
-         <h4:byteStream offset="3111840" nBytes="720" uuid="COADSY.COADSY" md5="foo"/>
+         <dmrpp:chunk offset="3111840" nBytes="720"  />
     </Float64>
     <Float64 name="TIME">
         <Dim name="/TIME"/>
@@ -45,7 +45,7 @@
         <Attribute name="modulo" type="String">
             <Value> </Value>
         </Attribute>
-         <h4:byteStream offset="3112560" nBytes="96" uuid="TIME.TIME" md5="foo"/>
+         <dmrpp:chunk offset="3112560" nBytes="96"  />
     </Float64>
     <Float32 name="SST">
         <Dim name="/TIME"/>
@@ -69,7 +69,7 @@
         <Map name="TIME"/>
         <Map name="COADSY"/>
         <Map name="COADSX"/>
-        <h4:byteStream offset="0" nBytes="777600" uuid="SST.SST" md5="foo"/>
+        <dmrpp:chunk offset="0" nBytes="777600"  />
     </Float32>
     <Float32 name="AIRT">
         <Dim name="/TIME"/>
@@ -93,7 +93,7 @@
         <Map name="TIME"/>
         <Map name="COADSY"/>
         <Map name="COADSX"/>
-        <h4:byteStream offset="777600" nBytes="777600" uuid="AIRT.AIRT" md5="foo"/>
+        <dmrpp:chunk offset="777600" nBytes="777600"  />
     </Float32>
     <Float32 name="UWND">
         <Dim name="/TIME"/>
@@ -117,7 +117,7 @@
         <Map name="TIME"/>
         <Map name="COADSY"/>
         <Map name="COADSX"/>
-        <h4:byteStream offset="1555200" nBytes="777600" uuid="UWND.UWND" md5="foo"/>
+        <dmrpp:chunk offset="1555200" nBytes="777600"  />
     </Float32>
     <Float32 name="VWND">
         <Dim name="/TIME"/>
@@ -141,7 +141,7 @@
         <Map name="TIME"/>
         <Map name="COADSY"/>
         <Map name="COADSX"/>
-         <h4:byteStream offset="2332800" nBytes="777600" uuid="VWND.VWND" md5="foo"/>
+         <dmrpp:chunk offset="2332800" nBytes="777600"  />
    </Float32>
     <Attribute name="NC_GLOBAL" type="Container">
         <Attribute name="history" type="String">

--- a/modules/dmrpp_module/data/dmrpp/d_int.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/d_int.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="d_int.h5"

--- a/modules/dmrpp_module/data/dmrpp/d_int.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/d_int.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="d_int.h5"

--- a/modules/dmrpp_module/data/dmrpp/d_int.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/d_int.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="d_int.h5"
-    xml:base="data/dmrpp/d_int.h5">
+    dmrpp:href="data/dmrpp/d_int.h5">
   <Int16 name="d16_1">
     <Dim size="2"/>
     <Attribute name="minimum" type="Int16">
@@ -14,7 +14,7 @@
     <Attribute name="maximum" type="Int16">
       <Value>32767</Value>
     </Attribute>
-    <h4:byteStream nBytes="4" uuid="4a0e86ee-484a-44f7-8c03-9c39b202d680" offset="2216" md5="094e70793148a97742191430ccea74c7"/>
+    <dmrpp:chunk nBytes="4"  offset="2216" />
   </Int16>
   <Int16 name="d16_2">
     <Dim size="2"/>
@@ -35,7 +35,7 @@
       <Value>2</Value>
       <Value>32767</Value>
     </Attribute>
-    <h4:byteStream nBytes="8" uuid="2ebf051a-cb32-45ae-b846-172a4ea451f9" offset="2220" md5="7d881b5a33bbc8bb7d21d3a24f803c6c"/>
+    <dmrpp:chunk nBytes="8"  offset="2220" />
   </Int16>
   <Int32 name="d32_1">
     <Dim size="2"/>
@@ -47,7 +47,7 @@
     <Attribute name="maximum" type="Int32">
       <Value>2147483647</Value>
     </Attribute>
-    <h4:byteStream nBytes="32" uuid="0ba99033-541d-44c6-8b7c-330ba3ce782e" offset="2228" md5="a9a3743b60524ab66f4d16546893f06b"/>
+    <dmrpp:chunk nBytes="32"  offset="2228" />
   </Int32>
   <Int32 name="d32_2">
     <Dim size="2"/>
@@ -61,6 +61,6 @@
     <Attribute name="maximum" type="Int32">
       <Value>2147483647</Value>
     </Attribute>
-    <h4:byteStream nBytes="128" uuid="49d12a6c-cda0-49b5-8fce-12e8d160b4f7" offset="2260" md5="780c27c624c158fb88305f41a767459d"/>
+    <dmrpp:chunk nBytes="128"  offset="2260" />
   </Int32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/grid_1_2d.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/grid_1_2d.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0"
     name="grid_1_2d.h5"
-    xml:base="data/dmrpp/grid_1_2d.h5">
+    dmrpp:href="data/dmrpp/grid_1_2d.h5">
   <Group name="HDFEOS">
     <Group name="ADDITIONAL">
       <Group name="FILE_ATTRIBUTES"/>
@@ -19,7 +19,7 @@
             <Attribute name="units" type="String">
               <Value>K</Value>
             </Attribute>
-            <h4:byteStream offset="40672" nBytes="128" uuid="3fd2c024-4934-4732-ad47-063539472602" md5="3b37566bd3a2587a88e4787820e0d36f"/>
+            <dmrpp:chunk offset="40672" nBytes="128"  />
           </Float32>
         </Group>
       </Group>
@@ -27,7 +27,7 @@
   </Group>
   <Group name="HDFEOS INFORMATION">
     <String name="StructMetadata.0">
-      <h4:byteStream offset="5304" nBytes="32000" uuid="1721dd71-90df-4781-af2f-4098eb28baca" md5="a1d84a9da910f58677226bf71fa9d1dd"/>
+      <dmrpp:chunk offset="5304" nBytes="32000"  />
     </String>
     <Attribute name="HDFEOSVersion" type="String">
       <Value>HDFEOS_5.1.13</Value>

--- a/modules/dmrpp_module/data/dmrpp/grid_1_2d.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/grid_1_2d.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0"
     name="grid_1_2d.h5"

--- a/modules/dmrpp_module/data/dmrpp/grid_1_2d.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/grid_1_2d.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0"
     name="grid_1_2d.h5"

--- a/modules/dmrpp_module/data/dmrpp/grid_2_2d.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/grid_2_2d.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="grid_2_2d.h5"

--- a/modules/dmrpp_module/data/dmrpp/grid_2_2d.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/grid_2_2d.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="grid_2_2d.h5"

--- a/modules/dmrpp_module/data/dmrpp/grid_2_2d.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/grid_2_2d.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="grid_2_2d.h5"
-    xml:base="data/dmrpp/grid_2_2d.h5">
+    dmrpp:href="data/dmrpp/grid_2_2d.h5">
   <Group name="HDFEOS">
     <Group name="ADDITIONAL">
       <Group name="FILE_ATTRIBUTES"/>
@@ -19,7 +19,7 @@
             <Attribute name="units" type="String">
               <Value>K</Value>
             </Attribute>
-            <h4:byteStream nBytes="128" uuid="dda2aaf3-2502-4fa9-9d1a-e0d6b0e9adaa" md5="3b37566bd3a2587a88e4787820e0d36f" offset="40672"/>
+            <dmrpp:chunk nBytes="128"   offset="40672"/>
           </Float32>
         </Group>
       </Group>
@@ -31,7 +31,7 @@
             <Attribute name="units" type="String">
               <Value>K</Value>
             </Attribute>
-            <h4:byteStream nBytes="128" uuid="33c42554-050c-44cd-b0fb-aa26efdbb21a" md5="3b37566bd3a2587a88e4787820e0d36f" offset="40800"/>
+            <dmrpp:chunk nBytes="128"   offset="40800"/>
           </Float32>
         </Group>
       </Group>
@@ -39,7 +39,7 @@
   </Group>
   <Group name="HDFEOS INFORMATION">
     <String name="StructMetadata.0">
-      <h4:byteStream nBytes="32000" uuid="c574dd93-8712-498b-9f80-ed212734c87a" md5="fbf5900764d583f05f705988170581ce" offset="5304"/>
+      <dmrpp:chunk nBytes="32000"   offset="5304"/>
     </String>
     <Attribute name="HDFEOSVersion" type="String">
       <Value>HDFEOS_5.1.13</Value>

--- a/modules/dmrpp_module/data/dmrpp/http_d_int.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/http_d_int.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="d_int.h5"

--- a/modules/dmrpp_module/data/dmrpp/http_d_int.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/http_d_int.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="d_int.h5"

--- a/modules/dmrpp_module/data/dmrpp/http_d_int.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/http_d_int.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="d_int.h5"
-    xml:base="https://s3.amazonaws.com/cloudydap/samples/d_int.h5">
+    dmrpp:href="https://s3.amazonaws.com/cloudydap/samples/d_int.h5">
   <Int16 name="d16_1">
     <Dim size="2"/>
     <Attribute name="minimum" type="Int16">
@@ -14,7 +14,7 @@
     <Attribute name="maximum" type="Int16">
       <Value>32767</Value>
     </Attribute>
-    <h4:byteStream nBytes="4" uuid="4a0e86ee-484a-44f7-8c03-9c39b202d680" offset="2216" md5="094e70793148a97742191430ccea74c7"/>
+    <dmrpp:chunk nBytes="4"  offset="2216" />
   </Int16>
   <Int16 name="d16_2">
     <Dim size="2"/>
@@ -35,7 +35,7 @@
       <Value>2</Value>
       <Value>32767</Value>
     </Attribute>
-    <h4:byteStream nBytes="8" uuid="2ebf051a-cb32-45ae-b846-172a4ea451f9" offset="2220" md5="7d881b5a33bbc8bb7d21d3a24f803c6c"/>
+    <dmrpp:chunk nBytes="8"  offset="2220" />
   </Int16>
   <Int32 name="d32_1">
     <Dim size="2"/>
@@ -47,7 +47,7 @@
     <Attribute name="maximum" type="Int32">
       <Value>2147483647</Value>
     </Attribute>
-    <h4:byteStream nBytes="32" uuid="0ba99033-541d-44c6-8b7c-330ba3ce782e" offset="2228" md5="a9a3743b60524ab66f4d16546893f06b"/>
+    <dmrpp:chunk nBytes="32"  offset="2228" />
   </Int32>
   <Int32 name="d32_2">
     <Dim size="2"/>
@@ -61,6 +61,6 @@
     <Attribute name="maximum" type="Int32">
       <Value>2147483647</Value>
     </Attribute>
-    <h4:byteStream nBytes="128" uuid="49d12a6c-cda0-49b5-8fce-12e8d160b4f7" offset="2260" md5="780c27c624c158fb88305f41a767459d"/>
+    <dmrpp:chunk nBytes="128"  offset="2260" />
   </Int32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/http_t_int_scalar.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/http_t_int_scalar.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0"
     name="t_int_scalar.h5"

--- a/modules/dmrpp_module/data/dmrpp/http_t_int_scalar.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/http_t_int_scalar.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0"
     name="t_int_scalar.h5"

--- a/modules/dmrpp_module/data/dmrpp/http_t_int_scalar.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/http_t_int_scalar.h5.dmrpp
@@ -1,15 +1,15 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0"
     name="t_int_scalar.h5"
-    xml:base="https://s3.amazonaws.com/cloudydap/samples/t_int_scalar.h5">
+    dmrpp:href="https://s3.amazonaws.com/cloudydap/samples/t_int_scalar.h5">
   <Int32 name="scalar">
     <Attribute name="value" type="Int32">
       <Value>45</Value>
     </Attribute>
-    <h4:byteStream offset="2144" md5="1ebc4541e985d612a5ff7ed2ee92bf3d" uuid="6609c41e-0feb-4c00-a11b-48ae9a493542" nBytes="4"/>
+    <dmrpp:chunk offset="2144"   nBytes="4"/>
   </Int32>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/nc4_group_atomic.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/nc4_group_atomic.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0"
     dmrVersion="1.0" 
     name="nc4_group_atomic.h5"

--- a/modules/dmrpp_module/data/dmrpp/nc4_group_atomic.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/nc4_group_atomic.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0"
     dmrVersion="1.0" 
     name="nc4_group_atomic.h5"
-    xml:base="data/dmrpp/nc4_group_atomic.h5">
+    dmrpp:href="data/dmrpp/nc4_group_atomic.h5">
   <Dimension name="dim1" size="2"/>
   <Int32 name="dim1">
     <Dim name="/dim1"/>
@@ -18,11 +18,11 @@
     <Attribute name="_Netcdf4Dimid" type="Int32">
       <Value>0</Value>
     </Attribute>
-    <h4:byteStream nBytes="8" uuid="d6d6cbc9-04bf-4d3d-8827-4d7c52939e6d" md5="a068b90f3c19bf407f80db4945944e29" offset="6192"/>
+    <dmrpp:chunk nBytes="8"   offset="6192"/>
   </Int32>
   <Float32 name="d1">
     <Dim name="/dim1"/>
-    <h4:byteStream nBytes="8" uuid="55d3ca3d-4e1b-472e-822b-23d48838cf4d" md5="53163d5fb838cd8dabfd4425feda2b12" offset="6200"/>
+    <dmrpp:chunk nBytes="8"   offset="6200"/>
   </Float32>
   <Group name="g1">
     <Dimension name="dim2" size="3"/>
@@ -37,12 +37,12 @@
       <Attribute name="_Netcdf4Dimid" type="Int32">
         <Value>1</Value>
       </Attribute>
-      <h4:byteStream nBytes="12" uuid="4c91c3f7-73a1-43d5-a0fc-cfa23e92b3d2" md5="1719bc13ae9f2ad5aa50c720edc400a6" offset="6208"/>
+      <dmrpp:chunk nBytes="12"   offset="6208"/>
     </Int32>
     <Float32 name="d2">
       <Dim name="/dim1"/>
       <Dim name="/g1/dim2"/>
-      <h4:byteStream nBytes="24" uuid="62569081-e56e-47b5-ab10-ea9132cc8ef2" md5="2162ed0aecd0db6abb21fd1b4d56af73" offset="6220"/>
+      <dmrpp:chunk nBytes="24"   offset="6220"/>
     </Float32>
   </Group>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/nc4_group_atomic.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/nc4_group_atomic.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0"
     dmrVersion="1.0" 
     name="nc4_group_atomic.h5"

--- a/modules/dmrpp_module/data/dmrpp/t_float.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/t_float.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="t_float.h5"

--- a/modules/dmrpp_module/data/dmrpp/t_float.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/t_float.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="t_float.h5"

--- a/modules/dmrpp_module/data/dmrpp/t_float.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/t_float.h5.dmrpp
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1"
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0" 
     name="t_float.h5"
-    xml:base="data/dmrpp/t_float.h5">
+    dmrpp:href="data/dmrpp/t_float.h5">
   <Float32 name="d32_1">
     <Dim size="2"/>
     <Attribute name="minimum" type="Float32">
@@ -14,7 +14,7 @@
     <Attribute name="maximum" type="Float32">
       <Value>2.140000105</Value>
     </Attribute>
-    <h4:byteStream offset="2216" md5="ec2b3d664cfbfd9217e74738bbcd281f" uuid="c498ba62-0915-4641-bbda-e583daeae899" nBytes="8"/>
+    <dmrpp:chunk offset="2216"   nBytes="8"/>
   </Float32>
   <Float32 name="d32_2">
     <Dim size="2"/>
@@ -25,7 +25,7 @@
     <Attribute name="maximum" type="Float32">
       <Value>4.099999905</Value>
     </Attribute>
-    <h4:byteStream offset="2224" md5="aeaafe45df3d2e57fe3c68f9887c60b0" uuid="e5cb51bc-ed3f-4f66-89da-9793fdbd7667" nBytes="16"/>
+    <dmrpp:chunk offset="2224"   nBytes="16"/>
   </Float32>
   <Float64 name="d64_1">
     <Dim size="2"/>
@@ -37,7 +37,7 @@
     <Attribute name="maximum" type="Float64">
       <Value>4.9000000953674316</Value>
     </Attribute>
-    <h4:byteStream offset="2240" md5="f1e57dab82f2500507cad0888d520c08" uuid="eef57d69-e7ee-4199-a14b-c97e63e865c6" nBytes="64"/>
+    <dmrpp:chunk offset="2240"   nBytes="64"/>
   </Float64>
   <Float64 name="d64_2">
     <Dim size="2"/>
@@ -51,6 +51,6 @@
     <Attribute name="maximum" type="Float64">
       <Value>20.899999618530273</Value>
     </Attribute>
-    <h4:byteStream offset="2304" md5="88a376f14f1b9b5564b5930b931d3a1a" uuid="e16c36b1-9d21-4015-9c8f-b1c88de67078" nBytes="256"/>
+    <dmrpp:chunk offset="2304"   nBytes="256"/>
   </Float64>
 </Dataset>

--- a/modules/dmrpp_module/data/dmrpp/t_int_scalar.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/t_int_scalar.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0"
     name="t_int_scalar.h5"

--- a/modules/dmrpp_module/data/dmrpp/t_int_scalar.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/t_int_scalar.h5.dmrpp
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
+xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0"
     name="t_int_scalar.h5"

--- a/modules/dmrpp_module/data/dmrpp/t_int_scalar.h5.dmrpp
+++ b/modules/dmrpp_module/data/dmrpp/t_int_scalar.h5.dmrpp
@@ -1,15 +1,15 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Dataset 
     xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
-    xmlns:h4="http://www.hdfgroup.org/HDF4/XML/schema/HDF4map/1.0.1" 
+xmlns:dmrpp="http://www.opendap.org/dmrpp/schema/dmrpp/1.0.0#"
     dapVersion="4.0" 
     dmrVersion="1.0"
     name="t_int_scalar.h5"
-    xml:base="data/dmrpp/t_int_scalar.h5">
+    dmrpp:href="data/dmrpp/t_int_scalar.h5">
   <Int32 name="scalar">
     <Attribute name="value" type="Int32">
       <Value>45</Value>
     </Attribute>
-    <h4:byteStream offset="2144" md5="1ebc4541e985d612a5ff7ed2ee92bf3d" uuid="6609c41e-0feb-4c00-a11b-48ae9a493542" nBytes="4"/>
+    <dmrpp:chunk offset="2144"   nBytes="4"/>
   </Int32>
 </Dataset>

--- a/modules/dmrpp_module/unit-tests/DmrppChunkedReadTest.cc
+++ b/modules/dmrpp_module/unit-tests/DmrppChunkedReadTest.cc
@@ -610,7 +610,7 @@ int main(int argc, char*argv[])
 
     GetOpt getopt(argc, argv, "d");
     int option_char;
-    while ((option_char = getopt()) != -1)
+    while ((option_char = getopt()) != -1){
         switch (option_char) {
         case 'd':
             debug = true;  // debug is a static global
@@ -618,6 +618,7 @@ int main(int argc, char*argv[])
         default:
             break;
         }
+    }
 
     bool wasSuccessful = true;
     string test = "";
@@ -628,14 +629,17 @@ int main(int argc, char*argv[])
     }
     else {
         while (i < argc) {
-            test = string("dmrpp::DmrppChunkedReadTest::") + argv[i++];
-
-            cerr << endl << "Running test " << test << endl << endl;
-
+            if (debug) cerr << "Running " << argv[i] << endl;
+            test = dmrpp::DmrppChunkedReadTest::suite()->getName().append("::").append(argv[i]);
             wasSuccessful = wasSuccessful && runner.run(test);
+        ++i;
         }
     }
 
     return wasSuccessful ? 0 : 1;
+
+
+
+
 }
 

--- a/modules/dmrpp_module/unit-tests/DmrppHttpReadTest.cc
+++ b/modules/dmrpp_module/unit-tests/DmrppHttpReadTest.cc
@@ -68,19 +68,19 @@ static bool debug = false;
 
 namespace dmrpp {
 
-class DmrppHttpReadTeat: public CppUnit::TestFixture {
+class DmrppHttpReadTest: public CppUnit::TestFixture {
 private:
     DmrppParserSax2 parser;
 
 public:
     // Called once before everything gets tested
-    DmrppHttpReadTeat() :
+    DmrppHttpReadTest() :
         parser()
     {
     }
 
     // Called at the end of the test
-    ~DmrppHttpReadTeat()
+    ~DmrppHttpReadTest()
     {
     }
 
@@ -259,7 +259,7 @@ public:
         CPPUNIT_ASSERT("Passed");
     }
 
-    CPPUNIT_TEST_SUITE( DmrppHttpReadTeat );
+    CPPUNIT_TEST_SUITE( DmrppHttpReadTest );
 
     CPPUNIT_TEST(test_integer_scalar);
     CPPUNIT_TEST(test_integer_arrays);
@@ -267,7 +267,7 @@ public:
     CPPUNIT_TEST_SUITE_END();
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(DmrppHttpReadTeat);
+CPPUNIT_TEST_SUITE_REGISTRATION(DmrppHttpReadTest);
 
 } // namespace dmrpp
 
@@ -278,7 +278,7 @@ int main(int argc, char*argv[])
 
     GetOpt getopt(argc, argv, "d");
     int option_char;
-    while ((option_char = getopt()) != -1)
+    while ((option_char = getopt()) != -1){
         switch (option_char) {
         case 'd':
             debug = true;  // debug is a static global
@@ -286,6 +286,7 @@ int main(int argc, char*argv[])
         default:
             break;
         }
+    }
 
     bool wasSuccessful = true;
     string test = "";
@@ -296,14 +297,12 @@ int main(int argc, char*argv[])
     }
     else {
         while (i < argc) {
-            test = string("dmrpp::DmrppHttpReadTeat::") + argv[i++];
-
-            cerr << endl << "Running test " << test << endl << endl;
-
+            if (debug) cerr << "Running " << argv[i] << endl;
+            test = dmrpp::DmrppHttpReadTest::suite()->getName().append("::").append(argv[i]);
             wasSuccessful = wasSuccessful && runner.run(test);
+        ++i;
         }
     }
-
     return wasSuccessful ? 0 : 1;
 }
 

--- a/modules/dmrpp_module/unit-tests/DmrppParserTest.cc
+++ b/modules/dmrpp_module/unit-tests/DmrppParserTest.cc
@@ -449,7 +449,7 @@ int main(int argc, char*argv[])
 
     GetOpt getopt(argc, argv, "d");
     int option_char;
-    while ((option_char = getopt()) != -1)
+    while ((option_char = getopt()) != -1){
         switch (option_char) {
         case 'd':
             debug = true;  // debug is a static global
@@ -457,6 +457,7 @@ int main(int argc, char*argv[])
         default:
             break;
         }
+    }
 
     bool wasSuccessful = true;
     string test = "";
@@ -467,14 +468,12 @@ int main(int argc, char*argv[])
     }
     else {
         while (i < argc) {
-            test = string("dmrpp::DmrppParserTest::") + argv[i++];
-
-            cerr << endl << "Running test " << test << endl << endl;
-
+            if (debug) cerr << "Running " << argv[i] << endl;
+            test = dmrpp::DmrppParserTest::suite()->getName().append("::").append(argv[i]);
             wasSuccessful = wasSuccessful && runner.run(test);
+        ++i;
         }
     }
-
     return wasSuccessful ? 0 : 1;
 }
 

--- a/modules/dmrpp_module/unit-tests/DmrppTypeReadTest.cc
+++ b/modules/dmrpp_module/unit-tests/DmrppTypeReadTest.cc
@@ -895,14 +895,17 @@ int main(int argc, char*argv[])
     }
     else {
         while (i < argc) {
-            test = string("dmrpp::DmrppTypeReadTest::") + argv[i++];
-
-            cerr << endl << "Running test " << test << endl << endl;
-
+            if (debug) cerr << "Running " << argv[i] << endl;
+            test = dmrpp::DmrppTypeReadTest::suite()->getName().append("::").append(argv[i]);
             wasSuccessful = wasSuccessful && runner.run(test);
+        ++i;
         }
     }
 
     return wasSuccessful ? 0 : 1;
+
+
+
+
 }
 

--- a/modules/dmrpp_module/unit-tests/DmrppTypeReadTest.cc
+++ b/modules/dmrpp_module/unit-tests/DmrppTypeReadTest.cc
@@ -91,7 +91,8 @@ public:
     // Called before each test
     void setUp()
     {
-        if (debug) BESDebug::SetUp("cerr,dmrpp");
+        if (debug) BESDebug::SetUp("cerr,all");
+        BESDEBUG("dmrpp","BES debug enabled."<< endl);
     }
 
     // Called after each test
@@ -209,7 +210,7 @@ public:
         BESDEBUG("dmrpp", "Opening: " << int_h5 << endl);
 
         ifstream in(int_h5.c_str());
-        parser.intern(in, dmr.get(), debug);
+        parser.intern(in, dmr.get(), parser_debug);
         BESDEBUG("dmrpp", "Parsing complete"<< endl);
 
         D4Group *root = dmr->root();
@@ -300,7 +301,7 @@ public:
         BESDEBUG("dmrpp", "Opening: " << grid_h5 << endl);
 
         ifstream in(grid_h5.c_str());
-        parser.intern(in, dmr.get(), debug);
+        parser.intern(in, dmr.get(), parser_debug);
         BESDEBUG("dmrpp", "Parsing complete"<< endl);
 
         D4Group *root = dmr->root();
@@ -411,7 +412,7 @@ public:
         BESDEBUG("dmrpp", "Opening: " << grid_h5 << endl);
 
         ifstream in(grid_h5.c_str());
-        parser.intern(in, dmr.get(), debug);
+        parser.intern(in, dmr.get(), parser_debug);
         BESDEBUG("dmrpp", "Parsing complete"<< endl);
 
         D4Group *root = dmr->root();
@@ -576,7 +577,7 @@ public:
         BESDEBUG("dmrpp", "Opening: " << coads << endl);
 
         ifstream in(coads.c_str());
-        parser.intern(in, dmr.get(), debug);
+        parser.intern(in, dmr.get(), parser_debug);
         BESDEBUG("dmrpp", "Parsing complete"<< endl);
 
         // Check to make sure we have something that smells like coads_climatology
@@ -796,7 +797,7 @@ public:
         string coads = string(TEST_DATA_DIR).append("/").append("coads_climatology.dmrpp");
         BESDEBUG("dmrpp", "Opening: " << coads << endl);
         ifstream in(coads.c_str());
-        parser.intern(in, dmr.get(), debug);
+        parser.intern(in, dmr.get(), parser_debug);
         BESDEBUG("dmrpp", "Parsing complete"<< endl);
         // Check to make sure we have something that smells like coads_climatology
         D4Group *root = dmr->root();

--- a/modules/dmrpp_module/unit-tests/DmrppUtilTest.cc
+++ b/modules/dmrpp_module/unit-tests/DmrppUtilTest.cc
@@ -292,13 +292,11 @@ int main(int argc, char*argv[])
     }
     else {
         while (i < argc) {
-            test = string("dmrpp::DmrppUtilTest::") + argv[i++];
-
-            cerr << endl << "Running test " << test << endl << endl;
-
+            if (debug) cerr << "Running " << argv[i] << endl;
+            test = dmrpp::DmrppUtilTest::suite()->getName().append("::").append(argv[i]);
             wasSuccessful = wasSuccessful && runner.run(test);
+        ++i;
         }
     }
-
     return wasSuccessful ? 0 : 1;
 }


### PR DESCRIPTION
In this change we migrate away from using the hdf4 namespace to hold the chunking information to a dedicated dmrpp namespace. On this branch the parser no longer supports the dmrpp files that contain hdf4 namespace content. If we want the parser to support both representations we will need to do more work.