### PR TITLE
dmrpp mds

### DIFF
--- a/dap/BESDASResponseHandler.cc
+++ b/dap/BESDASResponseHandler.cc
@@ -83,7 +83,7 @@ BESDASResponseHandler::execute( BESDataHandlerInterface &dhi )
 
     if (mds && lock()) {
         // send the response
-        mds->get_das_response(dhi.container->get_real_name(), dhi.get_output_stream());
+        mds->write_das_response(dhi.container->get_real_name(), dhi.get_output_stream());
         // suppress transmitting a ResponseObject in transmit()
         d_response_object = 0;
     }

--- a/dap/BESDDSResponseHandler.cc
+++ b/dap/BESDDSResponseHandler.cc
@@ -85,7 +85,7 @@ void BESDDSResponseHandler::execute(BESDataHandlerInterface &dhi)
     if (mds && lock() && dhi.container->get_constraint().empty()) {
         // FIXME Does not work for constrained DDS requests
         // send the stored response
-        mds->get_dds_response(dhi.container->get_real_name(), dhi.get_output_stream());
+        mds->write_dds_response(dhi.container->get_real_name(), dhi.get_output_stream());
         // suppress transmitting a ResponseObject in transmit()
         d_response_object = 0;
     }

--- a/dap/BESDMRResponseHandler.cc
+++ b/dap/BESDMRResponseHandler.cc
@@ -92,7 +92,7 @@ void BESDMRResponseHandler::execute(BESDataHandlerInterface &dhi)
         // FIXME Does not work for constrained DMR requests
         BESDEBUG("dmr", __func__ << " Locked: " << dhi.container->get_real_name() << endl);
         // send the response
-        mds->get_dmr_response(dhi.container->get_real_name(), dhi.get_output_stream());
+        mds->write_dmr_response(dhi.container->get_real_name(), dhi.get_output_stream());
         // suppress transmitting a ResponseObject in transmit()
         d_response_object = 0;
     }
@@ -101,7 +101,7 @@ void BESDMRResponseHandler::execute(BESDataHandlerInterface &dhi)
     // however. And there are other things that are breaking still... jhrg 3/19/18
     else if (mds && lock() && !dhi.container->get_dap4_constraint().empty()) {  // with CE
         stringstream oss;
-        mds->get_dmr_response(dhi.container->get_real_name(), oss);
+        mds->write_dmr_response(dhi.container->get_real_name(), oss);
 
         DMR *dmr = new DMR(new D4BaseTypeFactory, "mds");
 

--- a/dap/GlobalMetadataStore.cc
+++ b/dap/GlobalMetadataStore.cc
@@ -813,12 +813,14 @@ GlobalMetadataStore::remove_responses(const string &name)
 
      bool removed_dmr = remove_response_helper(name, "dmr_r", "DMR");
 
+     bool removed_dmrpp = remove_response_helper(name, "dmrpp_r", "DMR++");
+
      write_ledger(); // write the index line
 
 #if SYMETRIC_ADD_RESPONSES
      return  (removed_dds && removed_das && removed_dmr);
 #else
-     return  (removed_dds || removed_das || removed_dmr);
+     return  (removed_dds || removed_das || removed_dmr || removed_dmrpp);
 #endif
 }
 

--- a/dap/GlobalMetadataStore.cc
+++ b/dap/GlobalMetadataStore.cc
@@ -59,11 +59,6 @@
 
 #include "GlobalMetadataStore.h"
 
-#if 0
-#include "DMRpp.h"
-#endif
-
-
 #define DEBUG_KEY "metadata_store"
 #define MAINTAIN_STORE_SIZE_EVEN_WHEN_UNLIMITED 0
 
@@ -313,23 +308,6 @@ GlobalMetadataStore::GlobalMetadataStore(const string &cache_dir, const string &
     unsigned long long size) : BESFileLockingCache(cache_dir, prefix, size)
 {
     initialize();
-
-#if 0
-    bool found;
-
-    TheBESKeys::TheKeys()->get_value(LEDGER_KEY, d_ledger_name, found);
-    if (found) {
-        BESDEBUG(DEBUG_KEY, "Located BES key " << LEDGER_KEY << "=" << d_ledger_name << endl);
-    }
-    else {
-        d_ledger_name = default_ledger_name;
-    }
-
-    // By default, use UTC in the logs.
-    string local_time = "no";
-    TheBESKeys::TheKeys()->get_value(LOCAL_TIME_KEY, local_time, found);
-    d_use_local_time = (local_time == "YES" || local_time == "Yes" || local_time == "yes");
-#endif
 }
 ///@}
 
@@ -426,27 +404,6 @@ void GlobalMetadataStore::StreamDMR::operator()(ostream &os)
         throw BESInternalFatalError("Unknown DAP object type.", __FILE__, __LINE__);
     }
 }
