### PR TITLE
BESInfo API Addition

### DIFF
--- a/dispatch/BESInfo.cc
+++ b/dispatch/BESInfo.cc
@@ -109,6 +109,19 @@ BESInfo::~BESInfo()
  * @param response_name name of the response this information represents
  * @param dhi information about the request and response
  */
+void BESInfo::begin_response(const string &response_name, map<string, string> */*attrs*/, BESDataHandlerInterface &/*dhi*/)
+{
+    _response_started = true;
+    _response_name = response_name;
+}
+
+/** @brief begin the informational response
+ *
+ * basic setup of the response from abstract class
+ *
+ * @param response_name name of the response this information represents
+ * @param dhi information about the request and response
+ */
 void BESInfo::begin_response(const string &response_name, BESDataHandlerInterface &/*dhi*/)
 {
     _response_started = true;

--- a/dispatch/BESInfo.h
+++ b/dispatch/BESInfo.h
@@ -81,6 +81,7 @@ public:
     virtual ~BESInfo();
 
     virtual void begin_response(const string &response_name, BESDataHandlerInterface &dhi);
+    virtual void begin_response(const string &response_name, map<string, string> *attrs, BESDataHandlerInterface &dhi);
     virtual void end_response();
 
     virtual void add_tag(const string &tag_name, const string &tag_data, map<string, string> *attrs = 0) = 0;

--- a/dispatch/BESXMLInfo.cc
+++ b/dispatch/BESXMLInfo.cc
@@ -90,7 +90,21 @@ void BESXMLInfo::cleanup()
  */
 void BESXMLInfo::begin_response(const string &response_name, BESDataHandlerInterface &dhi)
 {
-    BESInfo::begin_response(response_name, dhi);
+    map<string, string> empty_attrs;
+    begin_response(response_name,  &empty_attrs, dhi);
+
+}
+/** @brief begin the informational response
+ *
+ * This will add the response name as well as the &lt;response&gt; tag tot
+ * he informational response object
+ *
+ * @param response_name name of the response this information represents
+ * @param dhi information about the request and response
+ */
+void BESXMLInfo::begin_response(const string &response_name, map<string, string> *attrs, BESDataHandlerInterface &dhi)
+{
+    BESInfo::begin_response(response_name, attrs, dhi);
 
     _response_name = response_name;
 
@@ -172,7 +186,19 @@ void BESXMLInfo::begin_response(const string &response_name, BESDataHandlerInter
         string err = (string) "Error creating root element for response " + _response_name;
         throw BESInternalError(err, __FILE__, __LINE__);
     }
-}
+
+    map<string, string>::iterator it;
+    for ( it = attrs->begin(); it != attrs->end(); it++ )
+    {
+        rc = xmlTextWriterWriteAttribute( _writer, BAD_CAST it->first.c_str(), BAD_CAST it->second.c_str());
+        if (rc < 0) {
+            cleanup();
+            string err = (string) "Error creating root element for response " + _response_name;
+            throw BESInternalError(err, __FILE__, __LINE__);
+        }
+    }
+
+ }
 
 /** @brief end the response
  *

--- a/dispatch/BESXMLInfo.h
+++ b/dispatch/BESXMLInfo.h
@@ -61,6 +61,7 @@ public:
     virtual ~BESXMLInfo();
 
     virtual void begin_response(const string &response_name, BESDataHandlerInterface &dhi);
+    virtual void begin_response(const string &response_name, map<string, string> *attrs, BESDataHandlerInterface &dhi);
     virtual void end_response();
 
     virtual void add_tag(const string &tag_name, const string &tag_data, map<string, string> *attrs = 0);

--- a/xmlcommand/ShowBesKeyResponseHandler.cc
+++ b/xmlcommand/ShowBesKeyResponseHandler.cc
@@ -92,13 +92,13 @@ void ShowBesKeyResponseHandler::execute(BESDataHandlerInterface &dhi)
     map<string, string> emptyAttrs;
     attrs[KEY] = requested_bes_key;
 
-    info->begin_response(SHOW_BES_KEY_RESPONSE_STR, dhi);
-    info->begin_tag(BES_KEY_RESPONSE, &attrs);
+    info->begin_response(SHOW_BES_KEY_RESPONSE_STR, &attrs, dhi);
+    //info->begin_tag(BES_KEY_RESPONSE, &attrs);
 
     for(unsigned long i=0; i<key_values.size(); ++i)
         info->add_tag("value",key_values[i],&emptyAttrs);
 
-    info->end_tag(BES_KEY_RESPONSE);
+    //info->end_tag(BES_KEY_RESPONSE);
 
     // end the response object
     info->end_response();

--- a/xmlcommand/tests/bescmd/show_bes_key_1.bescmd.baseline
+++ b/xmlcommand/tests/bescmd/show_bes_key_1.bescmd.baseline
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <response reqID="[thread:http-nio-8080-exec-4-42][bes_client:/-2]" xmlns="http://xml.opendap.org/ns/bes/1.0#">
-    <showBesKey>
-        <BesKey key="BES.Catalog.catalog.TypeMatch">
-            <value>dapreader:.*\.(das|dds|dods|data|dmr|dap)$;</value>
-        </BesKey>
+    <showBesKey key="BES.Catalog.catalog.TypeMatch">
+        <value>dapreader:.*\.(das|dds|dods|data|dmr|dap)$;</value>
     </showBesKey>
 </response>

--- a/xmlcommand/tests/bescmd/show_bes_key_2.bescmd.baseline
+++ b/xmlcommand/tests/bescmd/show_bes_key_2.bescmd.baseline
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <response reqID="[thread:http-nio-8080-exec-4-42][bes_client:/-2]" xmlns="http://xml.opendap.org/ns/bes/1.0#">
-    <showBesKey>
-        <BesKey key="BES.User">
-            <value>user_name</value>
-        </BesKey>
+    <showBesKey key="BES.User">
+        <value>user_name</value>
     </showBesKey>
 </response>

--- a/xmlcommand/tests/bescmd/show_bes_key_3.bescmd.baseline
+++ b/xmlcommand/tests/bescmd/show_bes_key_3.bescmd.baseline
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <response reqID="[thread:http-nio-8080-exec-4-42][bes_client:/-2]" xmlns="http://xml.opendap.org/ns/bes/1.0#">
-    <showBesKey>
-        <BesKey key="BES.FollowSymLinks">
-            <value>No</value>
-        </BesKey>
+    <showBesKey key="BES.FollowSymLinks">
+        <value>No</value>
     </showBesKey>
 </response>

--- a/xmlcommand/tests/bescmd/show_bes_key_4.bescmd.baseline
+++ b/xmlcommand/tests/bescmd/show_bes_key_4.bescmd.baseline
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <response reqID="[thread:http-nio-8080-exec-4-42][bes_client:/-2]" xmlns="http://xml.opendap.org/ns/bes/1.0#">
-    <showBesKey>
-        <BesKey key="BES.Catalog.catalog.Exclude">
-            <value>^\..*;</value>
-        </BesKey>
+    <showBesKey key="BES.Catalog.catalog.Exclude">
+        <value>^\..*;</value>
     </showBesKey>
 </response>

--- a/xmlcommand/tests/bescmd/show_bes_key_5.bescmd.baseline
+++ b/xmlcommand/tests/bescmd/show_bes_key_5.bescmd.baseline
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <response reqID="[thread:http-nio-8080-exec-4-42][bes_client:/-2]" xmlns="http://xml.opendap.org/ns/bes/1.0#">
-    <showBesKey>
-        <BesKey key="BES.modules">
-            <value>dap,cmd,dapreader</value>
-        </BesKey>
+    <showBesKey key="BES.modules">
+        <value>dap,cmd,dapreader</value>
     </showBesKey>
 </response>


### PR DESCRIPTION
Added a new begin_response() method to BESInfo that allows one to add attributes to the begin_response element header. Since the only part of the BESInfo ecosystem that is using this is using XML and thus BESXMLInfo I implemented it there.