### PR TITLE
Repairing DAS baselines broken by corrected DAS output

### DIFF
--- a/modules/ncml_module/tests/baselines/agg/aggUnionSimple.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/aggUnionSimple.ncml.das
@@ -25,73 +25,35 @@ Attributes {
         Float64 actual_range 715511.0000000000, 729360.0000000000;
     }
     cldc {
-        cldc {
-            Float32 valid_range 0.00000000, 8.00000000;
-            Float32 actual_range 0.00000000, 8.00000000;
-            String units "okta";
-            Int16 precision 1;
-            Int16 missing_value 32766;
-            Int16 _FillValue 32766;
-            String long_name "Cloudiness Monthly Mean at Surface";
-            String dataset "COADS 1-degree Equatorial Enhanced\012AI";
-            String var_desc "Cloudiness\012C";
-            String level_desc "Surface\0120";
-            String statistic "Mean\012M";
-            String parent_stat "Individual Obs\012I";
-            Float32 add_offset 3276.50000;
-            Float32 scale_factor 0.100000001;
-        }
-        time {
-            String units "days since 1-1-1 00:00:0.0";
-            String long_name "Time";
-            String delta_t "0000-01-00 00:00:00";
-            String avg_period "0000-01-00 00:00:00";
-            Float64 actual_range 715511.0000000000, 729360.0000000000;
-        }
-        lat {
-            String long_name "Latitude";
-            String units "degrees_north";
-            Float32 actual_range 10.0000000, -10.0000000;
-        }
-        lon {
-            String long_name "Longitude";
-            String units "degrees_east";
-            Float32 actual_range 0.500000000, 359.500000;
-        }
+        Float32 valid_range 0.00000000, 8.00000000;
+        Float32 actual_range 0.00000000, 8.00000000;
+        String units "okta";
+        Int16 precision 1;
+        Int16 missing_value 32766;
+        Int16 _FillValue 32766;
+        String long_name "Cloudiness Monthly Mean at Surface";
+        String dataset "COADS 1-degree Equatorial Enhanced\012AI";
+        String var_desc "Cloudiness\012C";
+        String level_desc "Surface\0120";
+        String statistic "Mean\012M";
+        String parent_stat "Individual Obs\012I";
+        Float32 add_offset 3276.50000;
+        Float32 scale_factor 0.100000001;
     }
     lflx {
-        lflx {
-            Float32 valid_range -1000.00000, 1000.00000;
-            Float32 actual_range -88.7000046, 236.100006;
-            String units "grams/kg m/s";
-            Int16 precision 1;
-            Int16 missing_value 32766;
-            Int16 _FillValue 32766;
-            String long_name "Latent Heat Parameter Monthly Mean at Surface";
-            String dataset "COADS 1-degree Equatorial Enhanced\012AI";
-            String var_desc "Latent Heat Parameter\012G";
-            String level_desc "Surface\0120";
-            String statistic "Mean\012M";
-            String parent_stat "Individual Obs\012I";
-            Float32 add_offset 2276.50000;
-            Float32 scale_factor 0.100000001;
-        }
-        time {
-            String units "days since 1-1-1 00:00:0.0";
-            String long_name "Time";
-            String delta_t "0000-01-00 00:00:00";
-            String avg_period "0000-01-00 00:00:00";
-            Float64 actual_range 715511.0000000000, 729360.0000000000;
-        }
-        lat {
-            String long_name "Latitude";
-            String units "degrees_north";
-            Float32 actual_range 10.0000000, -10.0000000;
-        }
-        lon {
-            String long_name "Longitude";
-            String units "degrees_east";
-            Float32 actual_range 0.500000000, 359.500000;
-        }
+        Float32 valid_range -1000.00000, 1000.00000;
+        Float32 actual_range -88.7000046, 236.100006;
+        String units "grams/kg m/s";
+        Int16 precision 1;
+        Int16 missing_value 32766;
+        Int16 _FillValue 32766;
+        String long_name "Latent Heat Parameter Monthly Mean at Surface";
+        String dataset "COADS 1-degree Equatorial Enhanced\012AI";
+        String var_desc "Latent Heat Parameter\012G";
+        String level_desc "Surface\0120";
+        String statistic "Mean\012M";
+        String parent_stat "Individual Obs\012I";
+        Float32 add_offset 2276.50000;
+        Float32 scale_factor 0.100000001;
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinExist_scan.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinExist_scan.ncml.das
@@ -9,14 +9,6 @@ Attributes {
         String Description "Test coordinate variable time.";
     }
     v {
-        v {
-            String Description "Test output data array v";
-        }
-        time {
-            String Description "Test coordinate variable time.";
-        }
-        x {
-            String Description "Test coordinate variable x.";
-        }
+        String Description "Test output data array v";
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinExist_scan_ncoords.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinExist_scan_ncoords.ncml.das
@@ -9,14 +9,6 @@ Attributes {
         String Description "Test coordinate variable time.";
     }
     v {
-        v {
-            String Description "Test output data array v";
-        }
-        time {
-            String Description "Test coordinate variable time.";
-        }
-        x {
-            String Description "Test coordinate variable x.";
-        }
+        String Description "Test output data array v";
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinExist_ugrid_scan.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinExist_ugrid_scan.ncml.das
@@ -17,8 +17,6 @@ Attributes {
         Int32 start_index 1;
         String standard_name "face_node_connectivity";
     }
-    time {
-    }
     twoDnodedata {
         String coordinates "Y X";
         String mesh "fvcom_mesh";

--- a/modules/ncml_module/tests/baselines/agg/joinExisting_multi.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinExisting_multi.ncml.das
@@ -1,12 +1,2 @@
 Attributes {
-    Decoy {
-    }
-    A {
-    }
-    B {
-    }
-    A_expected {
-    }
-    B_expected {
-    }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinExisting_simple_grid.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinExisting_simple_grid.ncml.das
@@ -10,14 +10,6 @@ Attributes {
         String Description "Test coordinate variable time.";
     }
     v {
-        v {
-            String Description "Test output data array v";
-        }
-        time {
-            String Description "Test coordinate variable time.";
-        }
-        x {
-            String Description "Test coordinate variable x.";
-        }
+        String Description "Test output data array v";
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinExisting_varAgg.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinExisting_varAgg.ncml.das
@@ -1,6 +1,2 @@
 Attributes {
-    B {
-    }
-    B_expected {
-    }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinExisting_virtual_fine.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinExisting_virtual_fine.ncml.das
@@ -2,8 +2,6 @@ Attributes {
     NC_GLOBAL {
         String Description "A global aggregation attribute.";
     }
-    V {
-    }
     V_expected {
         String Description "A test attribute for V_expected";
     }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_explicit_autogen.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_explicit_autogen.ncml.das
@@ -1,6 +1,4 @@
 Attributes {
-    V {
-    }
     day {
         String units "days since 2000-1-01 00:00";
     }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_grid_arr_hslab_0.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_grid_arr_hslab_0.das
@@ -103,56 +103,26 @@ Attributes {
         Float32 dsp_hgt_llvect 869.428, 1.14767, 868.659, 1.09635, 867.84, 1.04502, 866.979, 0.9937, 866.084, 0.942374, 865.165, 0.891045, 864.231, 0.839715, 863.292, 0.788383, 862.356, 0.737049, 861.434, 0.685714, 860.536, 0.634378, 859.67, 0.58304, 858.847, 0.531702, 858.075, 0.480362, 857.363, 0.429022, 856.718, 0.377682, 856.148, 0.326341, 855.66, 0.275, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
         String history "\001PATHNLC May 23 22:40:54 2000 PATHNLC t,3,269.16,0.125,0.,0.01,271.16,308.16,,,,1,,,2,,,3,,,,,,4,,,,,,,2.,,35.,0.1,5,,,,,,,2.,,35.,0.15,55.,80.,0.005,20,,,-2,6.,t,,,,,,,,,,16,,3.5 allb=0 nlsst=1 in=/pathfdr5//97182070958.N14@INGEST@ in1=/pathfdr10/mask/oi.9727.mean out=/pathfdr4/nlc/f97182070958.FMG@0\012\004PATHNLC  NLSST Temp calculation date: April 10, 1996\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 26 97 06 22 97 06 28  7        472\012\001STATS Jan 12 18:27:34 1998 STATS minpix=1 maxpix=255 in=/usr3/gacsst/maketc/oi/dout//oi.9726 \011  audit=t, callim=f, cal=f, cloud=f \011  outm=/usr3/gacsst/etc/oi/oi.9727.mean\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 28 97 07 06 97 07 12  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9728\012\002PATHNLC /pathfdr10/mask/oi.9727.mean\012\004PATHNLC  45d coeffs used (1) =    0.759   0.947   0.110   1.460   0.000\012\004PATHNLC  45d coeffs used (2) =    1.320   0.952   0.071   0.882   0.000\012\004PATHNLC  45d coeffs used (3) =    0.000   0.000   0.000   0.000   0.000\012\004PATHNLC  GETOZONE I     0.0900    0.0000\012\001REMAP Jun  4 07:59:42 2000 REMAP in=/coral/miami/remaps/sst_8r/file_uZ.FMG out=/coral/miami/remaps/sst_8r/f97182070958.nwa16\012\004REMAP Output image pixel, line size =    6144,    6144\012\004REMAP Grid spacing (X,Y) = (        6.00,        6.00), Projection Code=     1\012\004REMAP center lon,lat,dlon,dlat =       -70.00       38.00        0.01        0.01\012\001merge_sb Apr 16 16:05:09 2004 merge_sb in=(file=/NOPP/carlw/atlantic/remaps/nwa16/f97182070958.nwa16, filecheck=/RAID2/sbaker/atlantic/bslines97/f97182070958.nwa16) val=0 valcheck=0 tag=0 out=(file1=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2)\012\001merge_sb Apr 16 16:05:18 2004 merge_sb in=(file=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2, filecheck=/RAID/sbaker/DECLOUD/landmask16.img) val=1 valcheck=2 tag=0 out=(file1=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16)\012\001CONVRT Apr 16 16:05:21 2004 CONVRT 1024,1024,0,0,6,6,0,0,f,f,t,16,,SUB,1 in=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16   out=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.nwa16\012\012@\000\000\000";
     }
-    filename {
-    }
     dsp_band_1 {
-        Byte dsp_PixelType 1;
-        Byte dsp_PixelSize 2;
-        UInt16 dsp_Flag 0;
-        UInt16 dsp_nBits 16;
-        Int32 dsp_LineSize 0;
-        String dsp_cal_name "Temperature";
-        String units "Temp";
-        UInt16 dsp_cal_eqnNumber 2;
-        UInt16 dsp_cal_CoeffsLength 8;
-        Float32 dsp_cal_coeffs 0.125, -4;
-        Float32 scale_factor 0.125;
-        Float32 add_off -4;
-        dsp_band_1 {
-            Byte dsp_PixelType 1;
-            Byte dsp_PixelSize 2;
-            UInt16 dsp_Flag 0;
-            UInt16 dsp_nBits 16;
-            Int32 dsp_LineSize 0;
-            String dsp_cal_name "Temperature";
-            String units "Temp";
-            UInt16 dsp_cal_eqnNumber 2;
-            UInt16 dsp_cal_CoeffsLength 8;
-            Float32 dsp_cal_coeffs 0.125, -4;
-            Float32 scale_factor 0.125;
-            Float32 add_off -4;
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        Byte dsp_PixelType 1, 1;
+        Byte dsp_PixelSize 2, 2;
+        UInt16 dsp_Flag 0, 0;
+        UInt16 dsp_nBits 16, 16;
+        Int32 dsp_LineSize 0, 0;
+        String dsp_cal_name "Temperature", "Temperature";
+        String units "Temp", "Temp";
+        UInt16 dsp_cal_eqnNumber 2, 2;
+        UInt16 dsp_cal_CoeffsLength 8, 8;
+        Float32 dsp_cal_coeffs 0.125, -4, 0.125, -4;
+        Float32 scale_factor 0.125, 0.125;
+        Float32 add_off -4, -4;
+        dim_0 {
+            String name "lat";
+            String long_name "latitude";
         }
-        filename {
-        }
-        lat {
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-        }
-        lon {
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        dim_1 {
+            String name "lon";
+            String long_name "longitude";
         }
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_grid_hslab_0.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_grid_hslab_0.das
@@ -103,56 +103,26 @@ Attributes {
         Float32 dsp_hgt_llvect 869.428, 1.14767, 868.659, 1.09635, 867.84, 1.04502, 866.979, 0.9937, 866.084, 0.942374, 865.165, 0.891045, 864.231, 0.839715, 863.292, 0.788383, 862.356, 0.737049, 861.434, 0.685714, 860.536, 0.634378, 859.67, 0.58304, 858.847, 0.531702, 858.075, 0.480362, 857.363, 0.429022, 856.718, 0.377682, 856.148, 0.326341, 855.66, 0.275, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
         String history "\001PATHNLC May 23 22:40:54 2000 PATHNLC t,3,269.16,0.125,0.,0.01,271.16,308.16,,,,1,,,2,,,3,,,,,,4,,,,,,,2.,,35.,0.1,5,,,,,,,2.,,35.,0.15,55.,80.,0.005,20,,,-2,6.,t,,,,,,,,,,16,,3.5 allb=0 nlsst=1 in=/pathfdr5//97182070958.N14@INGEST@ in1=/pathfdr10/mask/oi.9727.mean out=/pathfdr4/nlc/f97182070958.FMG@0\012\004PATHNLC  NLSST Temp calculation date: April 10, 1996\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 26 97 06 22 97 06 28  7        472\012\001STATS Jan 12 18:27:34 1998 STATS minpix=1 maxpix=255 in=/usr3/gacsst/maketc/oi/dout//oi.9726 \011  audit=t, callim=f, cal=f, cloud=f \011  outm=/usr3/gacsst/etc/oi/oi.9727.mean\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 28 97 07 06 97 07 12  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9728\012\002PATHNLC /pathfdr10/mask/oi.9727.mean\012\004PATHNLC  45d coeffs used (1) =    0.759   0.947   0.110   1.460   0.000\012\004PATHNLC  45d coeffs used (2) =    1.320   0.952   0.071   0.882   0.000\012\004PATHNLC  45d coeffs used (3) =    0.000   0.000   0.000   0.000   0.000\012\004PATHNLC  GETOZONE I     0.0900    0.0000\012\001REMAP Jun  4 07:59:42 2000 REMAP in=/coral/miami/remaps/sst_8r/file_uZ.FMG out=/coral/miami/remaps/sst_8r/f97182070958.nwa16\012\004REMAP Output image pixel, line size =    6144,    6144\012\004REMAP Grid spacing (X,Y) = (        6.00,        6.00), Projection Code=     1\012\004REMAP center lon,lat,dlon,dlat =       -70.00       38.00        0.01        0.01\012\001merge_sb Apr 16 16:05:09 2004 merge_sb in=(file=/NOPP/carlw/atlantic/remaps/nwa16/f97182070958.nwa16, filecheck=/RAID2/sbaker/atlantic/bslines97/f97182070958.nwa16) val=0 valcheck=0 tag=0 out=(file1=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2)\012\001merge_sb Apr 16 16:05:18 2004 merge_sb in=(file=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2, filecheck=/RAID/sbaker/DECLOUD/landmask16.img) val=1 valcheck=2 tag=0 out=(file1=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16)\012\001CONVRT Apr 16 16:05:21 2004 CONVRT 1024,1024,0,0,6,6,0,0,f,f,t,16,,SUB,1 in=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16   out=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.nwa16\012\012@\000\000\000";
     }
-    filename {
-    }
     dsp_band_1 {
-        Byte dsp_PixelType 1;
-        Byte dsp_PixelSize 2;
-        UInt16 dsp_Flag 0;
-        UInt16 dsp_nBits 16;
-        Int32 dsp_LineSize 0;
-        String dsp_cal_name "Temperature";
-        String units "Temp";
-        UInt16 dsp_cal_eqnNumber 2;
-        UInt16 dsp_cal_CoeffsLength 8;
-        Float32 dsp_cal_coeffs 0.125, -4;
-        Float32 scale_factor 0.125;
-        Float32 add_off -4;
-        dsp_band_1 {
-            Byte dsp_PixelType 1;
-            Byte dsp_PixelSize 2;
-            UInt16 dsp_Flag 0;
-            UInt16 dsp_nBits 16;
-            Int32 dsp_LineSize 0;
-            String dsp_cal_name "Temperature";
-            String units "Temp";
-            UInt16 dsp_cal_eqnNumber 2;
-            UInt16 dsp_cal_CoeffsLength 8;
-            Float32 dsp_cal_coeffs 0.125, -4;
-            Float32 scale_factor 0.125;
-            Float32 add_off -4;
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        Byte dsp_PixelType 1, 1;
+        Byte dsp_PixelSize 2, 2;
+        UInt16 dsp_Flag 0, 0;
+        UInt16 dsp_nBits 16, 16;
+        Int32 dsp_LineSize 0, 0;
+        String dsp_cal_name "Temperature", "Temperature";
+        String units "Temp", "Temp";
+        UInt16 dsp_cal_eqnNumber 2, 2;
+        UInt16 dsp_cal_CoeffsLength 8, 8;
+        Float32 dsp_cal_coeffs 0.125, -4, 0.125, -4;
+        Float32 scale_factor 0.125, 0.125;
+        Float32 add_off -4, -4;
+        dim_0 {
+            String name "lat";
+            String long_name "latitude";
         }
-        filename {
-        }
-        lat {
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-        }
-        lon {
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        dim_1 {
+            String name "lon";
+            String long_name "longitude";
         }
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_grid_meta_2.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_grid_meta_2.ncml.das
@@ -104,54 +104,25 @@ Attributes {
         String history "\001PATHNLC May 23 22:40:54 2000 PATHNLC t,3,269.16,0.125,0.,0.01,271.16,308.16,,,,1,,,2,,,3,,,,,,4,,,,,,,2.,,35.,0.1,5,,,,,,,2.,,35.,0.15,55.,80.,0.005,20,,,-2,6.,t,,,,,,,,,,16,,3.5 allb=0 nlsst=1 in=/pathfdr5//97182070958.N14@INGEST@ in1=/pathfdr10/mask/oi.9727.mean out=/pathfdr4/nlc/f97182070958.FMG@0\012\004PATHNLC  NLSST Temp calculation date: April 10, 1996\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 26 97 06 22 97 06 28  7        472\012\001STATS Jan 12 18:27:34 1998 STATS minpix=1 maxpix=255 in=/usr3/gacsst/maketc/oi/dout//oi.9726 \011  audit=t, callim=f, cal=f, cloud=f \011  outm=/usr3/gacsst/etc/oi/oi.9727.mean\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 28 97 07 06 97 07 12  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9728\012\002PATHNLC /pathfdr10/mask/oi.9727.mean\012\004PATHNLC  45d coeffs used (1) =    0.759   0.947   0.110   1.460   0.000\012\004PATHNLC  45d coeffs used (2) =    1.320   0.952   0.071   0.882   0.000\012\004PATHNLC  45d coeffs used (3) =    0.000   0.000   0.000   0.000   0.000\012\004PATHNLC  GETOZONE I     0.0900    0.0000\012\001REMAP Jun  4 07:59:42 2000 REMAP in=/coral/miami/remaps/sst_8r/file_uZ.FMG out=/coral/miami/remaps/sst_8r/f97182070958.nwa16\012\004REMAP Output image pixel, line size =    6144,    6144\012\004REMAP Grid spacing (X,Y) = (        6.00,        6.00), Projection Code=     1\012\004REMAP center lon,lat,dlon,dlat =       -70.00       38.00        0.01        0.01\012\001merge_sb Apr 16 16:05:09 2004 merge_sb in=(file=/NOPP/carlw/atlantic/remaps/nwa16/f97182070958.nwa16, filecheck=/RAID2/sbaker/atlantic/bslines97/f97182070958.nwa16) val=0 valcheck=0 tag=0 out=(file1=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2)\012\001merge_sb Apr 16 16:05:18 2004 merge_sb in=(file=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2, filecheck=/RAID/sbaker/DECLOUD/landmask16.img) val=1 valcheck=2 tag=0 out=(file1=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16)\012\001CONVRT Apr 16 16:05:21 2004 CONVRT 1024,1024,0,0,6,6,0,0,f,f,t,16,,SUB,1 in=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16   out=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.nwa16\012\012@\000\000\000";
     }
     dsp_band_1 {
-        Byte dsp_PixelType 1;
-        Byte dsp_PixelSize 2;
-        UInt16 dsp_Flag 0;
-        UInt16 dsp_nBits 16;
-        Int32 dsp_LineSize 0;
-        String dsp_cal_name "Temperature";
-        String units "Temp";
-        UInt16 dsp_cal_eqnNumber 2;
-        UInt16 dsp_cal_CoeffsLength 8;
-        Float32 dsp_cal_coeffs 0.125, -4;
-        Float32 scale_factor 0.125;
-        Float32 add_off -4;
-        dsp_band_1 {
-            Byte dsp_PixelType 1;
-            Byte dsp_PixelSize 2;
-            UInt16 dsp_Flag 0;
-            UInt16 dsp_nBits 16;
-            Int32 dsp_LineSize 0;
-            String dsp_cal_name "Temperature";
-            String units "Temp";
-            UInt16 dsp_cal_eqnNumber 2;
-            UInt16 dsp_cal_CoeffsLength 8;
-            Float32 dsp_cal_coeffs 0.125, -4;
-            Float32 scale_factor 0.125;
-            Float32 add_off -4;
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        Byte dsp_PixelType 1, 1;
+        Byte dsp_PixelSize 2, 2;
+        UInt16 dsp_Flag 0, 0;
+        UInt16 dsp_nBits 16, 16;
+        Int32 dsp_LineSize 0, 0;
+        String dsp_cal_name "Temperature", "Temperature";
+        String units "Temp", "Temp";
+        UInt16 dsp_cal_eqnNumber 2, 2;
+        UInt16 dsp_cal_CoeffsLength 8, 8;
+        Float32 dsp_cal_coeffs 0.125, -4, 0.125, -4;
+        Float32 scale_factor 0.125, 0.125;
+        Float32 add_off -4, -4;
+        dim_0 {
+            String name "lat";
+            String long_name "latitude";
         }
-        station {
-            String units "Station ID";
-        }
-        lat {
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-        }
-        lon {
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        dim_1 {
+            String name "lon";
+            String long_name "longitude";
         }
     }
     station {

--- a/modules/ncml_module/tests/baselines/agg/joinNew_grid_meta_everywhere.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_grid_meta_everywhere.ncml.das
@@ -104,57 +104,26 @@ Attributes {
         String history "\001PATHNLC May 23 22:40:54 2000 PATHNLC t,3,269.16,0.125,0.,0.01,271.16,308.16,,,,1,,,2,,,3,,,,,,4,,,,,,,2.,,35.,0.1,5,,,,,,,2.,,35.,0.15,55.,80.,0.005,20,,,-2,6.,t,,,,,,,,,,16,,3.5 allb=0 nlsst=1 in=/pathfdr5//97182070958.N14@INGEST@ in1=/pathfdr10/mask/oi.9727.mean out=/pathfdr4/nlc/f97182070958.FMG@0\012\004PATHNLC  NLSST Temp calculation date: April 10, 1996\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 26 97 06 22 97 06 28  7        472\012\001STATS Jan 12 18:27:34 1998 STATS minpix=1 maxpix=255 in=/usr3/gacsst/maketc/oi/dout//oi.9726 \011  audit=t, callim=f, cal=f, cloud=f \011  outm=/usr3/gacsst/etc/oi/oi.9727.mean\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 28 97 07 06 97 07 12  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9728\012\002PATHNLC /pathfdr10/mask/oi.9727.mean\012\004PATHNLC  45d coeffs used (1) =    0.759   0.947   0.110   1.460   0.000\012\004PATHNLC  45d coeffs used (2) =    1.320   0.952   0.071   0.882   0.000\012\004PATHNLC  45d coeffs used (3) =    0.000   0.000   0.000   0.000   0.000\012\004PATHNLC  GETOZONE I     0.0900    0.0000\012\001REMAP Jun  4 07:59:42 2000 REMAP in=/coral/miami/remaps/sst_8r/file_uZ.FMG out=/coral/miami/remaps/sst_8r/f97182070958.nwa16\012\004REMAP Output image pixel, line size =    6144,    6144\012\004REMAP Grid spacing (X,Y) = (        6.00,        6.00), Projection Code=     1\012\004REMAP center lon,lat,dlon,dlat =       -70.00       38.00        0.01        0.01\012\001merge_sb Apr 16 16:05:09 2004 merge_sb in=(file=/NOPP/carlw/atlantic/remaps/nwa16/f97182070958.nwa16, filecheck=/RAID2/sbaker/atlantic/bslines97/f97182070958.nwa16) val=0 valcheck=0 tag=0 out=(file1=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2)\012\001merge_sb Apr 16 16:05:18 2004 merge_sb in=(file=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2, filecheck=/RAID/sbaker/DECLOUD/landmask16.img) val=1 valcheck=2 tag=0 out=(file1=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16)\012\001CONVRT Apr 16 16:05:21 2004 CONVRT 1024,1024,0,0,6,6,0,0,f,f,t,16,,SUB,1 in=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16   out=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.nwa16\012\012@\000\000\000";
     }
     dsp_band_1 {
-        Byte dsp_PixelType 1;
-        Byte dsp_PixelSize 2;
-        UInt16 dsp_Flag 0;
-        UInt16 dsp_nBits 16;
-        Int32 dsp_LineSize 0;
-        String dsp_cal_name "Temperature";
-        String units "Temp";
-        UInt16 dsp_cal_eqnNumber 2;
-        UInt16 dsp_cal_CoeffsLength 8;
-        Float32 dsp_cal_coeffs 0.125, -4;
-        Float32 scale_factor 0.125;
-        Float32 add_off -4;
+        Byte dsp_PixelType 1, 1;
+        Byte dsp_PixelSize 2, 2;
+        UInt16 dsp_Flag 0, 0;
+        UInt16 dsp_nBits 16, 16;
+        Int32 dsp_LineSize 0, 0;
+        String dsp_cal_name "Temperature", "Temperature";
+        String units "Temp", "Temp (packed)";
+        UInt16 dsp_cal_eqnNumber 2, 2;
+        UInt16 dsp_cal_CoeffsLength 8, 8;
+        Float32 dsp_cal_coeffs 0.125, -4, 0.125, -4;
+        Float32 scale_factor 0.125, 0.125;
+        Float32 add_off -4, -4;
         String Info "This is metadata on the Grid itself.";
-        dsp_band_1 {
-            Byte dsp_PixelType 1;
-            Byte dsp_PixelSize 2;
-            UInt16 dsp_Flag 0;
-            UInt16 dsp_nBits 16;
-            Int32 dsp_LineSize 0;
-            String dsp_cal_name "Temperature";
-            UInt16 dsp_cal_eqnNumber 2;
-            UInt16 dsp_cal_CoeffsLength 8;
-            Float32 dsp_cal_coeffs 0.125, -4;
-            Float32 scale_factor 0.125;
-            Float32 add_off -4;
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
-            String units "Temp (packed)";
+        dim_0 {
+            String name "lat";
+            String long_name "latitude";
         }
-        filename {
-            String Info "Filename with timestamp";
-        }
-        lat {
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-            String units "degrees_north";
-        }
-        lon {
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
-            String units "degrees_east";
+        dim_1 {
+            String name "lon";
+            String long_name "longitude";
         }
     }
     filename {

--- a/modules/ncml_module/tests/baselines/agg/joinNew_grid_metadata.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_grid_metadata.ncml.das
@@ -104,54 +104,25 @@ Attributes {
         String history "\001PATHNLC May 23 22:40:54 2000 PATHNLC t,3,269.16,0.125,0.,0.01,271.16,308.16,,,,1,,,2,,,3,,,,,,4,,,,,,,2.,,35.,0.1,5,,,,,,,2.,,35.,0.15,55.,80.,0.005,20,,,-2,6.,t,,,,,,,,,,16,,3.5 allb=0 nlsst=1 in=/pathfdr5//97182070958.N14@INGEST@ in1=/pathfdr10/mask/oi.9727.mean out=/pathfdr4/nlc/f97182070958.FMG@0\012\004PATHNLC  NLSST Temp calculation date: April 10, 1996\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 26 97 06 22 97 06 28  7        472\012\001STATS Jan 12 18:27:34 1998 STATS minpix=1 maxpix=255 in=/usr3/gacsst/maketc/oi/dout//oi.9726 \011  audit=t, callim=f, cal=f, cloud=f \011  outm=/usr3/gacsst/etc/oi/oi.9727.mean\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 28 97 07 06 97 07 12  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9728\012\002PATHNLC /pathfdr10/mask/oi.9727.mean\012\004PATHNLC  45d coeffs used (1) =    0.759   0.947   0.110   1.460   0.000\012\004PATHNLC  45d coeffs used (2) =    1.320   0.952   0.071   0.882   0.000\012\004PATHNLC  45d coeffs used (3) =    0.000   0.000   0.000   0.000   0.000\012\004PATHNLC  GETOZONE I     0.0900    0.0000\012\001REMAP Jun  4 07:59:42 2000 REMAP in=/coral/miami/remaps/sst_8r/file_uZ.FMG out=/coral/miami/remaps/sst_8r/f97182070958.nwa16\012\004REMAP Output image pixel, line size =    6144,    6144\012\004REMAP Grid spacing (X,Y) = (        6.00,        6.00), Projection Code=     1\012\004REMAP center lon,lat,dlon,dlat =       -70.00       38.00        0.01        0.01\012\001merge_sb Apr 16 16:05:09 2004 merge_sb in=(file=/NOPP/carlw/atlantic/remaps/nwa16/f97182070958.nwa16, filecheck=/RAID2/sbaker/atlantic/bslines97/f97182070958.nwa16) val=0 valcheck=0 tag=0 out=(file1=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2)\012\001merge_sb Apr 16 16:05:18 2004 merge_sb in=(file=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2, filecheck=/RAID/sbaker/DECLOUD/landmask16.img) val=1 valcheck=2 tag=0 out=(file1=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16)\012\001CONVRT Apr 16 16:05:21 2004 CONVRT 1024,1024,0,0,6,6,0,0,f,f,t,16,,SUB,1 in=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16   out=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.nwa16\012\012@\000\000\000";
     }
     dsp_band_1 {
-        Byte dsp_PixelType 1;
-        Byte dsp_PixelSize 2;
-        UInt16 dsp_Flag 0;
-        UInt16 dsp_nBits 16;
-        Int32 dsp_LineSize 0;
-        String dsp_cal_name "Temperature";
-        String units "Temp";
-        UInt16 dsp_cal_eqnNumber 2;
-        UInt16 dsp_cal_CoeffsLength 8;
-        Float32 dsp_cal_coeffs 0.125, -4;
-        Float32 scale_factor 0.125;
-        Float32 add_off -4;
-        dsp_band_1 {
-            Byte dsp_PixelType 1;
-            Byte dsp_PixelSize 2;
-            UInt16 dsp_Flag 0;
-            UInt16 dsp_nBits 16;
-            Int32 dsp_LineSize 0;
-            String dsp_cal_name "Temperature";
-            String units "Temp";
-            UInt16 dsp_cal_eqnNumber 2;
-            UInt16 dsp_cal_CoeffsLength 8;
-            Float32 dsp_cal_coeffs 0.125, -4;
-            Float32 scale_factor 0.125;
-            Float32 add_off -4;
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        Byte dsp_PixelType 1, 1;
+        Byte dsp_PixelSize 2, 2;
+        UInt16 dsp_Flag 0, 0;
+        UInt16 dsp_nBits 16, 16;
+        Int32 dsp_LineSize 0, 0;
+        String dsp_cal_name "Temperature", "Temperature";
+        String units "Temp", "Temp";
+        UInt16 dsp_cal_eqnNumber 2, 2;
+        UInt16 dsp_cal_CoeffsLength 8, 8;
+        Float32 dsp_cal_coeffs 0.125, -4, 0.125, -4;
+        Float32 scale_factor 0.125, 0.125;
+        Float32 add_off -4, -4;
+        dim_0 {
+            String name "lat";
+            String long_name "latitude";
         }
-        filename {
-            String units "Filename of the datafile";
-        }
-        lat {
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-        }
-        lon {
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        dim_1 {
+            String name "lon";
+            String long_name "longitude";
         }
     }
     filename {

--- a/modules/ncml_module/tests/baselines/agg/joinNew_grid_pre_metadata.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_grid_pre_metadata.ncml.das
@@ -104,54 +104,25 @@ Attributes {
         String history "\001PATHNLC May 23 22:40:54 2000 PATHNLC t,3,269.16,0.125,0.,0.01,271.16,308.16,,,,1,,,2,,,3,,,,,,4,,,,,,,2.,,35.,0.1,5,,,,,,,2.,,35.,0.15,55.,80.,0.005,20,,,-2,6.,t,,,,,,,,,,16,,3.5 allb=0 nlsst=1 in=/pathfdr5//97182070958.N14@INGEST@ in1=/pathfdr10/mask/oi.9727.mean out=/pathfdr4/nlc/f97182070958.FMG@0\012\004PATHNLC  NLSST Temp calculation date: April 10, 1996\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 26 97 06 22 97 06 28  7        472\012\001STATS Jan 12 18:27:34 1998 STATS minpix=1 maxpix=255 in=/usr3/gacsst/maketc/oi/dout//oi.9726 \011  audit=t, callim=f, cal=f, cloud=f \011  outm=/usr3/gacsst/etc/oi/oi.9727.mean\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 28 97 07 06 97 07 12  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9728\012\002PATHNLC /pathfdr10/mask/oi.9727.mean\012\004PATHNLC  45d coeffs used (1) =    0.759   0.947   0.110   1.460   0.000\012\004PATHNLC  45d coeffs used (2) =    1.320   0.952   0.071   0.882   0.000\012\004PATHNLC  45d coeffs used (3) =    0.000   0.000   0.000   0.000   0.000\012\004PATHNLC  GETOZONE I     0.0900    0.0000\012\001REMAP Jun  4 07:59:42 2000 REMAP in=/coral/miami/remaps/sst_8r/file_uZ.FMG out=/coral/miami/remaps/sst_8r/f97182070958.nwa16\012\004REMAP Output image pixel, line size =    6144,    6144\012\004REMAP Grid spacing (X,Y) = (        6.00,        6.00), Projection Code=     1\012\004REMAP center lon,lat,dlon,dlat =       -70.00       38.00        0.01        0.01\012\001merge_sb Apr 16 16:05:09 2004 merge_sb in=(file=/NOPP/carlw/atlantic/remaps/nwa16/f97182070958.nwa16, filecheck=/RAID2/sbaker/atlantic/bslines97/f97182070958.nwa16) val=0 valcheck=0 tag=0 out=(file1=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2)\012\001merge_sb Apr 16 16:05:18 2004 merge_sb in=(file=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2, filecheck=/RAID/sbaker/DECLOUD/landmask16.img) val=1 valcheck=2 tag=0 out=(file1=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16)\012\001CONVRT Apr 16 16:05:21 2004 CONVRT 1024,1024,0,0,6,6,0,0,f,f,t,16,,SUB,1 in=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16   out=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.nwa16\012\012@\000\000\000";
     }
     dsp_band_1 {
-        Byte dsp_PixelType 1;
-        Byte dsp_PixelSize 2;
-        UInt16 dsp_Flag 0;
-        UInt16 dsp_nBits 16;
-        Int32 dsp_LineSize 0;
-        String dsp_cal_name "Temperature";
-        String units "Temp";
-        UInt16 dsp_cal_eqnNumber 2;
-        UInt16 dsp_cal_CoeffsLength 8;
-        Float32 dsp_cal_coeffs 0.125, -4;
-        Float32 scale_factor 0.125;
-        Float32 add_off -4;
-        dsp_band_1 {
-            Byte dsp_PixelType 1;
-            Byte dsp_PixelSize 2;
-            UInt16 dsp_Flag 0;
-            UInt16 dsp_nBits 16;
-            Int32 dsp_LineSize 0;
-            String dsp_cal_name "Temperature";
-            String units "Temp";
-            UInt16 dsp_cal_eqnNumber 2;
-            UInt16 dsp_cal_CoeffsLength 8;
-            Float32 dsp_cal_coeffs 0.125, -4;
-            Float32 scale_factor 0.125;
-            Float32 add_off -4;
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        Byte dsp_PixelType 1, 1;
+        Byte dsp_PixelSize 2, 2;
+        UInt16 dsp_Flag 0, 0;
+        UInt16 dsp_nBits 16, 16;
+        Int32 dsp_LineSize 0, 0;
+        String dsp_cal_name "Temperature", "Temperature";
+        String units "Temp", "Temp";
+        UInt16 dsp_cal_eqnNumber 2, 2;
+        UInt16 dsp_cal_CoeffsLength 8, 8;
+        Float32 dsp_cal_coeffs 0.125, -4, 0.125, -4;
+        Float32 scale_factor 0.125, 0.125;
+        Float32 add_off -4, -4;
+        dim_0 {
+            String name "lat";
+            String long_name "latitude";
         }
-        filename {
-            String units "Filename of the datafile";
-        }
-        lat {
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-        }
-        lon {
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        dim_1 {
+            String name "lon";
+            String long_name "longitude";
         }
     }
     filename {

--- a/modules/ncml_module/tests/baselines/agg/joinNew_grid_proj_lat.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_grid_proj_lat.das
@@ -103,56 +103,26 @@ Attributes {
         Float32 dsp_hgt_llvect 869.428, 1.14767, 868.659, 1.09635, 867.84, 1.04502, 866.979, 0.9937, 866.084, 0.942374, 865.165, 0.891045, 864.231, 0.839715, 863.292, 0.788383, 862.356, 0.737049, 861.434, 0.685714, 860.536, 0.634378, 859.67, 0.58304, 858.847, 0.531702, 858.075, 0.480362, 857.363, 0.429022, 856.718, 0.377682, 856.148, 0.326341, 855.66, 0.275, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
         String history "\001PATHNLC May 23 22:40:54 2000 PATHNLC t,3,269.16,0.125,0.,0.01,271.16,308.16,,,,1,,,2,,,3,,,,,,4,,,,,,,2.,,35.,0.1,5,,,,,,,2.,,35.,0.15,55.,80.,0.005,20,,,-2,6.,t,,,,,,,,,,16,,3.5 allb=0 nlsst=1 in=/pathfdr5//97182070958.N14@INGEST@ in1=/pathfdr10/mask/oi.9727.mean out=/pathfdr4/nlc/f97182070958.FMG@0\012\004PATHNLC  NLSST Temp calculation date: April 10, 1996\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 26 97 06 22 97 06 28  7        472\012\001STATS Jan 12 18:27:34 1998 STATS minpix=1 maxpix=255 in=/usr3/gacsst/maketc/oi/dout//oi.9726 \011  audit=t, callim=f, cal=f, cloud=f \011  outm=/usr3/gacsst/etc/oi/oi.9727.mean\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 28 97 07 06 97 07 12  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9728\012\002PATHNLC /pathfdr10/mask/oi.9727.mean\012\004PATHNLC  45d coeffs used (1) =    0.759   0.947   0.110   1.460   0.000\012\004PATHNLC  45d coeffs used (2) =    1.320   0.952   0.071   0.882   0.000\012\004PATHNLC  45d coeffs used (3) =    0.000   0.000   0.000   0.000   0.000\012\004PATHNLC  GETOZONE I     0.0900    0.0000\012\001REMAP Jun  4 07:59:42 2000 REMAP in=/coral/miami/remaps/sst_8r/file_uZ.FMG out=/coral/miami/remaps/sst_8r/f97182070958.nwa16\012\004REMAP Output image pixel, line size =    6144,    6144\012\004REMAP Grid spacing (X,Y) = (        6.00,        6.00), Projection Code=     1\012\004REMAP center lon,lat,dlon,dlat =       -70.00       38.00        0.01        0.01\012\001merge_sb Apr 16 16:05:09 2004 merge_sb in=(file=/NOPP/carlw/atlantic/remaps/nwa16/f97182070958.nwa16, filecheck=/RAID2/sbaker/atlantic/bslines97/f97182070958.nwa16) val=0 valcheck=0 tag=0 out=(file1=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2)\012\001merge_sb Apr 16 16:05:18 2004 merge_sb in=(file=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2, filecheck=/RAID/sbaker/DECLOUD/landmask16.img) val=1 valcheck=2 tag=0 out=(file1=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16)\012\001CONVRT Apr 16 16:05:21 2004 CONVRT 1024,1024,0,0,6,6,0,0,f,f,t,16,,SUB,1 in=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16   out=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.nwa16\012\012@\000\000\000";
     }
-    filename {
-    }
     dsp_band_1 {
-        Byte dsp_PixelType 1;
-        Byte dsp_PixelSize 2;
-        UInt16 dsp_Flag 0;
-        UInt16 dsp_nBits 16;
-        Int32 dsp_LineSize 0;
-        String dsp_cal_name "Temperature";
-        String units "Temp";
-        UInt16 dsp_cal_eqnNumber 2;
-        UInt16 dsp_cal_CoeffsLength 8;
-        Float32 dsp_cal_coeffs 0.125, -4;
-        Float32 scale_factor 0.125;
-        Float32 add_off -4;
-        dsp_band_1 {
-            Byte dsp_PixelType 1;
-            Byte dsp_PixelSize 2;
-            UInt16 dsp_Flag 0;
-            UInt16 dsp_nBits 16;
-            Int32 dsp_LineSize 0;
-            String dsp_cal_name "Temperature";
-            String units "Temp";
-            UInt16 dsp_cal_eqnNumber 2;
-            UInt16 dsp_cal_CoeffsLength 8;
-            Float32 dsp_cal_coeffs 0.125, -4;
-            Float32 scale_factor 0.125;
-            Float32 add_off -4;
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        Byte dsp_PixelType 1, 1;
+        Byte dsp_PixelSize 2, 2;
+        UInt16 dsp_Flag 0, 0;
+        UInt16 dsp_nBits 16, 16;
+        Int32 dsp_LineSize 0, 0;
+        String dsp_cal_name "Temperature", "Temperature";
+        String units "Temp", "Temp";
+        UInt16 dsp_cal_eqnNumber 2, 2;
+        UInt16 dsp_cal_CoeffsLength 8, 8;
+        Float32 dsp_cal_coeffs 0.125, -4, 0.125, -4;
+        Float32 scale_factor 0.125, 0.125;
+        Float32 add_off -4, -4;
+        dim_0 {
+            String name "lat";
+            String long_name "latitude";
         }
-        filename {
-        }
-        lat {
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-        }
-        lon {
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        dim_1 {
+            String name "lon";
+            String long_name "longitude";
         }
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_grid_stride_evens.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_grid_stride_evens.das
@@ -103,56 +103,26 @@ Attributes {
         Float32 dsp_hgt_llvect 869.428, 1.14767, 868.659, 1.09635, 867.84, 1.04502, 866.979, 0.9937, 866.084, 0.942374, 865.165, 0.891045, 864.231, 0.839715, 863.292, 0.788383, 862.356, 0.737049, 861.434, 0.685714, 860.536, 0.634378, 859.67, 0.58304, 858.847, 0.531702, 858.075, 0.480362, 857.363, 0.429022, 856.718, 0.377682, 856.148, 0.326341, 855.66, 0.275, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
         String history "\001PATHNLC May 23 22:40:54 2000 PATHNLC t,3,269.16,0.125,0.,0.01,271.16,308.16,,,,1,,,2,,,3,,,,,,4,,,,,,,2.,,35.,0.1,5,,,,,,,2.,,35.,0.15,55.,80.,0.005,20,,,-2,6.,t,,,,,,,,,,16,,3.5 allb=0 nlsst=1 in=/pathfdr5//97182070958.N14@INGEST@ in1=/pathfdr10/mask/oi.9727.mean out=/pathfdr4/nlc/f97182070958.FMG@0\012\004PATHNLC  NLSST Temp calculation date: April 10, 1996\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 26 97 06 22 97 06 28  7        472\012\001STATS Jan 12 18:27:34 1998 STATS minpix=1 maxpix=255 in=/usr3/gacsst/maketc/oi/dout//oi.9726 \011  audit=t, callim=f, cal=f, cloud=f \011  outm=/usr3/gacsst/etc/oi/oi.9727.mean\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 28 97 07 06 97 07 12  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9728\012\002PATHNLC /pathfdr10/mask/oi.9727.mean\012\004PATHNLC  45d coeffs used (1) =    0.759   0.947   0.110   1.460   0.000\012\004PATHNLC  45d coeffs used (2) =    1.320   0.952   0.071   0.882   0.000\012\004PATHNLC  45d coeffs used (3) =    0.000   0.000   0.000   0.000   0.000\012\004PATHNLC  GETOZONE I     0.0900    0.0000\012\001REMAP Jun  4 07:59:42 2000 REMAP in=/coral/miami/remaps/sst_8r/file_uZ.FMG out=/coral/miami/remaps/sst_8r/f97182070958.nwa16\012\004REMAP Output image pixel, line size =    6144,    6144\012\004REMAP Grid spacing (X,Y) = (        6.00,        6.00), Projection Code=     1\012\004REMAP center lon,lat,dlon,dlat =       -70.00       38.00        0.01        0.01\012\001merge_sb Apr 16 16:05:09 2004 merge_sb in=(file=/NOPP/carlw/atlantic/remaps/nwa16/f97182070958.nwa16, filecheck=/RAID2/sbaker/atlantic/bslines97/f97182070958.nwa16) val=0 valcheck=0 tag=0 out=(file1=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2)\012\001merge_sb Apr 16 16:05:18 2004 merge_sb in=(file=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2, filecheck=/RAID/sbaker/DECLOUD/landmask16.img) val=1 valcheck=2 tag=0 out=(file1=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16)\012\001CONVRT Apr 16 16:05:21 2004 CONVRT 1024,1024,0,0,6,6,0,0,f,f,t,16,,SUB,1 in=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16   out=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.nwa16\012\012@\000\000\000";
     }
-    filename {
-    }
     dsp_band_1 {
-        Byte dsp_PixelType 1;
-        Byte dsp_PixelSize 2;
-        UInt16 dsp_Flag 0;
-        UInt16 dsp_nBits 16;
-        Int32 dsp_LineSize 0;
-        String dsp_cal_name "Temperature";
-        String units "Temp";
-        UInt16 dsp_cal_eqnNumber 2;
-        UInt16 dsp_cal_CoeffsLength 8;
-        Float32 dsp_cal_coeffs 0.125, -4;
-        Float32 scale_factor 0.125;
-        Float32 add_off -4;
-        dsp_band_1 {
-            Byte dsp_PixelType 1;
-            Byte dsp_PixelSize 2;
-            UInt16 dsp_Flag 0;
-            UInt16 dsp_nBits 16;
-            Int32 dsp_LineSize 0;
-            String dsp_cal_name "Temperature";
-            String units "Temp";
-            UInt16 dsp_cal_eqnNumber 2;
-            UInt16 dsp_cal_CoeffsLength 8;
-            Float32 dsp_cal_coeffs 0.125, -4;
-            Float32 scale_factor 0.125;
-            Float32 add_off -4;
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        Byte dsp_PixelType 1, 1;
+        Byte dsp_PixelSize 2, 2;
+        UInt16 dsp_Flag 0, 0;
+        UInt16 dsp_nBits 16, 16;
+        Int32 dsp_LineSize 0, 0;
+        String dsp_cal_name "Temperature", "Temperature";
+        String units "Temp", "Temp";
+        UInt16 dsp_cal_eqnNumber 2, 2;
+        UInt16 dsp_cal_CoeffsLength 8, 8;
+        Float32 dsp_cal_coeffs 0.125, -4, 0.125, -4;
+        Float32 scale_factor 0.125, 0.125;
+        Float32 add_off -4, -4;
+        dim_0 {
+            String name "lat";
+            String long_name "latitude";
         }
-        filename {
-        }
-        lat {
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-        }
-        lon {
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        dim_1 {
+            String name "lon";
+            String long_name "longitude";
         }
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_hdf5.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_hdf5.ncml.das
@@ -6,8 +6,6 @@ Attributes {
         String HDF5_OBJ_FULLPATH "H5_GLOBAL";
         String Desc "I am a test data from hdfview                                                                                                  ";
     }
-    file {
-    }
     /TestArray {
         String HDF5_OBJ_FULLPATH "/TestArray";
     }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_numeric_coordValue.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_numeric_coordValue.ncml.das
@@ -6,8 +6,6 @@ Attributes {
     DODS_EXTRA {
         String Unlimited_Dimension "time_a";
     }
-    source {
-    }
     lat {
         String units "degree North";
     }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_scan_dfm.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_scan_dfm.ncml.das
@@ -49,42 +49,9 @@ Attributes {
         String coordsys "geographic";
     }
     CGusfc {
-        CGusfc {
-            Float32 _FillValue -1.00000003e+32;
-            Float32 missing_value -1.00000003e+32;
-            Int32 numberOfObservations 303;
-            Float32 actual_range -0.287640005, 0.276320010;
-        }
-        fileTime {
-            String _CoordinateAxisType "Time";
-        }
-        time {
-            String long_name "End Time";
-            String standard_name "time";
-            String units "seconds since 1970-01-01T00:00:00Z";
-            Float64 actual_range 1149681600.000000, 1149681600.000000;
-        }
-        altitude {
-            String long_name "Altitude";
-            String standard_name "altitude";
-            String units "m";
-            Float32 actual_range 0.00000000, 0.00000000;
-        }
-        lat {
-            String long_name "Latitude";
-            String standard_name "latitude";
-            String units "degrees_north";
-            String point_spacing "even";
-            Float32 actual_range 37.2686996, 38.0247002;
-            String coordsys "geographic";
-        }
-        lon {
-            String long_name "Longitude";
-            String standard_name "longitude";
-            String units "degrees_east";
-            String point_spacing "even";
-            Float32 actual_range 236.580002, 237.479996;
-            String coordsys "geographic";
-        }
+        Float32 _FillValue -1.00000003e+32;
+        Float32 missing_value -1.00000003e+32;
+        Int32 numberOfObservations 303;
+        Float32 actual_range -0.287640005, 0.276320010;
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_scan_dfm_2.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_scan_dfm_2.ncml.das
@@ -49,42 +49,9 @@ Attributes {
         String coordsys "geographic";
     }
     CGusfc {
-        CGusfc {
-            Float32 _FillValue -1.00000003e+32;
-            Float32 missing_value -1.00000003e+32;
-            Int32 numberOfObservations 303;
-            Float32 actual_range -0.287640005, 0.276320010;
-        }
-        fileTime {
-            String _CoordinateAxisType "Time";
-        }
-        time {
-            String long_name "End Time";
-            String standard_name "time";
-            String units "seconds since 1970-01-01T00:00:00Z";
-            Float64 actual_range 1149681600.000000, 1149681600.000000;
-        }
-        altitude {
-            String long_name "Altitude";
-            String standard_name "altitude";
-            String units "m";
-            Float32 actual_range 0.00000000, 0.00000000;
-        }
-        lat {
-            String long_name "Latitude";
-            String standard_name "latitude";
-            String units "degrees_north";
-            String point_spacing "even";
-            Float32 actual_range 37.2686996, 38.0247002;
-            String coordsys "geographic";
-        }
-        lon {
-            String long_name "Longitude";
-            String standard_name "longitude";
-            String units "degrees_east";
-            String point_spacing "even";
-            Float32 actual_range 236.580002, 237.479996;
-            String coordsys "geographic";
-        }
+        Float32 _FillValue -1.00000003e+32;
+        Float32 missing_value -1.00000003e+32;
+        Int32 numberOfObservations 303;
+        Float32 actual_range -0.287640005, 0.276320010;
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_scan_hslab_0.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_scan_hslab_0.das
@@ -103,56 +103,26 @@ Attributes {
         Float32 dsp_hgt_llvect 869.428, 1.14767, 868.659, 1.09635, 867.84, 1.04502, 866.979, 0.9937, 866.084, 0.942374, 865.165, 0.891045, 864.231, 0.839715, 863.292, 0.788383, 862.356, 0.737049, 861.434, 0.685714, 860.536, 0.634378, 859.67, 0.58304, 858.847, 0.531702, 858.075, 0.480362, 857.363, 0.429022, 856.718, 0.377682, 856.148, 0.326341, 855.66, 0.275, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
         String history "\001PATHNLC May 23 22:40:54 2000 PATHNLC t,3,269.16,0.125,0.,0.01,271.16,308.16,,,,1,,,2,,,3,,,,,,4,,,,,,,2.,,35.,0.1,5,,,,,,,2.,,35.,0.15,55.,80.,0.005,20,,,-2,6.,t,,,,,,,,,,16,,3.5 allb=0 nlsst=1 in=/pathfdr5//97182070958.N14@INGEST@ in1=/pathfdr10/mask/oi.9727.mean out=/pathfdr4/nlc/f97182070958.FMG@0\012\004PATHNLC  NLSST Temp calculation date: April 10, 1996\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 26 97 06 22 97 06 28  7        472\012\001STATS Jan 12 18:27:34 1998 STATS minpix=1 maxpix=255 in=/usr3/gacsst/maketc/oi/dout//oi.9726 \011  audit=t, callim=f, cal=f, cloud=f \011  outm=/usr3/gacsst/etc/oi/oi.9727.mean\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 28 97 07 06 97 07 12  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9728\012\002PATHNLC /pathfdr10/mask/oi.9727.mean\012\004PATHNLC  45d coeffs used (1) =    0.759   0.947   0.110   1.460   0.000\012\004PATHNLC  45d coeffs used (2) =    1.320   0.952   0.071   0.882   0.000\012\004PATHNLC  45d coeffs used (3) =    0.000   0.000   0.000   0.000   0.000\012\004PATHNLC  GETOZONE I     0.0900    0.0000\012\001REMAP Jun  4 07:59:42 2000 REMAP in=/coral/miami/remaps/sst_8r/file_uZ.FMG out=/coral/miami/remaps/sst_8r/f97182070958.nwa16\012\004REMAP Output image pixel, line size =    6144,    6144\012\004REMAP Grid spacing (X,Y) = (        6.00,        6.00), Projection Code=     1\012\004REMAP center lon,lat,dlon,dlat =       -70.00       38.00        0.01        0.01\012\001merge_sb Apr 16 16:05:09 2004 merge_sb in=(file=/NOPP/carlw/atlantic/remaps/nwa16/f97182070958.nwa16, filecheck=/RAID2/sbaker/atlantic/bslines97/f97182070958.nwa16) val=0 valcheck=0 tag=0 out=(file1=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2)\012\001merge_sb Apr 16 16:05:18 2004 merge_sb in=(file=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2, filecheck=/RAID/sbaker/DECLOUD/landmask16.img) val=1 valcheck=2 tag=0 out=(file1=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16)\012\001CONVRT Apr 16 16:05:21 2004 CONVRT 1024,1024,0,0,6,6,0,0,f,f,t,16,,SUB,1 in=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16   out=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.nwa16\012\012@\000\000\000";
     }
-    filename {
-    }
     dsp_band_1 {
-        Byte dsp_PixelType 1;
-        Byte dsp_PixelSize 2;
-        UInt16 dsp_Flag 0;
-        UInt16 dsp_nBits 16;
-        Int32 dsp_LineSize 0;
-        String dsp_cal_name "Temperature";
-        String units "Temp";
-        UInt16 dsp_cal_eqnNumber 2;
-        UInt16 dsp_cal_CoeffsLength 8;
-        Float32 dsp_cal_coeffs 0.125, -4;
-        Float32 scale_factor 0.125;
-        Float32 add_off -4;
-        dsp_band_1 {
-            Byte dsp_PixelType 1;
-            Byte dsp_PixelSize 2;
-            UInt16 dsp_Flag 0;
-            UInt16 dsp_nBits 16;
-            Int32 dsp_LineSize 0;
-            String dsp_cal_name "Temperature";
-            String units "Temp";
-            UInt16 dsp_cal_eqnNumber 2;
-            UInt16 dsp_cal_CoeffsLength 8;
-            Float32 dsp_cal_coeffs 0.125, -4;
-            Float32 scale_factor 0.125;
-            Float32 add_off -4;
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        Byte dsp_PixelType 1, 1;
+        Byte dsp_PixelSize 2, 2;
+        UInt16 dsp_Flag 0, 0;
+        UInt16 dsp_nBits 16, 16;
+        Int32 dsp_LineSize 0, 0;
+        String dsp_cal_name "Temperature", "Temperature";
+        String units "Temp", "Temp";
+        UInt16 dsp_cal_eqnNumber 2, 2;
+        UInt16 dsp_cal_CoeffsLength 8, 8;
+        Float32 dsp_cal_coeffs 0.125, -4, 0.125, -4;
+        Float32 scale_factor 0.125, 0.125;
+        Float32 add_off -4, -4;
+        dim_0 {
+            String name "lat";
+            String long_name "latitude";
         }
-        filename {
-        }
-        lat {
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-        }
-        lon {
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        dim_1 {
+            String name "lon";
+            String long_name "longitude";
         }
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_scan_regexp_hslab_0.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_scan_regexp_hslab_0.das
@@ -103,56 +103,26 @@ Attributes {
         Float32 dsp_hgt_llvect 869.428, 1.14767, 868.659, 1.09635, 867.84, 1.04502, 866.979, 0.9937, 866.084, 0.942374, 865.165, 0.891045, 864.231, 0.839715, 863.292, 0.788383, 862.356, 0.737049, 861.434, 0.685714, 860.536, 0.634378, 859.67, 0.58304, 858.847, 0.531702, 858.075, 0.480362, 857.363, 0.429022, 856.718, 0.377682, 856.148, 0.326341, 855.66, 0.275, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
         String history "\001PATHNLC May 23 22:40:54 2000 PATHNLC t,3,269.16,0.125,0.,0.01,271.16,308.16,,,,1,,,2,,,3,,,,,,4,,,,,,,2.,,35.,0.1,5,,,,,,,2.,,35.,0.15,55.,80.,0.005,20,,,-2,6.,t,,,,,,,,,,16,,3.5 allb=0 nlsst=1 in=/pathfdr5//97182070958.N14@INGEST@ in1=/pathfdr10/mask/oi.9727.mean out=/pathfdr4/nlc/f97182070958.FMG@0\012\004PATHNLC  NLSST Temp calculation date: April 10, 1996\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 26 97 06 22 97 06 28  7        472\012\001STATS Jan 12 18:27:34 1998 STATS minpix=1 maxpix=255 in=/usr3/gacsst/maketc/oi/dout//oi.9726 \011  audit=t, callim=f, cal=f, cloud=f \011  outm=/usr3/gacsst/etc/oi/oi.9727.mean\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 27 97 06 29 97 07 05  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9727\012\001OISST Jan 12 17:53:43 1998 OISST  /usr3/gacsst/maketc/oi/dinp/oi.comp.bias.1997,/usr3/gacsst/maketc/oi/dout/oi.97,-3.,0.15,oi.dates.97,0\012\004OISST 28 97 07 06 97 07 12  7        472\012\002STATS /usr3/gacsst/maketc/oi/dout//oi.9728\012\002PATHNLC /pathfdr10/mask/oi.9727.mean\012\004PATHNLC  45d coeffs used (1) =    0.759   0.947   0.110   1.460   0.000\012\004PATHNLC  45d coeffs used (2) =    1.320   0.952   0.071   0.882   0.000\012\004PATHNLC  45d coeffs used (3) =    0.000   0.000   0.000   0.000   0.000\012\004PATHNLC  GETOZONE I     0.0900    0.0000\012\001REMAP Jun  4 07:59:42 2000 REMAP in=/coral/miami/remaps/sst_8r/file_uZ.FMG out=/coral/miami/remaps/sst_8r/f97182070958.nwa16\012\004REMAP Output image pixel, line size =    6144,    6144\012\004REMAP Grid spacing (X,Y) = (        6.00,        6.00), Projection Code=     1\012\004REMAP center lon,lat,dlon,dlat =       -70.00       38.00        0.01        0.01\012\001merge_sb Apr 16 16:05:09 2004 merge_sb in=(file=/NOPP/carlw/atlantic/remaps/nwa16/f97182070958.nwa16, filecheck=/RAID2/sbaker/atlantic/bslines97/f97182070958.nwa16) val=0 valcheck=0 tag=0 out=(file1=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2)\012\001merge_sb Apr 16 16:05:18 2004 merge_sb in=(file=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.tmp_m2, filecheck=/RAID/sbaker/DECLOUD/landmask16.img) val=1 valcheck=2 tag=0 out=(file1=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16)\012\001CONVRT Apr 16 16:05:21 2004 CONVRT 1024,1024,0,0,6,6,0,0,f,f,t,16,,SUB,1 in=/RAID2/sbaker/nwa6144d/NDC/dsp_data/f97182070958.nwa16   out=/RAID2/sbaker/nwa1024d/NDC/dsp_data/f97182070958.nwa16\012\012@\000\000\000";
     }
-    filename {
-    }
     dsp_band_1 {
-        Byte dsp_PixelType 1;
-        Byte dsp_PixelSize 2;
-        UInt16 dsp_Flag 0;
-        UInt16 dsp_nBits 16;
-        Int32 dsp_LineSize 0;
-        String dsp_cal_name "Temperature";
-        String units "Temp";
-        UInt16 dsp_cal_eqnNumber 2;
-        UInt16 dsp_cal_CoeffsLength 8;
-        Float32 dsp_cal_coeffs 0.125, -4;
-        Float32 scale_factor 0.125;
-        Float32 add_off -4;
-        dsp_band_1 {
-            Byte dsp_PixelType 1;
-            Byte dsp_PixelSize 2;
-            UInt16 dsp_Flag 0;
-            UInt16 dsp_nBits 16;
-            Int32 dsp_LineSize 0;
-            String dsp_cal_name "Temperature";
-            String units "Temp";
-            UInt16 dsp_cal_eqnNumber 2;
-            UInt16 dsp_cal_CoeffsLength 8;
-            Float32 dsp_cal_coeffs 0.125, -4;
-            Float32 scale_factor 0.125;
-            Float32 add_off -4;
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        Byte dsp_PixelType 1, 1;
+        Byte dsp_PixelSize 2, 2;
+        UInt16 dsp_Flag 0, 0;
+        UInt16 dsp_nBits 16, 16;
+        Int32 dsp_LineSize 0, 0;
+        String dsp_cal_name "Temperature", "Temperature";
+        String units "Temp", "Temp";
+        UInt16 dsp_cal_eqnNumber 2, 2;
+        UInt16 dsp_cal_CoeffsLength 8, 8;
+        Float32 dsp_cal_coeffs 0.125, -4, 0.125, -4;
+        Float32 scale_factor 0.125, 0.125;
+        Float32 add_off -4, -4;
+        dim_0 {
+            String name "lat";
+            String long_name "latitude";
         }
-        filename {
-        }
-        lat {
-            dim_0 {
-                String name "lat";
-                String long_name "latitude";
-            }
-        }
-        lon {
-            dim_1 {
-                String name "lon";
-                String long_name "longitude";
-            }
+        dim_1 {
+            String name "lon";
+            String long_name "longitude";
         }
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_simple.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_simple.ncml.das
@@ -1,12 +1,8 @@
 Attributes {
-    day {
-    }
     station {
         String Desc "I am in the first dataset, so WILL be in the output!";
     }
     V {
         String units "bohms";
-    }
-    V_expected {
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_simple_2.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_simple_2.ncml.das
@@ -1,8 +1,2 @@
 Attributes {
-    day {
-    }
-    V {
-    }
-    V_expected {
-    }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_simple_2_cons_1.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_simple_2_cons_1.ncml.das
@@ -1,8 +1,2 @@
 Attributes {
-    day {
-    }
-    V {
-    }
-    V_expected {
-    }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_simple_2_cons_2.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_simple_2_cons_2.ncml.das
@@ -1,8 +1,2 @@
 Attributes {
-    day {
-    }
-    V {
-    }
-    V_expected {
-    }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_simple_2_cons_3.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_simple_2_cons_3.ncml.das
@@ -1,8 +1,2 @@
 Attributes {
-    day {
-    }
-    V {
-    }
-    V_expected {
-    }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_simple_3.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_simple_3.ncml.das
@@ -1,12 +1,2 @@
 Attributes {
-    day {
-    }
-    V {
-    }
-    W {
-    }
-    V_expected {
-    }
-    W_expected {
-    }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_simple_cons_1.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_simple_cons_1.ncml.das
@@ -1,12 +1,8 @@
 Attributes {
-    day {
-    }
     station {
         String Desc "I am in the first dataset, so WILL be in the output!";
     }
     V {
         String units "bohms";
-    }
-    V_expected {
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_simple_cons_2.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_simple_cons_2.ncml.das
@@ -1,12 +1,8 @@
 Attributes {
-    day {
-    }
     station {
         String Desc "I am in the first dataset, so WILL be in the output!";
     }
     V {
         String units "bohms";
-    }
-    V_expected {
     }
 }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_string_coordVal.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_string_coordVal.ncml.das
@@ -6,8 +6,6 @@ Attributes {
     DODS_EXTRA {
         String Unlimited_Dimension "time_a";
     }
-    source {
-    }
     lat {
         String units "degree North";
     }

--- a/modules/ncml_module/tests/baselines/agg/joinNew_with_explicit_map.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/joinNew_with_explicit_map.ncml.das
@@ -1,6 +1,4 @@
 Attributes {
-    V {
-    }
     day {
         String units "days since 2000-1-01 00:00";
     }

--- a/modules/ncml_module/tests/baselines/agg/modify_post_union.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/modify_post_union.ncml.das
@@ -2,8 +2,6 @@ Attributes {
     NC_GLOBAL {
         String Dataset_Description "This is a union.";
     }
-    SelfReferentialVariable {
-    }
     Foo {
         String Description "I am Foo.Description and have modified the winning Foo and deserve to be in the output!";
     }

--- a/modules/ncml_module/tests/baselines/agg/multi_nested_unions.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/multi_nested_unions.ncml.das
@@ -3,14 +3,4 @@ Attributes {
         String Description "Dataset 0 -- I should win!";
         String FirstComer "This attribute is in a nested agg, but is first instance of the attr in the file and should win.";
     }
-    Foo {
-    }
-    Var_0_0 {
-    }
-    Var_1_0 {
-    }
-    Var_1_1 {
-    }
-    Var_0_1 {
-    }
 }

--- a/modules/ncml_module/tests/baselines/agg/netcdf_joinNew.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/netcdf_joinNew.ncml.das
@@ -6,8 +6,6 @@ Attributes {
     DODS_EXTRA {
         String Unlimited_Dimension "time_a";
     }
-    source {
-    }
     lat {
         String units "degree North";
     }

--- a/modules/ncml_module/tests/baselines/agg/netcdf_joinNew_cons_1.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/netcdf_joinNew_cons_1.ncml.das
@@ -6,8 +6,6 @@ Attributes {
     DODS_EXTRA {
         String Unlimited_Dimension "time_a";
     }
-    source {
-    }
     lat {
         String units "degree North";
     }

--- a/modules/ncml_module/tests/baselines/agg/virtual_union.ncml.das
+++ b/modules/ncml_module/tests/baselines/agg/virtual_union.ncml.das
@@ -7,8 +7,6 @@ Attributes {
         String Dataset_Description "Virtual union aggregation example";
         String Description "Dataset One";
     }
-    SelfReferentialVariable {
-    }
     Foo {
         String Description "This var names Foo comes first and should be in output.";
     }

--- a/modules/ncml_module/tests/baselines/bugs/empty_attr_string.ncml.das
+++ b/modules/ncml_module/tests/baselines/bugs/empty_attr_string.ncml.das
@@ -2,6 +2,4 @@ Attributes {
     NC_GLOBAL {
         String Empty "";
     }
-    EmptyVar {
-    }
 }

--- a/modules/ncml_module/tests/baselines/fnoc1_explicit.ncml.das
+++ b/modules/ncml_module/tests/baselines/fnoc1_explicit.ncml.das
@@ -15,10 +15,4 @@ Attributes {
         String component "Wind.N";
         Float32 range 0, 1023;
     }
-    lat {
-    }
-    lon {
-    }
-    time {
-    }
 }

--- a/modules/ncml_module/tests/baselines/gateway/gateway_aggregation.ncml.das
+++ b/modules/ncml_module/tests/baselines/gateway/gateway_aggregation.ncml.das
@@ -46,39 +46,9 @@ Attributes {
         Float64 actual_range 1149681600.000000, 1149681600.000000;
     }
     CGusfc {
-        CGusfc {
-            Float32 _FillValue -1.00000003e+32;
-            Float32 missing_value -1.00000003e+32;
-            Int32 numberOfObservations 303;
-            Float32 actual_range -0.287640005, 0.276320010;
-        }
-        time {
-            String long_name "End Time";
-            String standard_name "time";
-            String units "seconds since 1970-01-01T00:00:00Z";
-            Float64 actual_range 1149681600.000000, 1149681600.000000;
-        }
-        altitude {
-            String long_name "Altitude";
-            String standard_name "altitude";
-            String units "m";
-            Float32 actual_range 0.00000000, 0.00000000;
-        }
-        lat {
-            String long_name "Latitude";
-            String standard_name "latitude";
-            String units "degrees_north";
-            String point_spacing "even";
-            Float32 actual_range 37.2686996, 38.0247002;
-            String coordsys "geographic";
-        }
-        lon {
-            String long_name "Longitude";
-            String standard_name "longitude";
-            String units "degrees_east";
-            String point_spacing "even";
-            Float32 actual_range 236.580002, 237.479996;
-            String coordsys "geographic";
-        }
+        Float32 _FillValue -1.00000003e+32;
+        Float32 missing_value -1.00000003e+32;
+        Int32 numberOfObservations 303;
+        Float32 actual_range -0.287640005, 0.276320010;
     }
 }

--- a/modules/ncml_module/tests/baselines/gateway/gateway_var_mods.ncml.das
+++ b/modules/ncml_module/tests/baselines/gateway/gateway_var_mods.ncml.das
@@ -47,39 +47,9 @@ Attributes {
         String coordsys "geographic";
     }
     CGusfc {
-        CGusfc {
-            Float32 _FillValue -1.00000003e+32;
-            Float32 missing_value -1.00000003e+32;
-            Int32 numberOfObservations 303;
-            Float32 actual_range -0.287640005, 0.276320010;
-        }
-        time {
-            String long_name "End Time";
-            String standard_name "time";
-            String units "seconds since 1970-01-01T00:00:00Z";
-            Float64 actual_range 1149681600.000000, 1149681600.000000;
-        }
-        altitude {
-            String long_name "Altitude";
-            String standard_name "altitude";
-            String units "m";
-            Float32 actual_range 0.00000000, 0.00000000;
-        }
-        lat {
-            String long_name "Latitude";
-            String standard_name "latitude";
-            String units "degrees_north";
-            String point_spacing "even";
-            Float32 actual_range 37.2686996, 38.0247002;
-            String coordsys "geographic";
-        }
-        lon {
-            String long_name "Longitude";
-            String standard_name "longitude";
-            String units "degrees_east";
-            String point_spacing "even";
-            Float32 actual_range 236.580002, 237.479996;
-            String coordsys "geographic";
-        }
+        Float32 _FillValue -1.00000003e+32;
+        Float32 missing_value -1.00000003e+32;
+        Int32 numberOfObservations 303;
+        Float32 actual_range -0.287640005, 0.276320010;
     }
 }

--- a/modules/ncml_module/tests/baselines/gdal/joinNew_geotiff.ncml.das
+++ b/modules/ncml_module/tests/baselines/gdal/joinNew_geotiff.ncml.das
@@ -10,19 +10,9 @@ Attributes {
         }
         String spatial_ref "PROJCS[\"unnamed\",GEOGCS[\"NAD27\",DATUM[\"North_American_Datum_1927\",SPHEROID[\"Clarke 1866\",6378206.4,294.9786982138982,AUTHORITY[\"EPSG\",\"7008\"]],AUTHORITY[\"EPSG\",\"6267\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4267\"]],PROJECTION[\"Cylindrical_Equal_Area\"],PARAMETER[\"standard_parallel_1\",33.75],PARAMETER[\"central_meridian\",-117.333333333333],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]";
     }
-    slice {
-    }
     band_1 {
         Float64 add_offset 0;
         Float64 scale_factor 1;
         String PhotometricInterpretation "Gray";
-        band_1 {
-        }
-        slice {
-        }
-        northing {
-        }
-        easting {
-        }
     }
 }

--- a/modules/ncml_module/tests/baselines/grid_attributes.ncml.das
+++ b/modules/ncml_module/tests/baselines/grid_attributes.ncml.das
@@ -25,40 +25,19 @@ Attributes {
         Float64 actual_range 715511.0000000000, 729360.0000000000;
     }
     cldc {
-        cldc {
-            Float32 valid_range 0.00000000, 8.00000000;
-            Float32 actual_range 0.00000000, 8.00000000;
-            String units "okta";
-            Int16 precision 1;
-            Int16 missing_value 32766;
-            Int16 _FillValue 32766;
-            String long_name "Cloudiness Monthly Mean at Surface";
-            String dataset "COADS 1-degree Equatorial Enhanced\012AI";
-            String var_desc "Cloudiness\012C";
-            String level_desc "Surface\0120";
-            String statistic "Mean\012M";
-            String parent_stat "Individual Obs\012I";
-            Float32 add_offset 3276.50000;
-            Float32 scale_factor 0.100000001;
-        }
-        time {
-            String units "days since 1-1-1 00:00:0.0";
-            String long_name "Time";
-            String delta_t "0000-01-00 00:00:00";
-            String avg_period "0000-01-00 00:00:00";
-            Float64 actual_range 715511.0000000000, 729360.0000000000;
-        }
-        lat {
-            String long_name "Latitude";
-            String units "degrees_north";
-            Float32 actual_range 10.0000000, -10.0000000;
-            String Description "I am a new attribute in the Grid map vector named lat!";
-        }
-        lon {
-            String long_name "Longitude";
-            String units "degrees_east";
-            Float32 actual_range 0.500000000, 359.500000;
-            String Description "I am a new attribute in the Grid map vector named lon!";
-        }
+        Float32 valid_range 0.00000000, 8.00000000;
+        Float32 actual_range 0.00000000, 8.00000000;
+        String units "okta";
+        Int16 precision 1;
+        Int16 missing_value 32766;
+        Int16 _FillValue 32766;
+        String long_name "Cloudiness Monthly Mean at Surface";
+        String dataset "COADS 1-degree Equatorial Enhanced\012AI";
+        String var_desc "Cloudiness\012C";
+        String level_desc "Surface\0120";
+        String statistic "Mean\012M";
+        String parent_stat "Individual Obs\012I";
+        Float32 add_offset 3276.50000;
+        Float32 scale_factor 0.100000001;
     }
 }

--- a/modules/ncml_module/tests/baselines/new_arrays/var_array_int_2.ncml.das
+++ b/modules/ncml_module/tests/baselines/new_arrays/var_array_int_2.ncml.das
@@ -1,4 +1,2 @@
 Attributes {
-    MyArray2D {
-    }
 }

--- a/modules/ncml_module/tests/baselines/new_arrays/var_array_int_2_cons_1.ncml.das
+++ b/modules/ncml_module/tests/baselines/new_arrays/var_array_int_2_cons_1.ncml.das
@@ -1,4 +1,2 @@
 Attributes {
-    MyArray2D {
-    }
 }

--- a/modules/ncml_module/tests/baselines/new_arrays/var_array_int_3.ncml.das
+++ b/modules/ncml_module/tests/baselines/new_arrays/var_array_int_3.ncml.das
@@ -1,4 +1,2 @@
 Attributes {
-    MyArray3D {
-    }
 }

--- a/modules/ncml_module/tests/baselines/new_arrays/var_array_string_2d.ncml.das
+++ b/modules/ncml_module/tests/baselines/new_arrays/var_array_string_2d.ncml.das
@@ -1,4 +1,2 @@
 Attributes {
-    MyArray2D {
-    }
 }

--- a/modules/ncml_module/tests/baselines/new_arrays/var_string_3d.ncml.das
+++ b/modules/ncml_module/tests/baselines/new_arrays/var_string_3d.ncml.das
@@ -1,4 +1,2 @@
 Attributes {
-    MyArray3D {
-    }
 }

--- a/modules/ncml_module/tests/baselines/new_arrays/var_string_3d_cons_1.ncml.das
+++ b/modules/ncml_module/tests/baselines/new_arrays/var_string_3d_cons_1.ncml.das
@@ -1,4 +1,2 @@
 Attributes {
-    MyArray3D {
-    }
 }

--- a/modules/ncml_module/tests/baselines/new_arrays/var_string_3d_cons_2.ncml.das
+++ b/modules/ncml_module/tests/baselines/new_arrays/var_string_3d_cons_2.ncml.das
@@ -1,4 +1,2 @@
 Attributes {
-    MyArray3D {
-    }
 }

--- a/modules/ncml_module/tests/baselines/reentrancy_test.ncml.das
+++ b/modules/ncml_module/tests/baselines/reentrancy_test.ncml.das
@@ -6,6 +6,4 @@ Attributes {
     Wrapped_Wrappee_Variable {
         String Description "This should be modified from the wrappee in a successful wrap!";
     }
-    Foo {
-    }
 }

--- a/modules/ncml_module/tests/baselines/separator_test.ncml.das
+++ b/modules/ncml_module/tests/baselines/separator_test.ncml.das
@@ -7,10 +7,4 @@ Attributes {
         String zork "I am a string without a specified separator so won't get separated into an array.";
         String enchanter "Each", "One", "Is", "A", "Token";
     }
-    sorcerer {
-    }
-    grue {
-    }
-    dungeon_master {
-    }
 }

--- a/modules/ncml_module/tests/baselines/var_new_Structure.ncml.das
+++ b/modules/ncml_module/tests/baselines/var_new_Structure.ncml.das
@@ -1,9 +1,5 @@
 Attributes {
     MyStructure {
         String MyStructure_MetaData "Hi Mom!";
-        ContainedScalar1 {
-        }
-        DougAdamsSays {
-        }
     }
 }

--- a/modules/ncml_module/tests/baselines/var_new_Structure_nest.ncml.das
+++ b/modules/ncml_module/tests/baselines/var_new_Structure_nest.ncml.das
@@ -1,10 +1,2 @@
 Attributes {
-    MyStructure {
-        ContainedScalar1 {
-        }
-        MyChildStructure {
-            ChildSays {
-            }
-        }
-    }
 }

--- a/modules/ncml_module/tests/baselines/var_with_dot.ncml.das
+++ b/modules/ncml_module/tests/baselines/var_with_dot.ncml.das
@@ -1,11 +1,5 @@
 Attributes {
     MyStructure {
         String MyStructure_MetaData "Hi Mom!";
-        ContainedScalar1 {
-        }
-        DougAdamsSays {
-        }
-    }
-    MyStructure.ContainedScalar1 {
     }
 }


### PR DESCRIPTION


The `flatten-grids` branch changes the DAS output by eliminating empty DAS containers and flattening the Grid object contents. This change breaks test (duh) so we need to update and inspect the baselines. Once done we'll merge this to `flatten-grids` and then we'll merge `flatten-grids` to `master`.