-
-#if 0
-void GlobalMetadataStore::StreamDMRpp::operator()(ostream &os)
-{
-    // Even though StreamDMRpp is-a StreamDAP and the latter has a d_dds
-    // field, we cannot use it for this version of the output operator.
-    // jhrg 5/17/18
-    if (d_dmr && typeid(*d_dmr) == typeid(dmrpp::DMRpp)) {
-        XMLWriter xml;
-        // FIXME This is where we will add the href that points toward the data file in S3. jhrg 5/17/18
-        string href = "";
-        static_cast<dmrpp::DMRpp*>(d_dmr)->print_dmrpp(xml, href);
-        os << xml.get_doc();
-    }
-    else {
-        throw BESInternalFatalError("StreamDMRpp output operator call with non-DMRpp instance.", __FILE__, __LINE__);
-
-    }
-}
-#endif
-
 
 /// @see GlobalMetadataStore::StreamDAP
 void GlobalMetadataStore::StreamDDS::operator()(ostream &os) {
@@ -634,18 +591,6 @@ GlobalMetadataStore::add_responses(DMR *dmr, const string &name)
 
     StreamDMR write_the_dmr_response(dmr);
     bool stored_dmr = store_dap_response(write_the_dmr_response, get_hash(name + "dmr_r"), name, "DMR");
-
-#if 0
-    bool stored_dmrpp = false;
-    if (typeid(*dmr) == typeid(dmrpp::DMRpp)) {
-        StreamDMRpp write_the_dmrpp_response(dmr);
-        stored_dmrpp = store_dap_response(write_the_dmrpp_response, get_hash(name + "dmrpp_r"), name, "DMRpp");
-    }
-    else {
-        stored_dmrpp = true;    // if dmr is not a DMRpp, not writing the object is 'success.'
-    }
-#endif
-
 
     write_ledger(); // write the index line
 

--- a/dap/GlobalMetadataStore.h
+++ b/dap/GlobalMetadataStore.h
@@ -82,7 +82,6 @@ class GlobalMetadataStore: public BESFileLockingCache {
 private:
     bool d_use_local_time;      // Base on BES.LogTimeLocal
     std::string d_ledger_name;  // Name of the ledger file
-    std::string d_ledger_entry; // Built up as info is added, written on success
 
     static bool d_enabled;
     static GlobalMetadataStore *d_instance;
@@ -97,6 +96,7 @@ private:
     friend class GlobalMetadataStoreTest;
 
 protected:
+    std::string d_ledger_entry; // Built up as info is added, written on success
     void write_ledger();
 
     std::string get_hash(const std::string &name);

--- a/dap/GlobalMetadataStore.h
+++ b/dap/GlobalMetadataStore.h
@@ -31,7 +31,10 @@
 #include "BESFileLockingCache.h"
 #include "BESInternalFatalError.h"
 
+#if 0
 #include "DMRpp.h"
+#endif
+
 
 namespace libdap {
 class DapObj;
@@ -39,9 +42,12 @@ class DDS;
 class DMR;
 }
 
+#if 0
 namespace dmrpp {
-class DMRpp;    // Added for DMR++ support. jhrg 5/17.18
+    class DMRpp;    // Added for DMR++ support. jhrg 5/17.18
 }
+#endif
+
 
 namespace bes {
 
@@ -99,6 +105,7 @@ private:
         d_instance = 0;
     }
 
+protected:
     void write_ledger();
 
     std::string get_hash(const std::string &name);
@@ -156,21 +163,11 @@ private:
         virtual void operator()(ostream &os);
     };
 
+#if 0
     /// Hack use a DMR to write a DMR++ response. WIP
     struct StreamDMRpp : public StreamDAP {
         // Making a StreamDMRpp with a DDS or DMR is not supported.
         StreamDMRpp(libdap::DMR *dmrpp) : StreamDAP(dmrpp) {}
-
-        virtual void operator()(ostream &os);
-    };
-#if 0
-    /// Instantiate with a DMRpp and write the DMRpp response.
-    /// @note this can only be built using a DMRpp, not a DDS or DMR.
-    /// DMRpp is a child of DMR, so teh StreamDAP parent can store the
-    /// DMRpp in the DMR* field.
-    struct StreamDMRpp : public StreamDAP {
-        // Making a StreamDMRpp with a DDS or DMR is not supported.
-        StreamDMRpp(dmrpp::DMRpp *dmrpp) : StreamDAP(dmrpp) {}
 
         virtual void operator()(ostream &os);
     };
@@ -205,14 +202,16 @@ public:
 
     typedef struct MDSReadLock MDSReadLock;
 
-private:
+protected:
     MDSReadLock get_read_lock_helper(const string &name, const string &suffix, const string &object_name);
 
     // Suppress the automatic generation of these ctors
-    GlobalMetadataStore();
     GlobalMetadataStore(const GlobalMetadataStore &src);
 
+    void initialize();
+
     // Only get_instance() should be used to instantiate this class
+    GlobalMetadataStore();
     GlobalMetadataStore(const std::string &cache_dir, const std::string &prefix, unsigned long long size);
 
     // these are static because they are called by the static method get_instance()

--- a/dap/GlobalMetadataStore.h
+++ b/dap/GlobalMetadataStore.h
@@ -219,7 +219,7 @@ protected:
     static string get_cache_prefix_from_config();
     static unsigned long get_cache_size_from_config();
 
-    friend class GlobalMetadataStoreTest;
+    friend class DmrppMetadataStoreTest;
 
 public:
     static GlobalMetadataStore *get_instance(const std::string &cache_dir, const std::string &prefix,

--- a/dap/Makefile.am
+++ b/dap/Makefile.am
@@ -9,7 +9,9 @@ AUTOMAKE_OPTIONS = foreign check-news
 ACLOCAL_AMFLAGS = -I conf
 
 AM_CPPFLAGS = $(XML2_CFLAGS) -I$(top_srcdir)/xmlcommand $(BES_CPPFLAGS) -I$(top_srcdir)/dispatch \
-$(DAP_CFLAGS) -I$(top_srcdir)/modules/dmrpp_module
+$(DAP_CFLAGS)
+
+#  -I$(top_srcdir)/modules/dmrpp_module
 
 AM_CXXFLAGS =
 

--- a/dap/Makefile.am
+++ b/dap/Makefile.am
@@ -8,7 +8,9 @@ AUTOMAKE_OPTIONS = foreign check-news
 
 ACLOCAL_AMFLAGS = -I conf
 
-AM_CPPFLAGS =  $(XML2_CFLAGS) -I$(top_srcdir)/xmlcommand
+AM_CPPFLAGS = $(XML2_CFLAGS) -I$(top_srcdir)/xmlcommand $(BES_CPPFLAGS) -I$(top_srcdir)/dispatch \
+$(DAP_CFLAGS) -I$(top_srcdir)/modules/dmrpp_module
+
 AM_CXXFLAGS =
 
 # These are not used by automake but are often useful for certain types of
@@ -98,9 +100,11 @@ BESDAP_HDRS = BESDASResponseHandler.h \
 	ShowPathInfoResponseHandler.h
 
 libdap_module_la_SOURCES = $(BESDAP_SRCS) $(BESDAP_HDRS)
-libdap_module_la_CPPFLAGS = $(BES_CPPFLAGS) -I$(top_srcdir)/dispatch $(DAP_CFLAGS)
+# libdap_module_la_CPPFLAGS = $(BES_CPPFLAGS) -I$(top_srcdir)/dispatch $(DAP_CFLAGS)
 libdap_module_la_LDFLAGS = -avoid-version -module 
 libdap_module_la_LIBADD = $(DAP_LIBS) $(LIBS)
+
+# $(top_builddir)/modules/dmrpp_module/libdmrpp_module.la
 
 pkginclude_HEADERS = $(BESDAP_HDRS) 
 

--- a/dap/unit-tests/GlobalMetadataStoreTest.cc
+++ b/dap/unit-tests/GlobalMetadataStoreTest.cc
@@ -85,7 +85,7 @@ static const string c_mds_prefix = "mds_"; // used when cleaning the cache, etc.
 static const string c_mds_name = "/mds";
 static const string c_mds_baselines = string(TEST_SRC_DIR) + "/mds_baselines";
 
-class GlobalMetadataStoreTest: public TestFixture {
+class DmrppMetadataStoreTest: public TestFixture {
 private:
     DDS *d_test_dds;
     BaseTypeFactory d_btf;
@@ -200,12 +200,12 @@ private:
 #endif
 
 public:
-    GlobalMetadataStoreTest() :
+    DmrppMetadataStoreTest() :
         d_test_dds(0), d_test_dmr(0), d_mds_dir(string(TEST_BUILD_DIR).append(c_mds_name)), d_mds(0)
     {
     }
 
-    ~GlobalMetadataStoreTest()
+    ~DmrppMetadataStoreTest()
     {
     }
 
@@ -882,7 +882,7 @@ public:
          DBG(cerr << __func__ << " - END" << endl);
      }
 
-    CPPUNIT_TEST_SUITE( GlobalMetadataStoreTest );
+    CPPUNIT_TEST_SUITE( DmrppMetadataStoreTest );
 
     CPPUNIT_TEST(ctor_test_1);
     CPPUNIT_TEST(ctor_test_2);
@@ -916,7 +916,7 @@ public:
     CPPUNIT_TEST_SUITE_END();
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(GlobalMetadataStoreTest);
+CPPUNIT_TEST_SUITE_REGISTRATION(DmrppMetadataStoreTest);
 
 }
 
@@ -939,8 +939,8 @@ int main(int argc, char*argv[])
             break;
         case 'h': {     // help - show test names
             cerr << "Usage: GlobalMetadataStoreTest has the following tests:" << endl;
-            const std::vector<Test*> &tests = bes::GlobalMetadataStoreTest::suite()->getTests();
-            unsigned int prefix_len = bes::GlobalMetadataStoreTest::suite()->getName().append("::").length();
+            const std::vector<Test*> &tests = bes::DmrppMetadataStoreTest::suite()->getTests();
+            unsigned int prefix_len = bes::DmrppMetadataStoreTest::suite()->getName().append("::").length();
             for (std::vector<Test*>::const_iterator i = tests.begin(), e = tests.end(); i != e; ++i) {
                 cerr << (*i)->getName().replace(0, prefix_len, "") << endl;
             }
@@ -963,7 +963,7 @@ int main(int argc, char*argv[])
     else {
         while (i < argc) {
             if (debug) cerr << "Running " << argv[i] << endl;
-            test = bes::GlobalMetadataStoreTest::suite()->getName().append("::").append(argv[i]);
+            test = bes::DmrppMetadataStoreTest::suite()->getName().append("::").append(argv[i]);
             wasSuccessful = wasSuccessful && runner.run(test);
 
             ++i;

--- a/dap/unit-tests/GlobalMetadataStoreTest.cc
+++ b/dap/unit-tests/GlobalMetadataStoreTest.cc
@@ -52,9 +52,11 @@
 
 #include "GlobalMetadataStore.h"
 
+#if 0
 #include "DMRpp.h"
 #include "DmrppTypeFactory.h"
 #include "DmrppParserSax2.h"
+#endif
 
 #include "test_utils.h"
 #include "test_config.h"
@@ -71,7 +73,10 @@ static bool clean = true;
 using namespace CppUnit;
 using namespace std;
 using namespace libdap;
+#if 0
 using namespace dmrpp;
+#endif
+
 
 namespace bes {
 
@@ -160,6 +165,7 @@ private:
         }
     }
 
+#if 0
     void init_dmrpp_and_mds()
     {
         try {
@@ -191,6 +197,7 @@ private:
             CPPUNIT_FAIL(e.what());
         }
     }
+#endif
 
 public:
     GlobalMetadataStoreTest() :
@@ -400,6 +407,7 @@ public:
         DBG(cerr << __func__ << " - END" << endl);
     }
 
+#if 0
     void cache_a_dmrpp_response()
     {
         DBG(cerr << __func__ << " - BEGIN" << endl);
@@ -434,6 +442,7 @@ public:
 
         DBG(cerr << __func__ << " - END" << endl);
     }
+#endif
 
     void add_response_test()
      {
@@ -882,7 +891,9 @@ public:
     CPPUNIT_TEST(cache_a_dds_response);
     CPPUNIT_TEST(cache_a_das_response);
     CPPUNIT_TEST(cache_a_dmr_response);
+#if 0
     CPPUNIT_TEST(cache_a_dmrpp_response);
+#endif
 
     CPPUNIT_TEST(add_response_test);
 

--- a/dap/unit-tests/GlobalMetadataStoreTest.cc
+++ b/dap/unit-tests/GlobalMetadataStoreTest.cc
@@ -545,7 +545,7 @@ public:
          DBG(cerr << __func__ << " - END" << endl);
     }
 
-    void get_dmr_response_test() {
+    void write_dmr_response_test() {
         DBG(cerr << __func__ << " - BEGIN" << endl);
 
          try {
@@ -899,7 +899,7 @@ public:
 
     CPPUNIT_TEST(get_dds_response_test);
     CPPUNIT_TEST(get_das_response_test);
-    CPPUNIT_TEST(get_dmr_response_test);
+    CPPUNIT_TEST(write_dmr_response_test);
 #if SYMETRIC_ADD_RESPONSES
     CPPUNIT_TEST(get_dmr_response_test_2);
 #endif

--- a/dap/unit-tests/GlobalMetadataStoreTest.cc
+++ b/dap/unit-tests/GlobalMetadataStoreTest.cc
@@ -496,7 +496,7 @@ public:
 
              // Now lets read the object from the cache
              ostringstream oss;
-             d_mds->get_dds_response(d_test_dds->get_dataset_name(), oss);
+             d_mds->write_dds_response(d_test_dds->get_dataset_name(), oss);
              DBG(cerr << "DDS response: " << endl << oss.str() << endl);
 
              string baseline_name = c_mds_baselines + "/" + c_mds_prefix + "SimpleTypes.dds_r";
@@ -527,7 +527,7 @@ public:
 
              // Now lets read the object from the cache
              ostringstream oss;
-             d_mds->get_das_response(d_test_dds->get_dataset_name(), oss);
+             d_mds->write_das_response(d_test_dds->get_dataset_name(), oss);
              DBG(cerr << "DAS response: " << endl << oss.str() << endl);
 
              string baseline_name = c_mds_baselines + "/" + c_mds_prefix + "SimpleTypes.das_r";
@@ -558,7 +558,7 @@ public:
 
              // Now lets read the object from the cache
              ostringstream oss;
-             d_mds->get_dmr_response(d_test_dmr->name(), oss);
+             d_mds->write_dmr_response(d_test_dmr->name(), oss);
              DBG(cerr << "DMR response: " << endl << oss.str() << endl);
 
              string baseline_name = c_mds_baselines + "/" + c_mds_prefix + "test_01.dmr_r";
@@ -590,7 +590,7 @@ public:
 
              // Now lets read the object from the cache
              ostringstream oss;
-             d_mds->get_dmr_response(d_test_dds->get_dataset_name(), oss);
+             d_mds->write_dmr_response(d_test_dds->get_dataset_name(), oss);
              DBG(cerr << "DMR response: " << endl << oss.str() << endl);
 
              string baseline_name = c_mds_baselines + "/" + c_mds_prefix + "SimpleTypes.dmr_r";

--- a/dap/unit-tests/Makefile.am
+++ b/dap/unit-tests/Makefile.am
@@ -5,8 +5,10 @@ AUTOMAKE_OPTIONS = foreign
 
 # Headers in 'tests' are used by the arrayT unit tests.
 
-AM_CPPFLAGS = -I$(top_srcdir)/dap -I$(top_srcdir)/dispatch $(DAP_CFLAGS) 
-LDADD =  $(top_builddir)/dispatch/libbes_dispatch.la -ltest-types $(DAP_LIBS) $(LIBS)
+AM_CPPFLAGS = -I$(top_srcdir)/dap -I$(top_srcdir)/dispatch $(DAP_CFLAGS) \
+-I$(top_srcdir)/modules/dmrpp_module
+
+LDADD =  $(top_builddir)/dispatch/libbes_dispatch.la $(top_builddir)/modules/dmrpp_module/libdmrpp_module.la -ltest-types $(DAP_LIBS) $(LIBS)
 
 if CPPUNIT
 AM_CPPFLAGS += $(CPPUNIT_CFLAGS)
@@ -118,7 +120,7 @@ TemporaryFileTest_LDADD = $(TemporaryFileTest_OBJS) $(LDADD)
 
 GlobalMetadataStoreTest_SOURCES = GlobalMetadataStoreTest.cc $(TEST_SRC)
 GlobalMetadataStoreTest_OBJS = ../GlobalMetadataStore.o ../TempFile.o
-GlobalMetadataStoreTest_LDADD = $(GlobalMetadataStoreTest_OBJS) $(LDADD)
+GlobalMetadataStoreTest_LDADD = $(GlobalMetadataStoreTest_OBJS) ../libdap_module.la $(LDADD)
 
 # StoredDap2ResultTest_SOURCES = StoredDap2ResultTest.cc  $(TEST_SRC)
 # StoredDap2ResultTest_LDADD = $(LDADD)

--- a/dap/unit-tests/Makefile.am
+++ b/dap/unit-tests/Makefile.am
@@ -8,7 +8,8 @@ AUTOMAKE_OPTIONS = foreign
 AM_CPPFLAGS = -I$(top_srcdir)/dap -I$(top_srcdir)/dispatch $(DAP_CFLAGS) \
 -I$(top_srcdir)/modules/dmrpp_module
 
-LDADD =  $(top_builddir)/dispatch/libbes_dispatch.la $(top_builddir)/modules/dmrpp_module/libdmrpp_module.la -ltest-types $(DAP_LIBS) $(LIBS)
+LDADD = $(top_builddir)/dispatch/libbes_dispatch.la \
+$(top_builddir)/modules/dmrpp_module/libdmrpp_module.la -ltest-types $(DAP_LIBS) $(LIBS)
 
 if CPPUNIT
 AM_CPPFLAGS += $(CPPUNIT_CFLAGS)

--- a/dap/unit-tests/input-files/chunked_fourD.h5.dmrpp
+++ b/dap/unit-tests/input-files/chunked_fourD.h5.dmrpp
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Dataset 
+    xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    dapVersion="4.0" 
+    dmrVersion="1.0" 
+    name="chunked_fourD.h5"
+    dmrpp:href="data/dmrpp/chunked_fourD.h5">
+  <Float32 name="d_16_chunks">
+    <Dim size="40"/>
+    <Dim size="40"/>
+    <Dim size="40"/>
+    <Dim size="40"/>
+    <Attribute name="origname" type="String">
+      <Value>d_16_chunks</Value>
+    </Attribute>
+    <Attribute name="fullnamepath" type="String">
+      <Value>/d_16_chunks</Value>
+    </Attribute>
+    <dmrpp:chunks>
+      <dmrpp:chunkDimensionSizes>20 20 20 20</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk offset="4728"  nBytes="640000" chunkPositionInArray="[0,0,0,0]" />
+      <dmrpp:chunk offset="644728"  nBytes="640000" chunkPositionInArray="[0,0,0,20]" />
+      <dmrpp:chunk offset="1284728"  nBytes="640000" chunkPositionInArray="[0,0,20,0]" />
+      <dmrpp:chunk offset="1924728"  nBytes="640000" chunkPositionInArray="[0,0,20,20]" />
+      <dmrpp:chunk offset="2564728"  nBytes="640000" chunkPositionInArray="[0,20,0,0]" />
+      <dmrpp:chunk offset="3204728"  nBytes="640000" chunkPositionInArray="[0,20,0,20]" />
+      <dmrpp:chunk offset="3844728"  nBytes="640000" chunkPositionInArray="[0,20,20,0]" />
+      <dmrpp:chunk offset="4484728"  nBytes="640000" chunkPositionInArray="[0,20,20,20]" />
+      <dmrpp:chunk offset="5124728"  nBytes="640000" chunkPositionInArray="[20,0,0,0]" />
+      <dmrpp:chunk offset="5764728"  nBytes="640000" chunkPositionInArray="[20,0,0,20]" />
+      <dmrpp:chunk offset="6404728"  nBytes="640000" chunkPositionInArray="[20,0,20,0]" />
+      <dmrpp:chunk offset="7044728"  nBytes="640000" chunkPositionInArray="[20,0,20,20]" />
+      <dmrpp:chunk offset="7684728"  nBytes="640000" chunkPositionInArray="[20,20,0,0]" />
+      <dmrpp:chunk offset="8324728"  nBytes="640000" chunkPositionInArray="[20,20,0,20]" />
+      <dmrpp:chunk offset="8964728"  nBytes="640000" chunkPositionInArray="[20,20,20,0]" />
+      <dmrpp:chunk offset="9606776"  nBytes="640000" chunkPositionInArray="[20,20,20,20]" />
+    </dmrpp:chunks>
+  </Float32>
+</Dataset>

--- a/dap/unit-tests/mds_baselines/mds_chunked_fourD.h5.dmrpp_r
+++ b/dap/unit-tests/mds_baselines/mds_chunked_fourD.h5.dmrpp_r
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="chunked_fourD.h5">
+    <Float32 name="d_16_chunks">
+        <Dim size="40"/>
+        <Dim size="40"/>
+        <Dim size="40"/>
+        <Dim size="40"/>
+        <Attribute name="origname" type="String">
+            <Value>d_16_chunks</Value>
+        </Attribute>
+        <Attribute name="fullnamepath" type="String">
+            <Value>/d_16_chunks</Value>
+        </Attribute>
+        <dmrpp:chunks>
+            <dmrpp:chunkDimensionSizes>20 20 20 20</dmrpp:chunkDimensionSizes>
+            <dmrpp:chunk offset="4728" nBytes="640000" chunkPositionInArray="[0,0,0,0]"/>
+            <dmrpp:chunk offset="644728" nBytes="640000" chunkPositionInArray="[0,0,0,20]"/>
+            <dmrpp:chunk offset="1284728" nBytes="640000" chunkPositionInArray="[0,0,20,0]"/>
+            <dmrpp:chunk offset="1924728" nBytes="640000" chunkPositionInArray="[0,0,20,20]"/>
+            <dmrpp:chunk offset="2564728" nBytes="640000" chunkPositionInArray="[0,20,0,0]"/>
+            <dmrpp:chunk offset="3204728" nBytes="640000" chunkPositionInArray="[0,20,0,20]"/>
+            <dmrpp:chunk offset="3844728" nBytes="640000" chunkPositionInArray="[0,20,20,0]"/>
+            <dmrpp:chunk offset="4484728" nBytes="640000" chunkPositionInArray="[0,20,20,20]"/>
+            <dmrpp:chunk offset="5124728" nBytes="640000" chunkPositionInArray="[20,0,0,0]"/>
+            <dmrpp:chunk offset="5764728" nBytes="640000" chunkPositionInArray="[20,0,0,20]"/>
+            <dmrpp:chunk offset="6404728" nBytes="640000" chunkPositionInArray="[20,0,20,0]"/>
+            <dmrpp:chunk offset="7044728" nBytes="640000" chunkPositionInArray="[20,0,20,20]"/>
+            <dmrpp:chunk offset="7684728" nBytes="640000" chunkPositionInArray="[20,20,0,0]"/>
+            <dmrpp:chunk offset="8324728" nBytes="640000" chunkPositionInArray="[20,20,0,20]"/>
+            <dmrpp:chunk offset="8964728" nBytes="640000" chunkPositionInArray="[20,20,20,0]"/>
+            <dmrpp:chunk offset="9606776" nBytes="640000" chunkPositionInArray="[20,20,20,20]"/>
+        </dmrpp:chunks>
+    </Float32>
+</Dataset>

--- a/modules/dmrpp_module/DMRpp.cc
+++ b/modules/dmrpp_module/DMRpp.cc
@@ -25,22 +25,20 @@
 
 #include <XMLWriter.h>
 #include <D4Group.h>
+#include <D4BaseTypeFactory.h>
 #include <InternalErr.h>
 
 #include "DMRpp.h"
 #include "DmrppCommon.h"
+#include "DmrppTypeFactory.h"
 
 using namespace libdap;
 
 namespace dmrpp {
 
-#if 0
-/**
- * @brief The DMR++ namespace.
- */
-const string dmrpp_namespace = "http://xml.opendap.org/dap/dmrpp/1.0.0#";
-#endif
-
+DMRpp::DMRpp(DmrppTypeFactory *factory, const std::string &name) : DMR(factory, name)
+{
+}
 
 /**
  * @brief Print the DMR++ response

--- a/modules/dmrpp_module/DMRpp.h
+++ b/modules/dmrpp_module/DMRpp.h
@@ -34,12 +34,18 @@ class XMLWriter;
 
 namespace dmrpp {
 
+class DmrppTypeFactory;
+
 /**
  * @brief Provide a way to print the DMR++ response
  */
 class DMRpp : public libdap::DMR {
 public:
-    DMRpp() { }
+    DMRpp() : DMR() { }
+    DMRpp(const DMRpp &dmrpp) : DMR(dmrpp) { }
+
+    DMRpp(DmrppTypeFactory *factory, const std::string &name = "");
+
     virtual ~DMRpp() { }
 
     virtual void print_dmrpp(libdap::XMLWriter &xml, const std::string &href ="", bool constrained = false, bool print_chunks = true);

--- a/modules/dmrpp_module/DmrppMetadataStore.cc
+++ b/modules/dmrpp_module/DmrppMetadataStore.cc
@@ -279,31 +279,28 @@ DmrppMetadataStore::add_responses(DMR *dmr, const string &name)
 }
 ///@}
 
-
-#if 0
 /**
- * @brief Is the DMR response for \arg name in the MDS?
+ * @brief Is the DMR++ response for \arg name in the MDS?
  *
- * Look in the MDS to see if the DMR response has been stored/cached for
+ * Look in the MDS to see if the DMR++ response has been stored/cached for
  * \arg name.
  *
- * @note This method and the matching methods for the DDS and DAS use LOG()
+ * @note This method uses LOG()
  * to record cache hits and misses. Other methods also record information
  * about cache hits, but only using VERBOSE(), so that output will not show
  * up in a normal log.
  *
- * @param name Find the DMR response for \arg name.
+ * @param name Find the DMR++ response for \arg name.
  * @return A MDSReadLock object. This object is true if the item was found
  * (and a read lock was obtained), false if either of those things are not
  * true. When the MDSReadLock object goes out of scope, the read lock is
  * released.
  */
 DmrppMetadataStore::MDSReadLock
-DmrppMetadataStore::is_dmr_available(const string &name)
+DmrppMetadataStore::is_dmrpp_available(const string &name)
 {
-    return get_read_lock_helper(name, "dmr_r", "DMR");
+    return get_read_lock_helper(name, "dmrpp_r", "DMR++");
 }
-#endif
 
 #if 0
 /**

--- a/modules/dmrpp_module/DmrppMetadataStore.cc
+++ b/modules/dmrpp_module/DmrppMetadataStore.cc
@@ -1,0 +1,383 @@
+// -*- mode: c++; c-basic-offset:4 -*-
+
+// This file is part of HYrax, A C++ implementation of the OPeNDAP Data
+// Access Protocol.
+
+// Copyright (c) 2018 OPeNDAP, Inc.
+// Author: James Gallagher <jgallagher@opendap.org>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+// You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+
+#include "config.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+
+#include <iostream>
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <functional>
+#include <memory>
+
+#include <DapObj.h>
+#include <DDS.h>
+#include <DAS.h>
+#include <DMR.h>
+#include <D4ParserSax2.h>
+#include <XMLWriter.h>
+#include <BaseTypeFactory.h>
+#include <D4BaseTypeFactory.h>
+
+#include "PicoSHA2/picosha2.h"
+
+#include "TempFile.h"
+#include "TheBESKeys.h"
+#include "BESUtil.h"
+#include "BESLog.h"
+#include "BESDebug.h"
+
+#include "BESInternalError.h"
+#include "BESInternalFatalError.h"
+
+#include "DmrppMetadataStore.h"
+
+#include "DMRpp.h"
+
+
+#define DEBUG_KEY "dmrpp_store"
+#define MAINTAIN_STORE_SIZE_EVEN_WHEN_UNLIMITED 0
+
+#ifdef HAVE_ATEXIT
+#define AT_EXIT(x) atexit((x))
+#else
+#define AT_EXIT(x)
+#endif
+
+/// If SYMETRIC_ADD_RESPONSES is defined and a true value, then add_responses()
+/// will add all of DDS, DAS and DMR when called with _either_ the DDS or DMR
+/// objects. If it is not defined (or false), add_responses() called with a DDS
+/// will add only the DDS and DAS and add_responses() called with a DMR will add
+/// only a DMR.
+///
+/// There are slight differences in the DAS objects build by the DMR and DDS,
+/// especially when the underlying dataset contains types that can be encoded
+/// in the DMR (DAP4) but not the DDS (DAP2). jhrg 3/20/18
+#undef SYMETRIC_ADD_RESPONSES
+
+using namespace std;
+using namespace libdap;
+using namespace bes;
+
+using namespace dmrpp;
+
+#if 0
+static const unsigned int default_cache_size = 20; // 20 GB
+static const string default_cache_prefix = "mds";
+static const string default_cache_dir = "";// I'm making the default empty so that no key == no caching. jhrg 9.26.16
+static const string default_ledger_name = "mds_ledger.txt";///< In the CWD of the BES process
+
+static const string PATH_KEY = "DAP.DmrppMetadataStore.path";
+static const string PREFIX_KEY = "DAP.DmrppMetadataStore.prefix";
+static const string SIZE_KEY = "DAP.DmrppMetadataStore.size";
+static const string LEDGER_KEY = "DAP.DmrppMetadataStore.ledger";
+static const string LOCAL_TIME_KEY = "BES.LogTimeLocal";
+#endif
+
+
+DmrppMetadataStore *DmrppMetadataStore::d_instance = 0;
+bool DmrppMetadataStore::d_enabled = true;
+
+/**
+ * @name Get an instance of DmrppMetadataStore
+ * @brief  There are two ways to get an instance of DmrppMetadataStore singleton.
+ *
+ * @note If the cache_dir parameter is the empty string, get_instance() will return null
+ * for the pointer to the singleton and caching is disabled. This means that if the cache
+ * directory is not set in the bes.conf file(s), then the cache will be disabled. If
+ * the cache directory is given (or set in bes.conf) but the prefix or size is not,
+ * that's an error. If the directory is named but does not exist, it will
+ * be made. If the BES cannot make it, then an error will be signaled.
+ *
+ * @return A pointer to a DmrppMetadataStore object; null if the cache is disabled.
+ */
+///@{
+/**
+ * @brief Get an instance of the DmrppMetadataStore object.
+ *
+ * This class is a singleton, so the first call to any of two 'get_instance()' methods
+ * makes an instance and subsequent calls return a pointer to that instance.
+ *
+ * @param cache_dir_key Key to use to get the value of the cache directory. If this is
+ * the empty string, return null right away.
+ * @param prefix_key Key for the item/file prefix. Each item added to the cache uses this
+ * as a prefix so cached items can be easily identified when the same directory is used for
+ * several caches or /tmp is used for the cache.
+ * @param size_key The maximum size of the data stored in the cache, in megabytes
+ *
+ * @return A pointer to a DmrppMetadataStore object. If the cache is disabled, then
+ * the pointer returned will be null and the cache will be marked as not enabled.
+ * Subsequent calls will return immediately.
+ */
+DmrppMetadataStore *
+DmrppMetadataStore::get_instance(const string &cache_dir, const string &prefix, unsigned long long size)
+{
+    if (d_enabled && d_instance == 0) {
+        d_instance = new DmrppMetadataStore(cache_dir, prefix, size); // never returns null_ptr
+        d_enabled = d_instance->cache_enabled();
+        if (!d_enabled) {
+            delete d_instance;
+            d_instance = 0;
+
+            BESDEBUG(DEBUG_KEY, "DmrppMetadataStore::"<<__func__ << "() - " << "Cache is DISABLED"<< endl);
+        }
+        else {
+            AT_EXIT(delete_instance);
+
+            BESDEBUG(DEBUG_KEY, "DmrppMetadataStore::"<<__func__ << "() - " << "Cache is ENABLED"<< endl);
+        }
+    }
+
+    BESDEBUG(DEBUG_KEY, "DmrppMetadataStore::get_instance(dir,prefix,size) - d_instance: " << d_instance << endl);
+
+    return d_instance;
+}
+
+/**
+ * Get an instance of the DmrppMetadataStore using the default values for the cache directory,
+ * prefix and size.
+ *
+ * @return A pointer to a DmrppMetadataStore object; null if the cache is disabled.
+ */
+DmrppMetadataStore *
+DmrppMetadataStore::get_instance()
+{
+    if (d_enabled && d_instance == 0) {
+        d_instance = new DmrppMetadataStore();
+        d_enabled = d_instance->cache_enabled();
+        if (!d_enabled) {
+            delete d_instance;
+            d_instance = NULL;
+            BESDEBUG(DEBUG_KEY, "DmrppMetadataStore::"<<__func__ << "() - " << "Cache is DISABLED"<< endl);
+        }
+        else {
+            AT_EXIT(delete_instance);
+
+            BESDEBUG(DEBUG_KEY, "DmrppMetadataStore::"<<__func__ << "() - " << "Cache is ENABLED"<< endl);
+        }
+    }
+
+    BESDEBUG(DEBUG_KEY, "DmrppMetadataStore::get_instance() - d_instance: " << (void *) d_instance << endl);
+
+    return d_instance;
+}
+///@}
+
+void DmrppMetadataStore::StreamDMRpp::operator()(ostream &os)
+{
+    // Even though StreamDMRpp is-a StreamDAP and the latter has a d_dds
+    // field, we cannot use it for this version of the output operator.
+    // jhrg 5/17/18
+    if (d_dmr && typeid(*d_dmr) == typeid(dmrpp::DMRpp)) {
+        XMLWriter xml;
+        // FIXME This is where we will add the href that points toward the data file in S3. jhrg 5/17/18
+        string href = "";
+        static_cast<dmrpp::DMRpp*>(d_dmr)->print_dmrpp(xml, href);
+        os << xml.get_doc();
+    }
+    else {
+        throw BESInternalFatalError("StreamDMRpp output operator call with non-DMRpp instance.", __FILE__, __LINE__);
+    }
+}
+
+
+/**
+ * @name Add responses to the DmrppMetadataStore
+ *
+ * These methods use a DDS or DMR object to generate the DDS, DAS and DMR responses
+ * for DAP (2 and 4). They store those in the MDS and then update the
+ * MDS ledger file with the operation (add), the kind of object used
+ * to build the responses (DDS or DMR), name of the granule and hashes/names
+ * for each of the three files in the MDS that hold the responses.
+ *
+ * If verbose logging is on, the bes log also will hold information about
+ * the operation. If there is an error, that will always be recorded in
+ * the bes log.
+ */
+///@{
+
+
+/**
+ * @brief Add the DAP4 metadata responses using a DMR
+ *
+ * This method adds only the DMR unless the code was compiled with
+ * the symbol SYMETRIC_ADD_RESPONSES defined.
+ *
+ * @param name The granule name or identifier
+ * @param dmr A DMR built from the granule
+ * @return True if all of the cache/store entry was written, False if any
+ * could not be written.
+ */
+bool
+DmrppMetadataStore::add_responses(DMR *dmr, const string &name)
+{
+    // Start the index entry
+    // FIXME d_ledger_entry is private: d_ledger_entry = string("add DMR ").append(name);
+
+    // I'm appending the 'dds r' string to the name before hashing so that
+    // the different hashes for the file's DDS, DAS, ..., are all very different.
+    // This will be useful if we use S3 instead of EFS for the Metadata Store.
+    //
+    // The helper() also updates the ledger string.
+#if SYMETRIC_ADD_RESPONSES
+    StreamDDS write_the_dds_response(dmr);
+    bool stored_dds = store_dap_response(write_the_dds_response, get_hash(name + "dds_r"), name, "DDS");
+
+    StreamDAS write_the_das_response(dmr);
+    bool stored_das = store_dap_response(write_the_das_response, get_hash(name + "das_r"), name, "DAS");
+#endif
+
+    StreamDMR write_the_dmr_response(dmr);
+    bool stored_dmr = store_dap_response(write_the_dmr_response, get_hash(name + "dmr_r"), name, "DMR");
+
+#if 1
+    bool stored_dmrpp = false;
+    if (typeid(*dmr) == typeid(dmrpp::DMRpp)) {
+        StreamDMRpp write_the_dmrpp_response(dmr);
+        stored_dmrpp = store_dap_response(write_the_dmrpp_response, get_hash(name + "dmrpp_r"), name, "DMRpp");
+    }
+    else {
+        stored_dmrpp = true;    // if dmr is not a DMRpp, not writing the object is 'success.'
+    }
+#endif
+
+
+    write_ledger(); // write the index line
+
+#if SYMETRIC_ADD_RESPONSES
+    return (stored_dds && stored_das && stored_dmr);
+#else
+    return(stored_dmr && stored_dmrpp);
+#endif
+}
+///@}
+
+
+#if 0
+/**
+ * @brief Is the DMR response for \arg name in the MDS?
+ *
+ * Look in the MDS to see if the DMR response has been stored/cached for
+ * \arg name.
+ *
+ * @note This method and the matching methods for the DDS and DAS use LOG()
+ * to record cache hits and misses. Other methods also record information
+ * about cache hits, but only using VERBOSE(), so that output will not show
+ * up in a normal log.
+ *
+ * @param name Find the DMR response for \arg name.
+ * @return A MDSReadLock object. This object is true if the item was found
+ * (and a read lock was obtained), false if either of those things are not
+ * true. When the MDSReadLock object goes out of scope, the read lock is
+ * released.
+ */
+DmrppMetadataStore::MDSReadLock
+DmrppMetadataStore::is_dmr_available(const string &name)
+{
+    return get_read_lock_helper(name, "dmr_r", "DMR");
+}
+#endif
+
+#if 0
+/**
+ * @brief Write the stored DMR response to a stream
+ *
+ * @param name The (path)name of the granule
+ * @param os Write to this stream
+ */
+void
+DmrppMetadataStore::get_dmr_response(const std::string &name, ostream &os)
+{
+    get_response_helper(name, os, "dmr_r", "DMR");
+}
+#endif
+
+#if 0
+/**
+ * @brief Remove all cached responses and objects for a granule
+ *
+ * @param name
+ * @return
+ */
+bool
+DmrppMetadataStore::remove_responses(const string &name)
+{
+    // Start the index entry
+    d_ledger_entry = string("remove ").append(name);
+
+    bool removed_dds = remove_response_helper(name, "dds_r", "DDS");
+
+    bool removed_das = remove_response_helper(name, "das_r", "DAS");
+
+    bool removed_dmr = remove_response_helper(name, "dmr_r", "DMR");
+
+    write_ledger();// write the index line
+
+#if SYMETRIC_ADD_RESPONSES
+    return (removed_dds && removed_das && removed_dmr);
+#else
+    return (removed_dds || removed_das || removed_dmr);
+#endif
+}
+#endif
+
+
+#if 0
+/**
+ * @brief Build a DMR object from the cached Response
+ *
+ * Read and parse a DMR response , building a binary DMR object. The
+ * object is returned with a null factory. The variables are built using
+ * the default DAP4 type factory.
+ *
+ * @param name Name of the dataset
+ * @return A pointer to the DMR object; the caller must delete this object.
+ * @exception BESInternalError is thrown if \arg name does not have a
+ * cached DMR response.
+ */
+DMR *
+DmrppMetadataStore::get_dmr_object(const string &name)
+{
+    stringstream oss;
+    get_dmr_response(name, oss);    // throws BESInternalError if not found
+
+    D4BaseTypeFactory d4_btf;
+    auto_ptr<DMR> dmr(new DMR(&d4_btf, "mds"));
+
+    D4ParserSax2 parser;
+    parser.intern(oss.str(), dmr.get());
+
+    dmr->set_factory(0);
+
+    return dmr.release();
+}
+#endif
+
+

--- a/modules/dmrpp_module/DmrppMetadataStore.cc
+++ b/modules/dmrpp_module/DmrppMetadataStore.cc
@@ -24,39 +24,20 @@
 
 #include "config.h"
 
-#include <fcntl.h>
-#include <unistd.h>
-
-#include <cerrno>
-#include <cstring>
-
 #include <iostream>
 #include <string>
-#include <fstream>
 #include <sstream>
-#include <functional>
 #include <memory>
 
-#include <DapObj.h>
-#include <DDS.h>
-#include <DAS.h>
 #include <DMR.h>
-#include <D4ParserSax2.h>
 #include <XMLWriter.h>
-#include <BaseTypeFactory.h>
-#include <D4BaseTypeFactory.h>
 
-#include "PicoSHA2/picosha2.h"
-
-#include "TempFile.h"
-#include "TheBESKeys.h"
-#include "BESUtil.h"
-#include "BESLog.h"
 #include "BESDebug.h"
 
-#include "BESInternalError.h"
 #include "BESInternalFatalError.h"
 
+#include "DmrppParserSax2.h"
+#include "DmrppTypeFactory.h"
 #include "DmrppMetadataStore.h"
 
 #include "DMRpp.h"
@@ -243,34 +224,34 @@ DmrppMetadataStore::add_responses(DMR *dmr, const string &name)
 #endif
 }
 
-#if 0
+#if 1
 /**
- * @brief Build a DMR object from the cached Response
+ * @brief Build a DMR++ object from the cached Response
  *
- * Read and parse a DMR response , building a binary DMR object. The
+ * Read and parse a DMR++ response , building a binary DMR++ object. The
  * object is returned with a null factory. The variables are built using
- * the default DAP4 type factory.
+ * DmrppTypeFactory
  *
  * @param name Name of the dataset
  * @return A pointer to the DMR object; the caller must delete this object.
  * @exception BESInternalError is thrown if \arg name does not have a
  * cached DMR response.
  */
-DMR *
-DmrppMetadataStore::get_dmr_object(const string &name)
+DMRpp *
+DmrppMetadataStore::get_dmrpp_object(const string &name)
 {
     stringstream oss;
-    get_dmr_response(name, oss);    // throws BESInternalError if not found
+    write_dmrpp_response(name, oss);    // throws BESInternalError if not found
 
-    D4BaseTypeFactory d4_btf;
-    auto_ptr<DMR> dmr(new DMR(&d4_btf, "mds"));
+    DmrppTypeFactory dmrpp_btf;
+    auto_ptr<DMRpp> dmrpp(new DMRpp(&dmrpp_btf, "mds"));
 
-    D4ParserSax2 parser;
-    parser.intern(oss.str(), dmr.get());
+    DmrppParserSax2 parser;
+    parser.intern(oss.str(), dmrpp.get());
 
-    dmr->set_factory(0);
+    dmrpp->set_factory(0);
 
-    return dmr.release();
+    return dmrpp.release();
 }
 #endif
 

--- a/modules/dmrpp_module/DmrppMetadataStore.h
+++ b/modules/dmrpp_module/DmrppMetadataStore.h
@@ -87,21 +87,6 @@ private:
     friend class DmrppMetadataStoreTest;
 
 protected:
-#if 0
-    struct StreamDAP : public std::unary_function<libdap::DapObj*, void> {
-        libdap::DDS *d_dds;
-        libdap::DMR *d_dmr;
-
-        StreamDAP() {
-            throw BESInternalFatalError("Unknown DAP object type.", __FILE__, __LINE__);
-        }
-        StreamDAP(libdap::DDS *dds) : d_dds(dds), d_dmr(0) {}
-        StreamDAP(libdap::DMR *dmr) : d_dds(0), d_dmr(dmr) {}
-
-        virtual void operator()(std::ostream &os) = 0;
-    };
-#endif
-
     /// Hack use a DMR to write a DMR++ response. WIP
     struct StreamDMRpp : public StreamDAP {
         // Making a StreamDMRpp with a DDS or DMR is not supported.
@@ -127,15 +112,7 @@ public:
 
     virtual bool add_responses(libdap::DMR *dmrpp, const std::string &name);
 
-    virtual MDSReadLock is_dmrpp_available(const std::string &name);
-
 #if 0
-    // Add a third parameter to enable changing the value of xmlbase in this response.
-    // jhrg 2.28.18
-    virtual void get_dmrpp_response(const std::string &name, std::ostream &os);
-
-    virtual bool remove_responses(const std::string &name);
-
     virtual dmrpp::DMRpp *get_dmrpp_object(const std::string &name);
 #endif
 

--- a/modules/dmrpp_module/DmrppMetadataStore.h
+++ b/modules/dmrpp_module/DmrppMetadataStore.h
@@ -1,0 +1,144 @@
+// -*- mode: c++; c-basic-offset:4 -*-
+
+// This file is part of Hyrax, A C++ implementation of the OPeNDAP Data
+// Access Protocol.
+
+// Copyright (c) 2018 OPeNDAP, Inc.
+// Author: James Gallagher <jgallagher@opendap.org>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+// You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+
+#ifndef _dmrpp_metadata_store_h
+#define _dmrpp_metadata_store_h
+
+#include <string>
+//#include <functional>
+
+#include "GlobalMetadataStore.h"
+
+//#include "DMRpp.h"
+
+namespace libdap {
+class DMR;
+}
+
+namespace dmrpp {
+class DMRpp;
+}
+
+namespace bes {
+
+/**
+ * @brief Store the DAP metadata responses.
+ *
+ * Provide a global persistent store for the DAP metadata responses. Using either
+ * a DDS or a DMR, write the three DAP metadata responses to the global metadata
+ * store. This class also provides methods to get those responses and write them
+ * to an output stream and a method to remove the responses.
+ *
+ * The class maintains a ledger of 'add' and 'remove' operations.
+ *
+ * The class is implemented as a singleton; use the get_instance() methods to
+ * get an instance of the metadata store.
+ *
+ * BES Keys used:
+ * - _DAP.GlobalMetadataStore.path_: store root directory (assumes the store is
+ *   using a POSIX file system)
+ *
+ * - _DAP.GlobalMetadataStore.prefix_: prefix for the names of items in the store
+ *
+ * - _DAP.GlobalMetadataStore.size_: Maximum size of the store. Zero indicates
+ *   unlimited size.
+ *
+ * - _DAP.GlobalMetadataStore.ledger_: Name of the ledger. A relative pathname.
+ *   will be interpreted as relative to the directory where the BES was started.
+ *   The default name mds_ledger.txt
+ *
+ * - _BES.LogTimeLocal_: Use local or GMT time for the ledger entries; default is
+ *   to use GMT
+ *
+ * @author jhrg
+ */
+class DmrppMetadataStore: public bes::GlobalMetadataStore {
+private:
+    static bool d_enabled;
+    static DmrppMetadataStore *d_instance;
+
+    // Called by atexit()
+    static void delete_instance() {
+        delete d_instance;
+        d_instance = 0;
+    }
+
+protected:
+#if 0
+    struct StreamDAP : public std::unary_function<libdap::DapObj*, void> {
+        libdap::DDS *d_dds;
+        libdap::DMR *d_dmr;
+
+        StreamDAP() {
+            throw BESInternalFatalError("Unknown DAP object type.", __FILE__, __LINE__);
+        }
+        StreamDAP(libdap::DDS *dds) : d_dds(dds), d_dmr(0) {}
+        StreamDAP(libdap::DMR *dmr) : d_dds(0), d_dmr(dmr) {}
+
+        virtual void operator()(std::ostream &os) = 0;
+    };
+#endif
+
+    /// Hack use a DMR to write a DMR++ response. WIP
+    struct StreamDMRpp : public StreamDAP {
+        // Making a StreamDMRpp with a DDS or DMR is not supported.
+        StreamDMRpp(libdap::DMR *dmrpp) : StreamDAP(dmrpp) {}
+
+        virtual void operator()(std::ostream &os);
+    };
+
+    DmrppMetadataStore(const DmrppMetadataStore &src) : bes::GlobalMetadataStore(src) { }
+
+    // Only get_instance() should be used to instantiate this class
+    DmrppMetadataStore() : bes::GlobalMetadataStore() { }
+    DmrppMetadataStore(const std::string &cache_dir, const std::string &prefix, unsigned long long size) :
+        bes::GlobalMetadataStore(cache_dir, prefix, size) { }
+
+public:
+    static DmrppMetadataStore *get_instance(const std::string &cache_dir, const std::string &prefix, unsigned long long size);
+    static DmrppMetadataStore *get_instance();
+
+    virtual ~DmrppMetadataStore()
+    {
+    }
+
+    virtual bool add_responses(libdap::DMR *dmrpp, const std::string &name);
+
+#if 0
+    virtual MDSReadLock is_dmrpp_available(const std::string &name);
+
+    // Add a third parameter to enable changing the value of xmlbase in this response.
+    // jhrg 2.28.18
+    virtual void get_dmrpp_response(const std::string &name, std::ostream &os);
+
+    virtual bool remove_responses(const std::string &name);
+
+    virtual dmrpp::DMRpp *get_dmrpp_object(const std::string &name);
+#endif
+
+};
+
+} // namespace bes
+
+#endif // _dmrpp_metadata_store_h

--- a/modules/dmrpp_module/DmrppMetadataStore.h
+++ b/modules/dmrpp_module/DmrppMetadataStore.h
@@ -84,6 +84,8 @@ private:
         d_instance = 0;
     }
 
+    friend class DmrppMetadataStoreTest;
+
 protected:
 #if 0
     struct StreamDAP : public std::unary_function<libdap::DapObj*, void> {

--- a/modules/dmrpp_module/DmrppMetadataStore.h
+++ b/modules/dmrpp_module/DmrppMetadataStore.h
@@ -127,9 +127,9 @@ public:
 
     virtual bool add_responses(libdap::DMR *dmrpp, const std::string &name);
 
-#if 0
     virtual MDSReadLock is_dmrpp_available(const std::string &name);
 
+#if 0
     // Add a third parameter to enable changing the value of xmlbase in this response.
     // jhrg 2.28.18
     virtual void get_dmrpp_response(const std::string &name, std::ostream &os);

--- a/modules/dmrpp_module/DmrppMetadataStore.h
+++ b/modules/dmrpp_module/DmrppMetadataStore.h
@@ -89,9 +89,9 @@ private:
 protected:
     /// Hack use a DMR to write a DMR++ response. WIP
     struct StreamDMRpp : public StreamDAP {
-        // Making a StreamDMRpp with a DDS or DMR is not supported.
         StreamDMRpp(libdap::DMR *dmrpp) : StreamDAP(dmrpp) {}
-
+        // Use the DMR to write the DMR++ when the DMR has variables of the correct
+        // type. Look for this by checking the type of the object at runtime.
         virtual void operator()(std::ostream &os);
     };
 
@@ -112,10 +112,7 @@ public:
 
     virtual bool add_responses(libdap::DMR *dmrpp, const std::string &name);
 
-#if 0
     virtual dmrpp::DMRpp *get_dmrpp_object(const std::string &name);
-#endif
-
 };
 
 } // namespace bes

--- a/modules/dmrpp_module/DmrppParserSax2.h
+++ b/modules/dmrpp_module/DmrppParserSax2.h
@@ -37,6 +37,8 @@
 
 #include <libxml/parserInternals.h>
 
+#include <Type.h>   // from libdap
+
 #define CRLF "\r\n"
 
 namespace libdap {
@@ -110,25 +112,25 @@ private:
     libdap::DMR *dmr() const { return d_dmr; }
 
     // These stacks hold the state of the parse as it progresses.
-    stack<ParseState> s; // Current parse state
+    std::stack<ParseState> s; // Current parse state
     void push_state(DmrppParserSax2::ParseState state) { s.push(state); }
     DmrppParserSax2::ParseState get_state() const { return s.top(); }
     void pop_state() { s.pop(); }
     bool empty_state() const { return s.empty(); }
 
-    stack<libdap::BaseType*> btp_stack; // current variable(s)
+    std::stack<libdap::BaseType*> btp_stack; // current variable(s)
     void push_basetype(libdap::BaseType *btp) { btp_stack.push(btp); }
     libdap::BaseType *top_basetype() const { return btp_stack.top(); }
     void pop_basetype() { btp_stack.pop(); }
     bool empty_basetype() const { return btp_stack.empty(); }
 
-    stack<libdap::D4Group*> grp_stack; // current groups(s)
+    std::stack<libdap::D4Group*> grp_stack; // current groups(s)
     void push_group(libdap::D4Group *grp) { grp_stack.push(grp); }
     libdap::D4Group *top_group() const { return grp_stack.top(); }
     void pop_group() { grp_stack.pop(); }
     bool empty_group() const { return grp_stack.empty(); }
 
-    stack<libdap::D4Attributes*> d_attrs_stack; // DAP4 Attributes
+    std::stack<libdap::D4Attributes*> d_attrs_stack; // DAP4 Attributes
     void push_attributes(libdap::D4Attributes *attr) { d_attrs_stack.push(attr); }
     libdap::D4Attributes *top_attributes() const { return d_attrs_stack.top(); }
     void pop_attributes() { d_attrs_stack.pop(); }
@@ -200,14 +202,14 @@ private:
         }
     };
 
-    typedef map<string, XMLAttribute> XMLAttrMap;
+    typedef std::map<std::string, XMLAttribute> XMLAttrMap;
     XMLAttrMap xml_attrs; // dump XML attributes here
 
     XMLAttrMap::iterator xml_attr_begin() { return xml_attrs.begin(); }
 
     XMLAttrMap::iterator xml_attr_end() {  return xml_attrs.end(); }
 
-    map<string, string> namespace_table;
+    std::map<std::string, std::string> namespace_table;
 
     void cleanup_parse();
 
@@ -219,8 +221,8 @@ private:
     //@{
     void transfer_xml_attrs(const xmlChar **attrs, int nb_attributes);
     void transfer_xml_ns(const xmlChar **namespaces, int nb_namespaces);
-    bool check_required_attribute(const string &attr);
-    bool check_attribute(const string & attr);
+    bool check_required_attribute(const std::string &attr);
+    bool check_attribute(const std::string & attr);
     void process_variable_helper(libdap::Type t, ParseState s, const xmlChar **attrs, int nb_attributes);
 
     void process_enum_const_helper(const xmlChar **attrs, int nb_attributes);
@@ -267,7 +269,7 @@ public:
         ddx_sax_parser.endElementNs = &DmrppParserSax2::dmr_end_element;
     }
 
-    void intern(istream &f, libdap::DMR *dest_dmr, bool debug = false);
+    void intern(std::istream &f, libdap::DMR *dest_dmr, bool debug = false);
     void intern(const string &document, libdap::DMR *dest_dmr, bool debug = false);
     void intern(const char *buffer, int size, libdap::DMR *dest_dmr, bool debug = false);
 

--- a/modules/dmrpp_module/Makefile.am
+++ b/modules/dmrpp_module/Makefile.am
@@ -31,7 +31,7 @@ DmrppModule.cc DmrppRequestHandler.cc DmrppByte.cc DmrppArray.cc \
 DmrppFloat32.cc DmrppFloat64.cc DmrppInt16.cc DmrppInt32.cc DmrppInt64.cc \
 DmrppInt8.cc DmrppUInt16.cc DmrppUInt32.cc DmrppUInt64.cc DmrppStr.cc  \
 DmrppStructure.cc DmrppUrl.cc DmrppD4Enum.cc DmrppD4Group.cc DmrppD4Opaque.cc \
-DmrppD4Sequence.cc  DmrppTypeFactory.cc DmrppParserSax2.cc
+DmrppD4Sequence.cc  DmrppTypeFactory.cc DmrppParserSax2.cc DmrppMetadataStore.cc
 
 # Odometer.cc 
 
@@ -40,7 +40,8 @@ DmrppModule.h DmrppRequestHandler.h DmrppByte.h \
 DmrppArray.h DmrppFloat32.h DmrppFloat64.h DmrppInt16.h DmrppInt32.h \
 DmrppInt64.h DmrppInt8.h DmrppUInt16.h DmrppUInt32.h DmrppUInt64.h \
 DmrppStr.h DmrppStructure.h DmrppUrl.h DmrppD4Enum.h DmrppD4Group.h \
-DmrppD4Opaque.h DmrppD4Sequence.h DmrppTypeFactory.h DmrppParserSax2.h
+DmrppD4Opaque.h DmrppD4Sequence.h DmrppTypeFactory.h DmrppParserSax2.h \
+ DmrppMetadataStore.h
 
 # Odometer.h 
 

--- a/modules/dmrpp_module/Makefile.am
+++ b/modules/dmrpp_module/Makefile.am
@@ -2,7 +2,6 @@
 AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = $(H5_CPPFLAGS) -I$(top_srcdir)/dispatch -I$(top_srcdir)/dap $(DAP_CFLAGS)
-# Removed: $(GCTP_CPPFLAGS) 
 
 ACLOCAL_AMFLAGS = -I conf
 AM_CXXFLAGS = 
@@ -33,8 +32,6 @@ DmrppInt8.cc DmrppUInt16.cc DmrppUInt32.cc DmrppUInt64.cc DmrppStr.cc  \
 DmrppStructure.cc DmrppUrl.cc DmrppD4Enum.cc DmrppD4Group.cc DmrppD4Opaque.cc \
 DmrppD4Sequence.cc  DmrppTypeFactory.cc DmrppParserSax2.cc DmrppMetadataStore.cc
 
-# Odometer.cc 
-
 BES_HDRS = DMRpp.h DmrppCommon.h Chunk.h  CurlHandlePool.h \
 DmrppModule.h DmrppRequestHandler.h DmrppByte.h \
 DmrppArray.h DmrppFloat32.h DmrppFloat64.h DmrppInt16.h DmrppInt32.h \
@@ -43,15 +40,13 @@ DmrppStr.h DmrppStructure.h DmrppUrl.h DmrppD4Enum.h DmrppD4Group.h \
 DmrppD4Opaque.h DmrppD4Sequence.h DmrppTypeFactory.h DmrppParserSax2.h \
  DmrppMetadataStore.h
 
-# Odometer.h 
-
 # hack. This is probably not needed and is currently not used, but
 # I'm leaving it in for now. If there are run-time issues with this
 # module, add '$(BES_LIBS) $(OPENSSL_LIBS)' to LIBADD below.
 # jhrg 10/13/14 
-BES_LIBS = $(top_builddir)/xmlcommand/libbes_xml_command.la \
-$(top_builddir)/ppt/libbes_ppt.la \
-$(top_builddir)/dispatch/libbes_dispatch.la
+# BES_LIBS = $(top_builddir)/xmlcommand/libbes_xml_command.la \
+# $(top_builddir)/ppt/libbes_ppt.la \
+# $(top_builddir)/dispatch/libbes_dispatch.la
 
 libdmrpp_module_la_SOURCES = $(BES_HDRS) $(BES_SRCS)
 libdmrpp_module_la_LDFLAGS = -avoid-version -module 

--- a/modules/dmrpp_module/unit-tests/.gitignore
+++ b/modules/dmrpp_module/unit-tests/.gitignore
@@ -3,3 +3,4 @@
 /DmrppHttpReadTest
 /DmrppChunkedReadTest
 /DmrppUtilTest
+/mds_ledger.txt

--- a/modules/dmrpp_module/unit-tests/DmrppMetadataStoreTest.cc
+++ b/modules/dmrpp_module/unit-tests/DmrppMetadataStoreTest.cc
@@ -405,7 +405,7 @@ public:
 
     }
 
-    void get_dmr_response_test() {
+    void write_dmr_response_test() {
         DBG(cerr << __func__ << " - BEGIN" << endl);
 
         try {
@@ -436,42 +436,29 @@ public:
         DBG(cerr << __func__ << " - END" << endl);
     }
 
-#if 0
-    void remove_object_test()
-    {
+    void write_dmrpp_response_test() {
         DBG(cerr << __func__ << " - BEGIN" << endl);
 
         try {
-            init_dds_and_mds();
+            init_dmrpp_and_mds();
 
             // Store it - this will work if the the code is cleaning the cache.
-            bool stored = d_mds->add_responses(d_test_dds, d_test_dds->get_dataset_name());
+            bool stored = d_mds->add_responses(d_test_dmr, d_test_dmr->name());
 
             CPPUNIT_ASSERT(stored);
 
-            // look for the files
-            string dds_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dds->get_dataset_name().append("dds_r")), false /*mangle*/);
-            DBG(cerr << __func__ << " - dds_cache_name: " << dds_cache_name << endl);
-            CPPUNIT_ASSERT(access(dds_cache_name.c_str(), R_OK) == 0);
+            // Now lets read the object from the cache
+            ostringstream oss;
+            d_mds->write_dmrpp_response(d_test_dmr->name(), oss);
+            DBG(cerr << "DMR++ response: " << endl << oss.str() << endl);
 
-            string das_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dds->get_dataset_name().append("das_r")), false /*mangle*/);
-            DBG(cerr << __func__ << " - das_cache_name: " << das_cache_name << endl);
-            CPPUNIT_ASSERT(access(das_cache_name.c_str(), R_OK) == 0);
+            string baseline_name = c_mds_baselines + "/" + c_mds_prefix + "chunked_fourD.h5.dmrpp_r";
+            DBG(cerr << "Reading baseline: " << baseline_name << endl);
+            CPPUNIT_ASSERT(access(baseline_name.c_str(), R_OK) == 0);
 
-#if SYMETRIC_ADD_RESPONSES
-            string dmr_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dds->get_dataset_name().append("dmr_r")), false /*mangle*/);
-            DBG(cerr << __func__ << " - dmr_cache_name: " << dmr_cache_name << endl);
-            CPPUNIT_ASSERT(access(dmr_cache_name.c_str(), R_OK) == 0);
-#endif
+            string test_05_dmr_baseline = read_test_baseline(baseline_name);
 
-            bool removed = d_mds->remove_responses(d_test_dds->get_dataset_name());
-            CPPUNIT_ASSERT(removed);
-
-            CPPUNIT_ASSERT(access(dds_cache_name.c_str(), R_OK) != 0);
-            CPPUNIT_ASSERT(access(das_cache_name.c_str(), R_OK) != 0);
-#if SYMETRIC_ADD_RESPONSES
-            CPPUNIT_ASSERT(access(dmr_cache_name.c_str(), R_OK) != 0);
-#endif
+            CPPUNIT_ASSERT(test_05_dmr_baseline == oss.str());
         }
         catch (BESError &e) {
             CPPUNIT_FAIL(e.get_message());
@@ -479,7 +466,40 @@ public:
 
         DBG(cerr << __func__ << " - END" << endl);
     }
