### PR TITLE
Mds xml base

### DIFF
--- a/dap/GlobalMetadataStore.cc
+++ b/dap/GlobalMetadataStore.cc
@@ -130,7 +130,7 @@ static void transfer_bytes(int fd, ostream &os)
     }
 }
 
-static void insert_xml_base(int fd, ostream &os, const strong &xml_base)
+static void insert_xml_base(int fd, ostream &os, const string &xml_base)
 {
     static const int BUFFER_SIZE = 16*1024;
 
@@ -158,11 +158,11 @@ static void insert_xml_base(int fd, ostream &os, const strong &xml_base)
         // Assume it is well formed and always includes the prolog,
         // but might not use <CR> <CRLF> chars
 
-        int i = 0;
+        size_t i = 0;
         while (buf[i++] != '>');    // 'i' now points one char past the xml prolog
         os.write(buf, i);
 
-        int j = 0;
+        size_t j = 0;
         char xml_base_literal[] = "xml:base";
         while (i < bytes_read) {
             if (buf[i] == '>') {    // Found end of Dataset; no xml:base was present

--- a/dap/GlobalMetadataStore.cc
+++ b/dap/GlobalMetadataStore.cc
@@ -95,11 +95,6 @@ static const string SIZE_KEY = "DAP.GlobalMetadataStore.size";
 static const string LEDGER_KEY = "DAP.GlobalMetadataStore.ledger";
 static const string LOCAL_TIME_KEY = "BES.LogTimeLocal";
 
-#if 0
-/// We decided that if xml:base is not present in the context manager, it's an error. jhrg 6/6/18
-static const string XML_BASE_DEFAULT = "http://localhost/";
-#endif
-
 GlobalMetadataStore *GlobalMetadataStore::d_instance = 0;
 bool GlobalMetadataStore::d_enabled = true;
 
@@ -879,8 +874,16 @@ GlobalMetadataStore::write_dmr_response(const std::string &name, ostream &os)
 {
     bool found = false;
     string xml_base = BESContextManager::TheManager()->get_context("xml:base", found);
-    if (!found) throw BESInternalError("Could not read the value of xml:base.", __FILE__, __LINE__);
-    write_response_helper(name, os, "dmr_r", xml_base, "DMR");
+    if (!found) {
+#if XML_BASE_MISSING_MEANS_OMIT_ATTRIBUTE
+        write_response_helper(name, os, "dmr_r", "DMR");
+#else
+        throw BESInternalError("Could not read the value of xml:base.", __FILE__, __LINE__);
+#endif
+    }
+    else {
+        write_response_helper(name, os, "dmr_r", xml_base, "DMR");
+    }
 }
 
 /**
@@ -894,8 +897,16 @@ GlobalMetadataStore::write_dmrpp_response(const std::string &name, ostream &os)
 {
     bool found = false;
     string xml_base = BESContextManager::TheManager()->get_context("xml:base", found);
-    if (!found) throw BESInternalError("Could not read the value of xml:base.", __FILE__, __LINE__);
-    write_response_helper(name, os, "dmrpp_r", xml_base, "DMR++");
+    if (!found) {
+#if XML_BASE_MISSING_MEANS_OMIT_ATTRIBUTE
+        write_response_helper(name, os, "dmrpp_r", "DMR++");
+#else
+        throw BESInternalError("Could not read the value of xml:base.", __FILE__, __LINE__);
+#endif
+    }
+    else {
+        write_response_helper(name, os, "dmrpp_r", xml_base, "DMR++");
+    }
 }
 
 /**

--- a/dap/GlobalMetadataStore.h
+++ b/dap/GlobalMetadataStore.h
@@ -31,6 +31,11 @@
 #include "BESFileLockingCache.h"
 #include "BESInternalFatalError.h"
 
+/// Setting XML_BASE_MISSING_MEANS_OMIT_ATTRIBUTE to zero causes the MDS to throw
+/// BESInternalError when the xml:base context is not defined and a DMR/++ response
+/// is accessed. This will break tests in dapreader and dmrpp_module. jhrg 6/6/18
+#define XML_BASE_MISSING_MEANS_OMIT_ATTRIBUTE 1
+
 namespace libdap {
 class DapObj;
 class DDS;

--- a/dap/GlobalMetadataStore.h
+++ b/dap/GlobalMetadataStore.h
@@ -166,6 +166,9 @@ protected:
 
     bool remove_response_helper(const std::string& name, const std::string &suffix, const std::string &object_name);
 
+    static void transfer_bytes(int fd, ostream &os);
+    static void insert_xml_base(int fd, ostream &os, const string &xml_base);
+
 public:
     /**
      * @brief Unlock and close the MDS item when the ReadLock goes out of scope.

--- a/dap/GlobalMetadataStore.h
+++ b/dap/GlobalMetadataStore.h
@@ -82,6 +82,7 @@ class GlobalMetadataStore: public BESFileLockingCache {
 private:
     bool d_use_local_time;      // Base on BES.LogTimeLocal
     std::string d_ledger_name;  // Name of the ledger file
+    std::string d_xml_base;     // The value of the context xml:basse
 
     static bool d_enabled;
     static GlobalMetadataStore *d_instance;
@@ -158,6 +159,10 @@ protected:
 
     void write_response_helper(const std::string &name, std::ostream &os, const std::string &suffix,
         const std::string &object_name);
+
+    // This version adds xml:base to the DMR/DMR++
+    void write_response_helper(const std::string &name, std::ostream &os, const std::string &suffix,
+        const std::string &xml_base, const std::string &object_name);
 
     bool remove_response_helper(const std::string& name, const std::string &suffix, const std::string &object_name);
 

--- a/dap/unit-tests/GlobalMetadataStoreTest.cc
+++ b/dap/unit-tests/GlobalMetadataStoreTest.cc
@@ -967,16 +967,16 @@ public:
     CPPUNIT_TEST(cache_a_dds_response);
     CPPUNIT_TEST(cache_a_das_response);
     CPPUNIT_TEST(cache_a_dmr_response);
-#if 0
-    CPPUNIT_TEST(cache_a_dmrpp_response);
-#endif
 
     CPPUNIT_TEST(add_response_test);
 
     CPPUNIT_TEST(get_dds_response_test);
     CPPUNIT_TEST(get_das_response_test);
     CPPUNIT_TEST(write_dmr_response_test);
+
+#ifndef XML_BASE_MISSING_MEANS_OMIT_ATTRIBUTE
     CPPUNIT_TEST_EXCEPTION(write_dmr_response_test_error, BESInternalError);
+#endif
 
 #if SYMETRIC_ADD_RESPONSES
     CPPUNIT_TEST(get_dmr_response_test_2);

--- a/dap/unit-tests/input-files/insert_xml_base_baseline.txt
+++ b/dap/unit-tests/input-files/insert_xml_base_baseline.txt
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="ISO‌-8859-1"?>
+<Dataset xmlns="http://stuff" attr="value" xml:base="URI">
+</Dataset>

--- a/dap/unit-tests/input-files/insert_xml_base_baseline2.txt
+++ b/dap/unit-tests/input-files/insert_xml_base_baseline2.txt
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="ISO‌-8859-1"?>
+<Dataset xmlns="http://stuff" attr="value" xml:base="URI-2">
+</Dataset>

--- a/dap/unit-tests/input-files/insert_xml_base_src.txt
+++ b/dap/unit-tests/input-files/insert_xml_base_src.txt
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="ISO‌-8859-1"?>
+<Dataset xmlns="http://stuff" attr="value">
+</Dataset>

--- a/dap/unit-tests/input-files/insert_xml_base_src2.txt
+++ b/dap/unit-tests/input-files/insert_xml_base_src2.txt
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="ISO‌-8859-1"?>
+<Dataset xmlns="http://stuff" attr="value" xml:base="goofy">
+</Dataset>

--- a/dap/unit-tests/mds_baselines/mds_test_01.dmr_r
+++ b/dap/unit-tests/mds_baselines/mds_test_01.dmr_r
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="input-files/test_01.dmr" dapVersion="4.0" dmrVersion="1.0" name="test_array_4">
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xml:base="http://localhost/" dapVersion="4.0" dmrVersion="1.0" name="test_array_4">
     <Dimension name="row" size="3"/>
     <Dimension name="col" size="4"/>
     <Byte name="a">


### PR DESCRIPTION
For this branch I decided that if the xml:base context is not set, the MDS should do nothing. This preserves the tests, which is more than just a convenience, since they test the MDS by reusing baselines from a set of tests that don't use the MDS - i.e., does the server return _exactly_ the same thing with and without the MDS? 

Since the OLFS should never omit the xml:base context, it should not be a problem. If it is, then we can add a testing mode.