-#endif
+
+    void remove_object_test()
+    {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            init_dmrpp_and_mds();
+
+            // Store it - this will work if the the code is cleaning the cache.
+            bool stored = d_mds->add_responses(d_test_dmr, d_test_dmr->name());
+
+            CPPUNIT_ASSERT(stored);
+
+            // look for the files
+            string dmr_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dmr->name().append("dmr_r")), false /*mangle*/);
+            DBG(cerr << __func__ << " - dmr_cache_name: " << dmr_cache_name << endl);
+            CPPUNIT_ASSERT(access(dmr_cache_name.c_str(), R_OK) == 0);
+
+            string dmrpp_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dmr->name().append("dmrpp_r")), false /*mangle*/);
+            DBG(cerr << __func__ << " - dmrpp_cache_name: " << dmrpp_cache_name << endl);
+            CPPUNIT_ASSERT(access(dmrpp_cache_name.c_str(), R_OK) == 0);
+
+            bool removed = d_mds->remove_responses(d_test_dmr->name());
+            CPPUNIT_ASSERT(removed);
+
+            CPPUNIT_ASSERT(access(dmr_cache_name.c_str(), R_OK) != 0);
+            CPPUNIT_ASSERT(access(dmrpp_cache_name.c_str(), R_OK) != 0);
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL(e.get_message());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
 
     void get_dmr_object_test() {
         DBG(cerr << __func__ << " - BEGIN" << endl);
@@ -533,11 +553,14 @@ public:
     CPPUNIT_TEST(cache_a_dmr_response);
     CPPUNIT_TEST(cache_a_dmrpp_response);
 
-    CPPUNIT_TEST(get_dmr_response_test);
+    CPPUNIT_TEST(write_dmr_response_test);
     CPPUNIT_TEST(add_response_test);
     CPPUNIT_TEST(add_response_test_2);
 
     CPPUNIT_TEST(is_dmrpp_available_test);
+    CPPUNIT_TEST(write_dmrpp_response_test);
+
+    CPPUNIT_TEST(remove_object_test);
 
     CPPUNIT_TEST(get_dmr_object_test);
 

--- a/modules/dmrpp_module/unit-tests/DmrppMetadataStoreTest.cc
+++ b/modules/dmrpp_module/unit-tests/DmrppMetadataStoreTest.cc
@@ -1,0 +1,632 @@
+// -*- mode: c++; c-basic-offset:4 -*-
+
+// This file is part of libdap, A C++ implementation of the OPeNDAP Data
+// Access Protocol.
+
+// Copyright (c) 2002,2003 OPeNDAP, Inc.
+// Author: James Gallagher <jgallagher@opendap.org>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+// You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+
+#include "config.h"
+
+#include <unistd.h>
+
+#include <cppunit/TextTestRunner.h>
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <Array.h>
+#include <Byte.h>
+#include <DAS.h>
+#include <DDS.h>
+#include <DDXParserSAX2.h>
+#include <DMR.h>
+#include <D4ParserSax2.h>
+
+#include <GetOpt.h>
+#include <GNURegex.h>
+#include <util.h>
+#include <debug.h>
+
+#include <BaseTypeFactory.h>
+#include <D4BaseTypeFactory.h>
+
+#include "BESError.h"
+#include "TheBESKeys.h"
+#include "BESDebug.h"
+
+#include "DmrppMetadataStore.h"
+
+#if 1
+#include "DMRpp.h"
+#include "DmrppTypeFactory.h"
+#include "DmrppParserSax2.h"
+#endif
+
+#include "read_test_baseline.h"
+#include "test_config.h"
+
+static bool debug = false;
+static bool bes_debug = false;
+static bool clean = true;
+
+#undef DBG
+#define DBG(x) do { if (debug) (x); } while(false);
+
+#define DEBUG_KEY "dmrpp_store,cache"
+
+using namespace CppUnit;
+using namespace std;
+using namespace libdap;
+using namespace dmrpp;
+
+namespace bes {
+
+// Move this into the class when we goto C++-11
+static const string c_mds_prefix = "mds_"; // used when cleaning the cache, etc.
+static const string c_mds_name = "/mds";
+static const string c_mds_baselines = string(TEST_SRC_DIR) + "/baselines";
+
+class DmrppMetadataStoreTest: public TestFixture {
+private:
+    DMR *d_test_dmr;
+    D4BaseTypeFactory d_d4f;
+    DmrppTypeFactory d_dmrpp_f;
+
+    string d_mds_dir;
+    DmrppMetadataStore *d_mds;
+
+    /**
+     * SetUp()-like method to build a DMR for testing.
+     */
+    void init_dmr_and_mds()
+    {
+        try {
+            // Stock code to get the d_test_dds and d_mds objects used by many
+            // of the tests.
+            d_mds = DmrppMetadataStore::get_instance(d_mds_dir, c_mds_prefix, 1000);
+            DBG(cerr << "Retrieved DmrppMetadataStore object: " << d_mds << endl);
+
+            // Get a DMR to cache.
+            string file_name = string(TEST_SRC_DIR).append("/input-files/test_01.dmr");
+
+            d_test_dmr = new DMR(&d_d4f);
+            D4ParserSax2 dp;
+            DBG(cerr << "DMR file to be parsed: " << file_name << endl);
+            fstream in(file_name.c_str(), ios::in|ios::binary);
+            dp.intern(in, d_test_dmr);
+
+            DBG(cerr << "DMR Name: " << d_test_dmr->name() << endl);
+            CPPUNIT_ASSERT(d_test_dmr);
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL(e.get_message());
+        }
+        catch (Error &e) {
+            CPPUNIT_FAIL(e.get_error_message());
+        }
+        catch (std::exception &e) {
+            CPPUNIT_FAIL(e.what());
+        }
+    }
+
+#if 1
+    void init_dmrpp_and_mds()
+    {
+        try {
+            // Stock code to get the d_test_dds and d_mds objects used by many
+            // of the tests.
+            d_mds = DmrppMetadataStore::get_instance(d_mds_dir, c_mds_prefix, 1000);
+            DBG(cerr << "Retrieved DmrppMetadataStore object: " << d_mds << endl);
+
+            // Get a DMRpp to cache.
+            string file_name = string(TEST_SRC_DIR).append("/input-files/chunked_fourD.h5.dmrpp");
+
+            d_test_dmr = new DMRpp(&d_dmrpp_f);
+            DmrppParserSax2 dp;
+            DBG(cerr << "DMRpp file to be parsed: " << file_name << endl);
+            fstream in(file_name.c_str(), ios::in|ios::binary);
+            dp.intern(in, d_test_dmr);
+
+            DBG(cerr << "DMRpp Name: " << d_test_dmr->name() << endl);
+            CPPUNIT_ASSERT(d_test_dmr);
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL(e.get_message());
+        }
+        catch (Error &e) {
+            CPPUNIT_FAIL(e.get_error_message());
+        }
+        catch (std::exception &e) {
+            CPPUNIT_FAIL(e.what());
+        }
+    }
+#endif
+
+public:
+    DmrppMetadataStoreTest() :
+        d_test_dmr(0), d_mds_dir(string(TEST_BUILD_DIR).append(c_mds_name)), d_mds(0)
+    {
+    }
+
+    ~DmrppMetadataStoreTest()
+    {
+    }
+
+    void setUp()
+    {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        if (bes_debug) BESDebug::SetUp(string("cerr,").append(DEBUG_KEY));
+
+        if (clean) clean_cache_dir(c_mds_name);
+
+        // Contains BES Log parameters but not cache names
+        TheBESKeys::ConfigFile = string(TEST_BUILD_DIR).append("/bes.conf");
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+
+    void tearDown()
+    {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        delete d_test_dmr; d_test_dmr = 0;
+
+        d_mds->delete_instance();
+
+        if (clean) clean_cache_dir(d_mds_dir);
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+
+    void ctor_test_1()
+    {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            // The call to get_instance should fail since the directory is named,
+            // but does not exist and cannot be made.
+            d_mds = DmrppMetadataStore::get_instance("/new", c_mds_prefix, 1000);
+            DBG(cerr << "retrieved DmrppMetadataStore instance: " << d_mds << endl);
+            CPPUNIT_FAIL("get_instance() Should not return when the non-existent directory cannot be created");
+        }
+        catch (BESError &e) {
+            CPPUNIT_ASSERT(!e.get_message().empty());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+
+    void ctor_test_2()
+    {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            // This one should work and will make the directory
+            d_mds = DmrppMetadataStore::get_instance(d_mds_dir, c_mds_prefix, 1000);
+            DBG(cerr << "retrieved DmrppMetadataStore instance: " << d_mds << endl);
+            CPPUNIT_ASSERT(d_mds);
+            CPPUNIT_ASSERT(!d_mds->is_unlimited());
+
+            d_mds->update_and_purge("no_name"); //cheesy test - use -b to read BES debug info
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL("Caught exception: " + e.get_message());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+
+    void ctor_test_3()
+    {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            // This one should work and will make the directory
+            d_mds = DmrppMetadataStore::get_instance(d_mds_dir, c_mds_prefix, 0);
+            DBG(cerr << "retrieved DmrppMetadataStore instance: " << d_mds << endl);
+            CPPUNIT_ASSERT(d_mds);
+            CPPUNIT_ASSERT(d_mds->is_unlimited());
+
+            d_mds->update_and_purge("no_name");
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL("Caught exception: " + e.get_message());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+
+    void cache_a_dmr_response()
+    {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            init_dmr_and_mds();
+
+            // Store it - this will work if the the code is cleaning the cache.
+            DmrppMetadataStore::StreamDMR write_the_dmr_response(d_test_dmr);
+            bool stored = d_mds->store_dap_response(write_the_dmr_response,
+                d_test_dmr->name() + ".dmr_r", d_test_dmr->name(), "DMR");
+
+            CPPUNIT_ASSERT(stored);
+
+            // Now check the file
+            string baseline_name = c_mds_baselines + "/" + c_mds_prefix + "test_array_4.dmr_r";
+            DBG(cerr << "Reading baseline: " << baseline_name << endl);
+            CPPUNIT_ASSERT(access(baseline_name.c_str(), R_OK) == 0);
+
+            string test_05_dmr_baseline = read_test_baseline(baseline_name);
+
+            string response_name = d_mds_dir + "/" + c_mds_prefix + "test_array_4.dmr_r";
+            DBG(cerr << "Reading response: " << response_name << endl);
+            CPPUNIT_ASSERT(access(response_name.c_str(), R_OK) == 0);
+
+            string stored_response = read_test_baseline(response_name);
+
+            CPPUNIT_ASSERT(stored_response == test_05_dmr_baseline);
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL(e.get_message());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+
+#if 1
+    void cache_a_dmrpp_response()
+    {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            init_dmrpp_and_mds();
+
+            // Store it - this will work if the the code is cleaning the cache.
+            DmrppMetadataStore::StreamDMRpp write_the_dmrpp_response(d_test_dmr);
+            bool stored = d_mds->store_dap_response(write_the_dmrpp_response, d_test_dmr->name() + ".dmrpp_r", d_test_dmr->name(), "DMRpp");
+
+            CPPUNIT_ASSERT(stored);
+
+            // Now check the file
+            string baseline_name = c_mds_baselines + "/" + c_mds_prefix + "chunked_fourD.h5.dmrpp_r";
+            DBG(cerr << "Reading baseline: " << baseline_name << endl);
+            CPPUNIT_ASSERT(access(baseline_name.c_str(), R_OK) == 0);
+
+            string chunked_4d_dmrpp_baseline = read_test_baseline(baseline_name);
+
+            string response_name = d_mds_dir + "/" + c_mds_prefix + "chunked_fourD.h5.dmrpp_r";
+            DBG(cerr << "Reading response: " << response_name << endl);
+            CPPUNIT_ASSERT(access(response_name.c_str(), R_OK) == 0);
+
+            string stored_response = read_test_baseline(response_name);
+
+            CPPUNIT_ASSERT(stored_response == chunked_4d_dmrpp_baseline);
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL(e.get_message());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+#endif
+
+#if 0
+    void add_response_test()
+    {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            init_dds_and_mds();
+
+            // Store it - this will work if the the code is cleaning the cache.
+            bool stored = d_mds->add_responses(d_test_dds, d_test_dds->get_dataset_name());
+
+            CPPUNIT_ASSERT(stored);
+
+            // look for the files
+            string dds_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dds->get_dataset_name().append("dds_r")), false /*mangle*/);
+            DBG(cerr << __func__ << " - dds_cache_name: " << dds_cache_name << endl);
+            CPPUNIT_ASSERT(access(dds_cache_name.c_str(), R_OK) == 0);
+
+            string das_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dds->get_dataset_name().append("das_r")), false /*mangle*/);
+            DBG(cerr << __func__ << " - das_cache_name: " << das_cache_name << endl);
+            CPPUNIT_ASSERT(access(das_cache_name.c_str(), R_OK) == 0);
+
+            /// Previously the MDS built all three metadata responses using
+            /// either the DDS or DMR. Now it only does that when SYMETRIC_ADD_RESPONSES
+            /// is defined. When that is not defined (the default) the DDS
+            /// builds only the DAP2 responses and the DMR builds only the
+            /// DAP4 responses. jhrg 3/20/18
+#if SYMETRIC_ADD_RESPONSES
+            string dmr_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dds->get_dataset_name().append("dmr_r")), false /*mangle*/);
+            DBG(cerr << __func__ << " - dmr_cache_name: " << das_cache_name << endl);
+            CPPUNIT_ASSERT(access(dmr_cache_name.c_str(), R_OK) == 0);
+#endif
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL(e.get_message());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+#endif
+
+#if 0
+    void get_dmr_response_test() {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            init_dmr_and_mds();
+
+            // Store it - this will work if the the code is cleaning the cache.
+            bool stored = d_mds->add_responses(d_test_dmr, d_test_dmr->name());
+
+            CPPUNIT_ASSERT(stored);
+
+            // Now lets read the object from the cache
+            ostringstream oss;
+            d_mds->get_dmr_response(d_test_dmr->name(), oss);
+            DBG(cerr << "DMR response: " << endl << oss.str() << endl);
+
+            string baseline_name = c_mds_baselines + "/" + c_mds_prefix + "test_01.dmr_r";
+            DBG(cerr << "Reading baseline: " << baseline_name << endl);
+            CPPUNIT_ASSERT(access(baseline_name.c_str(), R_OK) == 0);
+
+            string test_05_dmr_baseline = read_test_baseline(baseline_name);
+
+            CPPUNIT_ASSERT(test_05_dmr_baseline == oss.str());
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL(e.get_message());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+
+#endif
+
+#if 0
+    void remove_object_test()
+    {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            init_dds_and_mds();
+
+            // Store it - this will work if the the code is cleaning the cache.
+            bool stored = d_mds->add_responses(d_test_dds, d_test_dds->get_dataset_name());
+
+            CPPUNIT_ASSERT(stored);
+
+            // look for the files
+            string dds_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dds->get_dataset_name().append("dds_r")), false /*mangle*/);
+            DBG(cerr << __func__ << " - dds_cache_name: " << dds_cache_name << endl);
+            CPPUNIT_ASSERT(access(dds_cache_name.c_str(), R_OK) == 0);
+
+            string das_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dds->get_dataset_name().append("das_r")), false /*mangle*/);
+            DBG(cerr << __func__ << " - das_cache_name: " << das_cache_name << endl);
+            CPPUNIT_ASSERT(access(das_cache_name.c_str(), R_OK) == 0);
+
+#if SYMETRIC_ADD_RESPONSES
+            string dmr_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dds->get_dataset_name().append("dmr_r")), false /*mangle*/);
+            DBG(cerr << __func__ << " - dmr_cache_name: " << dmr_cache_name << endl);
+            CPPUNIT_ASSERT(access(dmr_cache_name.c_str(), R_OK) == 0);
+#endif
+
+            bool removed = d_mds->remove_responses(d_test_dds->get_dataset_name());
+            CPPUNIT_ASSERT(removed);
+
+            CPPUNIT_ASSERT(access(dds_cache_name.c_str(), R_OK) != 0);
+            CPPUNIT_ASSERT(access(das_cache_name.c_str(), R_OK) != 0);
+#if SYMETRIC_ADD_RESPONSES
+            CPPUNIT_ASSERT(access(dmr_cache_name.c_str(), R_OK) != 0);
+#endif
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL(e.get_message());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+#endif
+
+#if 0
+    void cache_a_dmr_response_dmr()
+    {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            init_dmr_and_mds();
+
+            // Store it - this will work if the the code is cleaning the cache.
+            DmrppMetadataStore::StreamDMR write_the_dmr_response(d_test_dmr);
+            bool stored = d_mds->store_dap_response(write_the_dmr_response,
+                d_test_dmr->name() + ".dmr_r", d_test_dmr->name(), "DMR");
+
+            CPPUNIT_ASSERT(stored);
+
+            // Now check the file
+            string baseline_name = c_mds_baselines + "/" + c_mds_prefix + "test_array_4.dmr_r";
+            DBG(cerr << "Reading baseline: " << baseline_name << endl);
+            CPPUNIT_ASSERT(access(baseline_name.c_str(), R_OK) == 0);
+
+            string test_01_dmr_baseline = read_test_baseline(baseline_name);
+
+            string response_name = d_mds_dir + "/" + c_mds_prefix + "test_array_4.dmr_r";
+            // read_test_baseline() just reads stuff from a file - it will work for the response, too.
+            DBG(cerr << "Reading response: " << response_name << endl);
+            CPPUNIT_ASSERT(access(response_name.c_str(), R_OK) == 0);
+
+            string stored_response = read_test_baseline(response_name);
+
+            CPPUNIT_ASSERT(stored_response == test_01_dmr_baseline);
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL(e.get_message());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+
+    void add_response_dmr_test()
+    {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            init_dmr_and_mds();
+
+            // Store it - this will work if the the code is cleaning the cache.
+            bool stored = d_mds->add_responses(d_test_dmr, d_test_dmr->name());
+
+            CPPUNIT_ASSERT(stored);
+
+#if SYMETRIC_ADD_RESPONSES
+            // look for the files
+            string dds_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dmr->name().append("dds_r")), false /*mangle*/);
+            DBG(cerr << __func__ << " - dds_cache_name: " << dds_cache_name << endl);
+            CPPUNIT_ASSERT(access(dds_cache_name.c_str(), R_OK) == 0);
+
+            string das_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dmr->name().append("das_r")), false /*mangle*/);
+            DBG(cerr << __func__ << " - das_cache_name: " << das_cache_name << endl);
+            CPPUNIT_ASSERT(access(das_cache_name.c_str(), R_OK) == 0);
+#endif
+            string dmr_cache_name = d_mds->get_cache_file_name(d_mds->get_hash(d_test_dmr->name().append("dmr_r")), false /*mangle*/);
+            DBG(cerr << __func__ << " - dmr_cache_name: " << dmr_cache_name << endl);
+            CPPUNIT_ASSERT(access(dmr_cache_name.c_str(), R_OK) == 0);
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL(e.get_message());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+
+    void get_dmr_object_test() {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            init_dmr_and_mds();
+
+            // Store it - this will work if the the code is cleaning the cache.
+            bool stored = d_mds->add_responses(d_test_dmr, d_test_dmr->name());
+
+            CPPUNIT_ASSERT(stored);
+
+            DMR *dmr = d_mds->get_dmr_object(d_test_dmr->name());
+
+            CPPUNIT_ASSERT(dmr);
+
+            DBG(cerr << "DMR: " << dmr->name() << endl);
+
+            ostringstream oss;
+            XMLWriter writer;
+            dmr->print_dap4(writer);
+            oss << writer.get_doc();
+
+            string baseline_name = c_mds_baselines + "/" + c_mds_prefix + "test_01.dmr_r";
+            DBG(cerr << "Reading baseline: " << baseline_name << endl);
+            CPPUNIT_ASSERT(access(baseline_name.c_str(), R_OK) == 0);
+
+            string test_01_dmr_baseline = read_test_baseline(baseline_name);
+
+            CPPUNIT_ASSERT(test_01_dmr_baseline == oss.str());
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL(e.get_message());
+        }
+        catch(Error &e) {
+            CPPUNIT_FAIL(e.get_error_message());
+        }
+        catch (std::exception &e) {
+            CPPUNIT_FAIL(e.what());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+#endif
+
+
+    CPPUNIT_TEST_SUITE( DmrppMetadataStoreTest );
+
+    CPPUNIT_TEST(ctor_test_1);
+    CPPUNIT_TEST(ctor_test_2);
+    CPPUNIT_TEST(ctor_test_3);
+
+    CPPUNIT_TEST(cache_a_dmr_response);
+    CPPUNIT_TEST(cache_a_dmrpp_response);
+
+    CPPUNIT_TEST_SUITE_END();
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(DmrppMetadataStoreTest);
+
+} // namespace bes
+
+int main(int argc, char*argv[])
+{
+
+    GetOpt getopt(argc, argv, "dbkh");
+    int option_char;
+    while ((option_char = getopt()) != -1)
+        switch (option_char) {
+        case 'd':
+            debug = 1;  // debug is a static global
+            break;
+        case 'b':
+            bes_debug = true;  // bes_debug is a static global
+            cerr << "##### BES DEBUG is ON" << endl;
+            break;
+        case 'k':   // -k turns off cleaning the metadata store dir
+            clean = false;
+            break;
+        case 'h': {     // help - show test names
+            cerr << "Usage: DmrppMetadataStoreTest has the following tests:" << endl;
+            const std::vector<Test*> &tests = bes::DmrppMetadataStoreTest::suite()->getTests();
+            unsigned int prefix_len = bes::DmrppMetadataStoreTest::suite()->getName().append("::").length();
+            for (std::vector<Test*>::const_iterator i = tests.begin(), e = tests.end(); i != e; ++i) {
+                cerr << (*i)->getName().replace(0, prefix_len, "") << endl;
+            }
+            break;
+        }
+        default:
+            break;
+        }
+
+    CppUnit::TextTestRunner runner;
+    runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
+
+    bool wasSuccessful = true;
+    string test = "";
+    int i = getopt.optind;
+    if (i == argc) {
+        // run them all
+        wasSuccessful = runner.run("");
+    }
+    else {
+        while (i < argc) {
+            if (debug) cerr << "Running " << argv[i] << endl;
+            test = bes::DmrppMetadataStoreTest::suite()->getName().append("::").append(argv[i]);
+            wasSuccessful = wasSuccessful && runner.run(test);
+
+            ++i;
+        }
+    }
+
+    return wasSuccessful ? 0 : 1;
+}

--- a/modules/dmrpp_module/unit-tests/DmrppMetadataStoreTest.cc
+++ b/modules/dmrpp_module/unit-tests/DmrppMetadataStoreTest.cc
@@ -544,6 +544,49 @@ public:
         DBG(cerr << __func__ << " - END" << endl);
     }
 
+    void get_dmrpp_object_test() {
+        DBG(cerr << __func__ << " - BEGIN" << endl);
+
+        try {
+            init_dmrpp_and_mds();
+
+            // Store it - this will work if the the code is cleaning the cache.
+            bool stored = d_mds->add_responses(d_test_dmr, d_test_dmr->name());
+
+            CPPUNIT_ASSERT(stored);
+
+            DMRpp *dmrpp = d_mds->get_dmrpp_object(d_test_dmr->name());
+
+            CPPUNIT_ASSERT(dmrpp);
+
+            DBG(cerr << "DMR++: " << dmrpp->name() << endl);
+
+            ostringstream oss;
+            XMLWriter writer;
+            dmrpp->print_dmrpp(writer); // no href passed, using the default which is ""
+            oss << writer.get_doc();
+
+            string baseline_name = c_mds_baselines + "/" + c_mds_prefix + "chunked_fourD.h5.dmrpp_r";
+            DBG(cerr << "Reading baseline: " << baseline_name << endl);
+            CPPUNIT_ASSERT(access(baseline_name.c_str(), R_OK) == 0);
+
+            string chunked_fourD_dmrpp_baseline = read_test_baseline(baseline_name);
+
+            CPPUNIT_ASSERT(chunked_fourD_dmrpp_baseline == oss.str());
+        }
+        catch (BESError &e) {
+            CPPUNIT_FAIL(e.get_message());
+        }
+        catch(Error &e) {
+            CPPUNIT_FAIL(e.get_error_message());
+        }
+        catch (std::exception &e) {
+            CPPUNIT_FAIL(e.what());
+        }
+
+        DBG(cerr << __func__ << " - END" << endl);
+    }
+
     CPPUNIT_TEST_SUITE( DmrppMetadataStoreTest );
 
     CPPUNIT_TEST(ctor_test_1);
@@ -563,6 +606,7 @@ public:
     CPPUNIT_TEST(remove_object_test);
 
     CPPUNIT_TEST(get_dmr_object_test);
+    CPPUNIT_TEST(get_dmrpp_object_test);
 
     CPPUNIT_TEST_SUITE_END();
 };

--- a/modules/dmrpp_module/unit-tests/Makefile.am
+++ b/modules/dmrpp_module/unit-tests/Makefile.am
@@ -33,6 +33,8 @@ TESTS = $(UNIT_TESTS)
 
 noinst_HEADERS = test_config.h
 
+noinst_DATA = bes.conf
+
 EXTRA_DIST = baselines
 
 CLEANFILES = *.gcda *.gcno *.strm *.file test_config.h tmp.txt
@@ -40,6 +42,8 @@ CLEANFILES = *.gcda *.gcno *.strm *.file test_config.h tmp.txt
 DISTCLEANFILES = 
 
 BUILT_SOURCES = test_config.h
+
+BES_CONF_IN = bes.conf.in
 
 test_config.h: $(srcdir)/test_config.h.in Makefile
 	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
@@ -49,12 +53,20 @@ test_config.h: $(srcdir)/test_config.h.in Makefile
 	    -e "s%[@]abs_top_srcdir[@]%$${mod_abs_top_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 
+# Build the bes.conf used for testing so that the value substituted for
+# @abs_top_srcdir@ does not contain '../'. This happens when using 
+# configure's value for the parameter when running the distcheck target.
+bes.conf: $(srcdir)/$(BES_CONF_IN) $(top_srcdir)/configure.ac
+	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
+	    -e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
+
 ############################################################################
 # Unit Tests
 #
 
 if CPPUNIT
-UNIT_TESTS = ChunkTest DmrppParserTest DmrppCommonTest
+UNIT_TESTS = ChunkTest DmrppParserTest DmrppCommonTest DmrppMetadataStoreTest
 else
 UNIT_TESTS =
 
@@ -67,6 +79,9 @@ check-local:
 	@echo ""
 endif
 
+clean-local:
+	-rm -rf mds
+
 OBJS = ../*.o
 
 ChunkTest_SOURCES = ChunkTest.cc
@@ -74,7 +89,10 @@ ChunkTest_LDADD = $(OBJS) $(LIBADD)
 
 DmrppParserTest_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/hdf5_handler
 DmrppParserTest_SOURCES = DmrppParserTest.cc
-DmrppParserTest_LDADD   =  $(OBJS) $(LIBADD) 
+DmrppParserTest_LDADD = $(OBJS) $(LIBADD) 
 
 DmrppCommonTest_SOURCES = DmrppCommonTest.cc $(top_srcdir)/modules/read_test_baseline.cc
-DmrppCommonTest_LDADD =  $(OBJS) $(LIBADD)
+DmrppCommonTest_LDADD = $(OBJS) $(LIBADD)
+
+DmrppMetadataStoreTest_SOURCES = DmrppMetadataStoreTest.cc $(top_srcdir)/modules/read_test_baseline.cc
+DmrppMetadataStoreTest_LDADD = $(OBJS) $(LIBADD)

--- a/modules/dmrpp_module/unit-tests/Makefile.am
+++ b/modules/dmrpp_module/unit-tests/Makefile.am
@@ -35,7 +35,7 @@ noinst_HEADERS = test_config.h
 
 noinst_DATA = bes.conf
 
-EXTRA_DIST = baselines
+EXTRA_DIST = baselines input-files
 
 CLEANFILES = *.gcda *.gcno *.strm *.file test_config.h tmp.txt
 

--- a/modules/dmrpp_module/unit-tests/Makefile.am
+++ b/modules/dmrpp_module/unit-tests/Makefile.am
@@ -80,7 +80,7 @@ check-local:
 endif
 
 clean-local:
-	-rm -rf mds
+	-rm -rf mds mds_ledger.txt
 
 OBJS = ../*.o
 

--- a/modules/dmrpp_module/unit-tests/Makefile.am
+++ b/modules/dmrpp_module/unit-tests/Makefile.am
@@ -39,7 +39,7 @@ EXTRA_DIST = baselines input-files
 
 CLEANFILES = *.gcda *.gcno *.strm *.file test_config.h tmp.txt
 
-DISTCLEANFILES = 
+DISTCLEANFILES = bes.conf bes.log
 
 BUILT_SOURCES = test_config.h
 

--- a/modules/dmrpp_module/unit-tests/baselines/mds_chunked_fourD.h5.dmrpp_r
+++ b/modules/dmrpp_module/unit-tests/baselines/mds_chunked_fourD.h5.dmrpp_r
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="chunked_fourD.h5">
+    <Float32 name="d_16_chunks">
+        <Dim size="40"/>
+        <Dim size="40"/>
+        <Dim size="40"/>
+        <Dim size="40"/>
+        <Attribute name="origname" type="String">
+            <Value>d_16_chunks</Value>
+        </Attribute>
+        <Attribute name="fullnamepath" type="String">
+            <Value>/d_16_chunks</Value>
+        </Attribute>
+        <dmrpp:chunks>
+            <dmrpp:chunkDimensionSizes>20 20 20 20</dmrpp:chunkDimensionSizes>
+            <dmrpp:chunk offset="4728" nBytes="640000" chunkPositionInArray="[0,0,0,0]"/>
+            <dmrpp:chunk offset="644728" nBytes="640000" chunkPositionInArray="[0,0,0,20]"/>
+            <dmrpp:chunk offset="1284728" nBytes="640000" chunkPositionInArray="[0,0,20,0]"/>
+            <dmrpp:chunk offset="1924728" nBytes="640000" chunkPositionInArray="[0,0,20,20]"/>
+            <dmrpp:chunk offset="2564728" nBytes="640000" chunkPositionInArray="[0,20,0,0]"/>
+            <dmrpp:chunk offset="3204728" nBytes="640000" chunkPositionInArray="[0,20,0,20]"/>
+            <dmrpp:chunk offset="3844728" nBytes="640000" chunkPositionInArray="[0,20,20,0]"/>
+            <dmrpp:chunk offset="4484728" nBytes="640000" chunkPositionInArray="[0,20,20,20]"/>
+            <dmrpp:chunk offset="5124728" nBytes="640000" chunkPositionInArray="[20,0,0,0]"/>
+            <dmrpp:chunk offset="5764728" nBytes="640000" chunkPositionInArray="[20,0,0,20]"/>
+            <dmrpp:chunk offset="6404728" nBytes="640000" chunkPositionInArray="[20,0,20,0]"/>
+            <dmrpp:chunk offset="7044728" nBytes="640000" chunkPositionInArray="[20,0,20,20]"/>
+            <dmrpp:chunk offset="7684728" nBytes="640000" chunkPositionInArray="[20,20,0,0]"/>
+            <dmrpp:chunk offset="8324728" nBytes="640000" chunkPositionInArray="[20,20,0,20]"/>
+            <dmrpp:chunk offset="8964728" nBytes="640000" chunkPositionInArray="[20,20,20,0]"/>
+            <dmrpp:chunk offset="9606776" nBytes="640000" chunkPositionInArray="[20,20,20,20]"/>
+        </dmrpp:chunks>
+    </Float32>
+</Dataset>

--- a/modules/dmrpp_module/unit-tests/baselines/mds_test_array_4.dmr_r
+++ b/modules/dmrpp_module/unit-tests/baselines/mds_test_array_4.dmr_r
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="input-files/test_01.dmr" dapVersion="4.0" dmrVersion="1.0" name="test_array_4">
+    <Dimension name="row" size="3"/>
+    <Dimension name="col" size="4"/>
+    <Byte name="a">
+        <Dim name="/row"/>
+        <Dim name="/col"/>
+    </Byte>
+    <Int16 name="b">
+        <Dim name="/row"/>
+        <Dim name="/col"/>
+    </Int16>
+    <Int32 name="c">
+        <Dim name="/row"/>
+        <Dim name="/col"/>
+    </Int32>
+    <UInt16 name="d">
+        <Dim name="/row"/>
+        <Dim name="/col"/>
+    </UInt16>
+    <UInt32 name="e">
+        <Dim name="/row"/>
+        <Dim name="/col"/>
+    </UInt32>
+    <Float32 name="f">
+        <Dim name="/row"/>
+        <Dim name="/col"/>
+    </Float32>
+    <Float64 name="g">
+        <Dim name="/row"/>
+        <Dim name="/col"/>
+    </Float64>
+    <String name="h">
+        <Dim name="/row"/>
+        <Dim name="/col"/>
+    </String>
+    <URL name="i">
+        <Dim name="/row"/>
+        <Dim name="/col"/>
+    </URL>
+    <Int32 name="x">
+        <Dim name="/row"/>
+        <Dim size="5"/>
+    </Int32>
+    <Int32 name="y">
+        <Dim size="5"/>
+        <Dim name="/col"/>
+    </Int32>
+</Dataset>

--- a/modules/dmrpp_module/unit-tests/bes.conf.in
+++ b/modules/dmrpp_module/unit-tests/bes.conf.in
@@ -1,0 +1,5 @@
+# 
+# This bes.conf file sets the Bes Log file so we can deal with errors
+
+BES.LogName=./bes.log
+BES.LogVerbose=yes

--- a/modules/dmrpp_module/unit-tests/input-files/chunked_fourD.h5.dmrpp
+++ b/modules/dmrpp_module/unit-tests/input-files/chunked_fourD.h5.dmrpp
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Dataset 
+    xmlns="http://xml.opendap.org/ns/DAP/4.0#" 
+    xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#"
+    dapVersion="4.0" 
+    dmrVersion="1.0" 
+    name="chunked_fourD.h5"
+    dmrpp:href="data/dmrpp/chunked_fourD.h5">
+  <Float32 name="d_16_chunks">
+    <Dim size="40"/>
+    <Dim size="40"/>
+    <Dim size="40"/>
+    <Dim size="40"/>
+    <Attribute name="origname" type="String">
+      <Value>d_16_chunks</Value>
+    </Attribute>
+    <Attribute name="fullnamepath" type="String">
+      <Value>/d_16_chunks</Value>
+    </Attribute>
+    <dmrpp:chunks>
+      <dmrpp:chunkDimensionSizes>20 20 20 20</dmrpp:chunkDimensionSizes>
+      <dmrpp:chunk offset="4728"  nBytes="640000" chunkPositionInArray="[0,0,0,0]" />
+      <dmrpp:chunk offset="644728"  nBytes="640000" chunkPositionInArray="[0,0,0,20]" />
+      <dmrpp:chunk offset="1284728"  nBytes="640000" chunkPositionInArray="[0,0,20,0]" />
+      <dmrpp:chunk offset="1924728"  nBytes="640000" chunkPositionInArray="[0,0,20,20]" />
+      <dmrpp:chunk offset="2564728"  nBytes="640000" chunkPositionInArray="[0,20,0,0]" />
+      <dmrpp:chunk offset="3204728"  nBytes="640000" chunkPositionInArray="[0,20,0,20]" />
+      <dmrpp:chunk offset="3844728"  nBytes="640000" chunkPositionInArray="[0,20,20,0]" />
+      <dmrpp:chunk offset="4484728"  nBytes="640000" chunkPositionInArray="[0,20,20,20]" />
+      <dmrpp:chunk offset="5124728"  nBytes="640000" chunkPositionInArray="[20,0,0,0]" />
+      <dmrpp:chunk offset="5764728"  nBytes="640000" chunkPositionInArray="[20,0,0,20]" />
+      <dmrpp:chunk offset="6404728"  nBytes="640000" chunkPositionInArray="[20,0,20,0]" />
+      <dmrpp:chunk offset="7044728"  nBytes="640000" chunkPositionInArray="[20,0,20,20]" />
+      <dmrpp:chunk offset="7684728"  nBytes="640000" chunkPositionInArray="[20,20,0,0]" />
+      <dmrpp:chunk offset="8324728"  nBytes="640000" chunkPositionInArray="[20,20,0,20]" />
+      <dmrpp:chunk offset="8964728"  nBytes="640000" chunkPositionInArray="[20,20,20,0]" />
+      <dmrpp:chunk offset="9606776"  nBytes="640000" chunkPositionInArray="[20,20,20,20]" />
+    </dmrpp:chunks>
+  </Float32>
+</Dataset>

--- a/modules/dmrpp_module/unit-tests/input-files/test_01.dmr
+++ b/modules/dmrpp_module/unit-tests/input-files/test_01.dmr
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Dataset name="test_array_4" dapVersion="4.0" dmrVersion="1.0" xml:base="input-files/test_01.dmr"
+  xmlns="http://xml.opendap.org/ns/DAP/4.0#"
+  xmlns:dap="http://xml.opendap.org/ns/DAP/4.0#">
+
+  <Dimension name="row" size="3"/>
+  <Dimension name="col" size="4"/>
+
+  <dap:Byte name="a">
+    <Dim name="row"/>
+    <Dim name="col"/>
+  </dap:Byte>
+
+  <dap:Int16 name="b">
+    <Dim name="row"/>
+    <Dim name="col"/>
+  </dap:Int16>
+
+  <dap:Int32 name="c">
+    <Dim name="row"/>
+    <Dim name="col"/>
+  </dap:Int32>
+
+  <dap:UInt16 name="d">
+    <Dim name="row"/>
+    <Dim name="col"/>
+  </dap:UInt16>
+
+  <dap:UInt32 name="e">
+    <Dim name="row"/>
+    <Dim name="col"/>
+  </dap:UInt32>
+
+  <dap:Float32 name="f">
+    <Dim name="row"/>
+    <Dim name="col"/>
+  </dap:Float32>
+
+  <dap:Float64 name="g">
+    <Dim name="row"/>
+    <Dim name="col"/>
+  </dap:Float64>
+
+  <dap:String name="h">
+    <Dim name="row"/>
+    <Dim name="col"/>
+  </dap:String>
+
+  <dap:URL name="i">
+    <Dim name="row"/>
+    <Dim name="col"/>
+  </dap:URL>
+
+  <dap:Int32 name="x">
+    <Dim name="row"/>
+    <Dim size="5"/>
+  </dap:Int32>
+  
+  <dap:Int32 name="y">
+    <Dim size="5"/>
+    <Dim name="col"/>
+  </dap:Int32>
+  
+</Dataset>

--- a/modules/dmrpp_module/unit-tests/test_config.h.in
+++ b/modules/dmrpp_module/unit-tests/test_config.h.in
@@ -2,6 +2,8 @@
 #define E_test_config_h
 
 #define TEST_SRC_DIR "@abs_srcdir@"
+#define TEST_BUILD_DIR "@abs_builddir@"
+
 #define TEST_DATA_DIR "@abs_top_srcdir@/modules/dmrpp_module/data/dmrpp"
 #define TEST_DMRPP_CATALOG "@abs_top_srcdir@/modules/dmrpp_module"
 

--- a/modules/read_test_baseline.cc
+++ b/modules/read_test_baseline.cc
@@ -27,6 +27,10 @@
 #include <string>
 #include <vector>
 
+#include <cstdlib>  // for system
+
+#include "BESInternalError.h"
+
 #include "read_test_baseline.h"
 
 using namespace std;
@@ -68,6 +72,21 @@ read_test_baseline(const string &fn)
     buffer[length] = '\0';
 
     return string(&buffer[0]);
+}
+
+void clean_cache_dir(const string &cache)
+{
+    string cache_dir = cache + "/*";
+
+    string command = string("rm ") + cache_dir + " 2>/dev/null";
+
+    int status = system(command.c_str());
+
+    // it's normal for this to 'fail' because the clean operation has already
+    // been run or because it's the first run of the tests. But, fork and waitpid
+    // should not return an error and the shell should be found.
+    if (status == -1 || status == 127)
+        throw BESInternalError("Failed to clean cache dir: " + cache_dir, __FILE__, __LINE__);
 }
 
 } // namespace bes

--- a/modules/read_test_baseline.h
+++ b/modules/read_test_baseline.h
@@ -34,6 +34,7 @@
 namespace bes {
 
 std::string read_test_baseline(const std::string &fn);
+void clean_cache_dir(const std::string &cache);
 
 }
 #endif


### PR DESCRIPTION
This branch Extends the MDS so that it supports the DMR++ responses. I added the DmrppMetadataStore which specializes the GlobalMetadataStore. The GMS class can read the DMR++ _responses_ but only the DmrppMS can write them (since the responses are just text documents). The DmrppMS also has a get_dmrpp_object() method, FWIW.

To actually use this to populate the MDS with DMR++ responses, we will need to write code that does that. 

I added a unit-test that uses the DmrppMS to add a DMR++ response and then the GMS to write that response to a stream, so it will work to use the GMS class/instance to look for DMR++ responses in the bes/dap code.

I changed the name of the get_..._response() methods to write_..._response().