### PR TITLE
Adds whitelist access control to dmr++ operations.

### DIFF
--- a/dispatch/BESDefaultModule.cc
+++ b/dispatch/BESDefaultModule.cc
@@ -81,6 +81,8 @@ using std::endl ;
 #include "BESInfoList.h"
 #include "BESInfoNames.h"
 
+#include "RemoteAccess.h"
+
 int
 BESDefaultModule::initialize(int, char**)
 {
@@ -172,6 +174,12 @@ BESDefaultModule::initialize(int, char**)
 
     BESDEBUG( "bes", "    adding bes debug context" << endl ) ;
     BESDebug::Register( "bes" ) ;
+
+
+    BESDEBUG( "bes", "    initializing RemoteAccess" << endl ) ;
+    bes::RemoteAccess::Initialize();
+
+
 
     BESDEBUG( "bes", "Done Initializing default modules:" << endl ) ;
 

--- a/dispatch/BESDefaultModule.cc
+++ b/dispatch/BESDefaultModule.cc
@@ -81,8 +81,6 @@ using std::endl ;
 #include "BESInfoList.h"
 #include "BESInfoNames.h"
 
-#include "RemoteAccess.h"
-
 int
 BESDefaultModule::initialize(int, char**)
 {
@@ -174,12 +172,6 @@ BESDefaultModule::initialize(int, char**)
 
     BESDEBUG( "bes", "    adding bes debug context" << endl ) ;
     BESDebug::Register( "bes" ) ;
-
-
-    BESDEBUG( "bes", "    initializing RemoteAccess" << endl ) ;
-    bes::RemoteAccess::Initialize();
-
-
 
     BESDEBUG( "bes", "Done Initializing default modules:" << endl ) ;
 

--- a/dispatch/Makefile.am
+++ b/dispatch/Makefile.am
@@ -98,7 +98,8 @@ SRCS = BESInterface.cc \
 	BESCatalogList.cc \
 	BESCatalogEntry.cc \
 	BESCatalogResponseHandler.cc \
-	CatalogNode.cc CatalogItem.cc
+	CatalogNode.cc CatalogItem.cc \
+	RemoteAccess.cc
 	
 # BESSilentInfo.cc
 # BESBasicHttpTransmitter.cc 
@@ -157,7 +158,9 @@ HDRS = BESInterface.h BESLog.h 			\
 	BESCatalogList.h \
 	BESCatalogEntry.h \
 	BESCatalogResponseHandler.h \
-	CatalogNode.h CatalogItem.h
+	CatalogNode.h CatalogItem.h \
+	RemoteAccess.h
+	
 	
 # BESSilentInfo.h
 # BESBasicHttpTransmitter.h

--- a/dispatch/RemoteAccess.cc
+++ b/dispatch/RemoteAccess.cc
@@ -27,12 +27,12 @@
 
 #include "config.h"
 
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-#include <cstdlib>
-#include <cstring>
-#include <curl/curl.h>
+//#ifdef HAVE_UNISTD_H
+//#include <unistd.h>
+//#endif
+//#include <cstdlib>
+//#include <cstring>
+//#include <curl/curl.h>
 
 #include "RemoteAccess.h"
 

--- a/dispatch/RemoteAccess.cc
+++ b/dispatch/RemoteAccess.cc
@@ -87,9 +87,9 @@ bool RemoteAccess::Is_Whitelisted(const std::string &url)
     if (!is_init) init();
 
     bool whitelisted = false;
-    string file_url("file://");
-    string http_url("http://");
-    string https_url("https://");
+    const string file_url("file://");
+    const string http_url("http://");
+    const string https_url("https://");
 
     // Special case: This allows any file: URL to pass if the URL starts with the default
     // catalog's path.
@@ -116,16 +116,12 @@ bool RemoteAccess::Is_Whitelisted(const std::string &url)
         BESDEBUG("bes", "RemoteAccess::Is_Whitelisted() - Is_Whitelisted: "<< (whitelisted?"true":"false") << endl);
     }
     else {
-   //if (!whitelisted) {
-        // This checks HTTP, HTTPS and FILE URLs against the whitelist patterns. I added
-        // file: URLs because I have tests that need to work with both 'make check' and
-        // 'make distcheck' where the latter has some complex paths
+        // This checks HTTP and HTTPS URLs against the whitelist patterns.
         if (url.compare(0, http_url.size(), http_url) == 0 /*equals http url */
-            || url.compare(0, https_url.size(), https_url) == 0 /*equals https url */
-            /*|| url.compare(0, file_url.size(), file_url) == 0*/ /*equals file url */) {
+            || url.compare(0, https_url.size(), https_url) == 0 /*equals https url */) {
 
-            std::vector<std::string>::const_iterator i = WhiteList.begin();
-            std::vector<std::string>::const_iterator e = WhiteList.end();
+            vector<string>::const_iterator i = WhiteList.begin();
+            vector<string>::const_iterator e = WhiteList.end();
             for (; i != e && !whitelisted; i++) {
                 if ((*i).length() <= url.length()) {
                     if (url.substr(0, (*i).length()) == (*i)) {

--- a/dispatch/RemoteAccess.cc
+++ b/dispatch/RemoteAccess.cc
@@ -108,7 +108,9 @@ bool RemoteAccess::Is_Whitelisted(const std::string &url){
             BESDEBUG("bes","RemoteAccess::Is_Whitelisted() - Found catalog: "<< bcat->get_catalog_name() << endl);
         }
         else {
-            BESDEBUG("bes","RemoteAccess::Is_Whitelisted() - Unable to locate default catalog!" << endl);
+            string msg = "OUCH! Unable to locate default catalog!";
+            BESDEBUG("bes","RemoteAccess::Is_Whitelisted() - " << msg << endl);
+            throw BESInternalError(msg,__FILE__,__LINE__);
         }
         string catalog_root = bcat->get_root();
         BESDEBUG("bes","RemoteAccess::Is_Whitelisted() - Catalog root: "<< catalog_root << endl);

--- a/dispatch/RemoteAccess.cc
+++ b/dispatch/RemoteAccess.cc
@@ -101,13 +101,20 @@ bool RemoteAccess::Is_Whitelisted(const std::string &url){
 
         // Ensure that the file path starts with the catalog root dir.
         string file_path = url.substr(file_url.size());
+        BESDEBUG("bes","RemoteAccess::Is_Whitelisted() - file_path: "<< file_path << endl);
 
         BESCatalog *bcat = BESCatalogList::TheCatalogList()->find_catalog(BES_DEFAULT_CATALOG);
+        if(bcat){
+            BESDEBUG("bes","RemoteAccess::Is_Whitelisted() - Found catalog: "<< bcat->get_catalog_name() << endl);
+        }
+        else {
+            BESDEBUG("bes","RemoteAccess::Is_Whitelisted() - Unable to locate default catalog!" << endl);
+        }
         string catalog_root = bcat->get_root();
-        // BESDEBUG("bes","Catalog root: "<< root << endl);
+        BESDEBUG("bes","RemoteAccess::Is_Whitelisted() - Catalog root: "<< catalog_root << endl);
 
         whitelisted = file_path.compare(0, catalog_root.size(), catalog_root) == 0;
-        // BESDEBUG("bes","Is_Whitelisted: "<< (whitelisted?"true":"false") << endl);
+        BESDEBUG("bes","RemoteAccess::Is_Whitelisted() - Is_Whitelisted: "<< (whitelisted?"true":"false") << endl);
     }
     else if (url.compare(0, http_url.size(),  http_url)  == 0  /*equals http url */   ||
              url.compare(0, https_url.size(), https_url) == 0  /*equals https url */ ) {

--- a/dispatch/RemoteAccess.cc
+++ b/dispatch/RemoteAccess.cc
@@ -87,9 +87,8 @@ bool RemoteAccess::Is_Whitelisted(const std::string &url){
     string https_url("https://");
 
     if (url.compare(0, file_url.size(), file_url) == 0 /*equal*/) {
-        // BESDEBUG("bes","Checking file URL for suitability. "<< url << endl);
-        // Check that the file path starts with the catalog root dir.
 
+        // Ensure that the file path starts with the catalog root dir.
         string file_path = url.substr(file_url.size());
         // BESDEBUG("bes","path component: "<< file_path << endl);
 

--- a/dispatch/RemoteAccess.cc
+++ b/dispatch/RemoteAccess.cc
@@ -47,7 +47,7 @@
 #include <BESDebug.h>
 #include <BESForbiddenError.h>
 
-#include <util.h>
+// #include <util.h>
 
 using namespace bes;
 

--- a/dispatch/RemoteAccess.cc
+++ b/dispatch/RemoteAccess.cc
@@ -1,4 +1,4 @@
-// RempteAccess.cc
+// RemoteAccess.cc
 
 // -*- mode: c++; c-basic-offset:4 -*-
 

--- a/dispatch/RemoteAccess.cc
+++ b/dispatch/RemoteAccess.cc
@@ -117,7 +117,7 @@ bool RemoteAccess::Is_Whitelisted(const std::string &url)
     }
 
     if (!whitelisted) {
-        // This checks HTTP, HTTPS and FILE URLs against the whitelist regexs. I added
+        // This checks HTTP, HTTPS and FILE URLs against the whitelist patterns. I added
         // file: URLs because I have tests that need to work with both 'make check' and
         // 'make distcheck' where the latter has some complex paths
         if (url.compare(0, http_url.size(), http_url) == 0 /*equals http url */

--- a/dispatch/RemoteAccess.cc
+++ b/dispatch/RemoteAccess.cc
@@ -37,12 +37,15 @@
 #include "RemoteAccess.h"
 
 #include <BESUtil.h>
+#include <BESCatalog.h>
+#include <BESCatalogList.h>
 #include <BESCatalogUtils.h>
 #include <BESRegex.h>
 #include <TheBESKeys.h>
 #include <BESInternalError.h>
 #include <BESSyntaxUserError.h>
 #include <BESDebug.h>
+#include <BESForbiddenError.h>
 
 #include <util.h>
 
@@ -71,16 +74,50 @@ void RemoteAccess::Initialize()
 }
 
 
+/**
+ * This method provides an access condition assessment for URLs and files
+ * to be accessed by the BES. The http and https urls are verified against a
+ * whitelist assembled from configurtion. The file urls are checked to be
+ * sure that they reference a resource within the BES catalog.
+ */
 bool RemoteAccess::Is_Whitelisted(const std::string &url){
     bool whitelisted = false;
-    std::vector<std::string>::const_iterator i = WhiteList.begin();
-    std::vector<std::string>::const_iterator e = WhiteList.end();
-    for (; i != e && !whitelisted; i++) {
-        if ((*i).length() <= url.length()) {
-            if (url.substr(0, (*i).length()) == (*i)) {
-                whitelisted = true;
+    string file_url("file://");
+    string http_url("http://");
+    string https_url("https://");
+
+    if (url.compare(0, file_url.size(), file_url) == 0 /*equal*/) {
+        // BESDEBUG("bes","Checking file URL for suitability. "<< url << endl);
+        // Check that the file path starts with the catalog root dir.
+
+        string file_path = url.substr(file_url.size());
+        // BESDEBUG("bes","path component: "<< file_path << endl);
+
+        BESCatalog *bcat = BESCatalogList::TheCatalogList()->find_catalog(BES_DEFAULT_CATALOG);
+        string root = bcat->get_root();
+        // BESDEBUG("bes","Catalog root: "<< root << endl);
+
+        whitelisted = file_path.compare(0, root.size(), root) == 0;
+        // BESDEBUG("bes","Is_Whitelisted: "<< (whitelisted?"true":"false") << endl);
+    }
+    else if (url.compare(0, http_url.size(), http_url) == 0    /*equals http url */   ||
+             url.compare(0, https_url.size(), https_url) == 0  /*equals https url */ ) {
+
+        std::vector<std::string>::const_iterator i = WhiteList.begin();
+        std::vector<std::string>::const_iterator e = WhiteList.end();
+        for (; i != e && !whitelisted; i++) {
+            if ((*i).length() <= url.length()) {
+                if (url.substr(0, (*i).length()) == (*i)) {
+                    whitelisted = true;
+                }
             }
         }
+    }
+    else {
+        string msg;
+        msg = "ERROR! Unknown URL protocol! Only "+http_url+", "+https_url+", and "+file_url+" are supported.";
+        BESDEBUG("bes", msg << endl);
+        throw BESForbiddenError(msg ,__FILE__,__LINE__);
     }
     return whitelisted;
 }

--- a/dispatch/RemoteAccess.cc
+++ b/dispatch/RemoteAccess.cc
@@ -1,0 +1,91 @@
+// RempteAccess.cc
+
+// -*- mode: c++; c-basic-offset:4 -*-
+
+// This file is part of the OPeNDAP Back-End Server (BES)
+// and embodies a whitelist of remote system that may be
+// accessed by the server as part of it's routine operation.
+
+// Copyright (c) 2018 OPeNDAP, Inc.
+// Author:Nathan D. Potter <ndp@opendap.org>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+// You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+
+#include "config.h"
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <cstdlib>
+#include <cstring>
+#include <curl/curl.h>
+
+#include "RemoteAccess.h"
+
+#include <BESUtil.h>
+#include <BESCatalogUtils.h>
+#include <BESRegex.h>
+#include <TheBESKeys.h>
+#include <BESInternalError.h>
+#include <BESSyntaxUserError.h>
+#include <BESDebug.h>
+
+#include <util.h>
+
+using namespace bes;
+
+
+std::vector<string> RemoteAccess::WhiteList;
+
+// Initialization routine for the gateway module for certain parameters
+// and keys, like the white list, the MimeTypes translation.
+void RemoteAccess::Initialize()
+{
+    // Whitelist - list of domain that the gateway is allowed to
+    // communicate with.
+    bool found = false;
+    string key = REMOTE_ACCESS_WHITELIST;
+    TheBESKeys::TheKeys()->get_values(key, WhiteList, found);
+
+    /*
+    if (!found || WhiteList.size() == 0) {
+        string err = (string) "The parameter " + REMOTE_ACCESS_WHITELIST + " is not set or has no values in the gateway"
+            + " configuration file";
+        throw BESSyntaxUserError(err, __FILE__, __LINE__);
+    }
+    */
+}
+
+
+bool RemoteAccess::Is_Whitelisted(const std::string &url){
+    bool whitelisted = false;
+    std::vector<std::string>::const_iterator i = WhiteList.begin();
+    std::vector<std::string>::const_iterator e = WhiteList.end();
+    for (; i != e && !whitelisted; i++) {
+        if ((*i).length() <= url.length()) {
+            if (url.substr(0, (*i).length()) == (*i)) {
+                whitelisted = true;
+            }
+        }
+    }
+    return whitelisted;
+}
+
+
+
+
+

--- a/dispatch/RemoteAccess.cc
+++ b/dispatch/RemoteAccess.cc
@@ -115,14 +115,14 @@ bool RemoteAccess::Is_Whitelisted(const std::string &url)
         whitelisted = file_path.compare(0, catalog_root.size(), catalog_root) == 0;
         BESDEBUG("bes", "RemoteAccess::Is_Whitelisted() - Is_Whitelisted: "<< (whitelisted?"true":"false") << endl);
     }
-
-    if (!whitelisted) {
+    else {
+   //if (!whitelisted) {
         // This checks HTTP, HTTPS and FILE URLs against the whitelist patterns. I added
         // file: URLs because I have tests that need to work with both 'make check' and
         // 'make distcheck' where the latter has some complex paths
         if (url.compare(0, http_url.size(), http_url) == 0 /*equals http url */
             || url.compare(0, https_url.size(), https_url) == 0 /*equals https url */
-            || url.compare(0, file_url.size(), file_url) == 0 /*equals file url */) {
+            /*|| url.compare(0, file_url.size(), file_url) == 0*/ /*equals file url */) {
 
             std::vector<std::string>::const_iterator i = WhiteList.begin();
             std::vector<std::string>::const_iterator e = WhiteList.end();

--- a/dispatch/RemoteAccess.h
+++ b/dispatch/RemoteAccess.h
@@ -7,7 +7,7 @@
 // accessed by the server as part of it's routine operation.
 
 // Copyright (c) 2018 OPeNDAP, Inc.
-// Author:Nathan D. Potter <ndp@opendap.org>
+// Author: Nathan D. Potter <ndp@opendap.org>
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
@@ -39,10 +39,15 @@
 
 namespace bes {
 
-/** @brief Embodies a configuration based remote access white list
- * and provides a simple API Is_Whitelisted() for determining what
- * resources may be accessed.
+/**
+ * @brief Can a given URL be dereferenced given the BES's configuration?
  *
+ * Embodies a configuration based remote access white list
+ * and provides a simple API (Is_Whitelisted()) for determining which
+ * resources may be accessed. This enables a system administrator to control
+ * the remote systems a particular BES daemon can access.
+ *
+ * @note This class is a singleton
  */
 class RemoteAccess {
 private:
@@ -51,7 +56,6 @@ private:
     static void init();
 
 public:
-
     static bool Is_Whitelisted(const std::string &url);
 };
 

--- a/dispatch/RemoteAccess.h
+++ b/dispatch/RemoteAccess.h
@@ -1,12 +1,13 @@
-// GatewayUtils.h
+// RempteAccess.h
 
 // -*- mode: c++; c-basic-offset:4 -*-
 
-// This file is part of gateway_module, A C++ module that can be loaded in to
-// the OPeNDAP Back-End Server (BES) and is able to handle remote requests.
+// This file is part of the OPeNDAP Back-End Server (BES)
+// and embodies a whitelist of remote system that may be
+// accessed by the server as part of it's routine operation.
 
-// Copyright (c) 2002,2003 OPeNDAP, Inc.
-// Author: Patrick West <pwest@ucar.edu>
+// Copyright (c) 2018 OPeNDAP, Inc.
+// Author:Nathan D. Potter <ndp@opendap.org>
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
@@ -25,47 +26,32 @@
 // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
 
 // Authors:
-//      pcw       Patrick West <pwest@ucar.edu>
+//      ndp       Nathan D. Potter <ndp@opendap.org>
 
-#ifndef I_GatewayUtils_H
-#define I_GatewayUtils_H 1
+#ifndef I_RemoteAccess_H
+#define I_RemoteAccess_H 1
 
 #include <string>
 #include <map>
 #include <vector>
 
-namespace gateway {
+#define REMOTE_ACCESS_WHITELIST "Gateway.Whitelist"
+
+namespace bes {
 
 /** @brief utility class for the gateway remote request mechanism
  *
  */
-class GatewayUtils {
-public:
-#if 0
+class RemoteAccess {
     static std::vector<std::string> WhiteList;
-#endif
-    static std::map<std::string, std::string> MimeList;
-    static std::string ProxyProtocol;
-    static std::string ProxyHost;
-    static std::string ProxyUserPW;
-    static std::string ProxyUser;
-    static std::string ProxyPassword;
-    static int ProxyPort;
-    static int ProxyAuthType;
-    static bool useInternalCache;
 
-    static std::string NoProxyRegex;
+public:
 
     static void Initialize();
-    static void Get_type_from_disposition(const std::string &disp, std::string &type);
-    static void Get_type_from_content_type(const std::string &ctype, std::string &type);
-    static void Get_type_from_url(const std::string &url, std::string &type);
-#if 0
     static bool Is_Whitelisted(const std::string &url);
-#endif
 };
 
-} // namespace gateway
+} // namespace bes
 
-#endif // I_GatewayUtils_H
+#endif // I_RemoteAccess_H
 

--- a/dispatch/RemoteAccess.h
+++ b/dispatch/RemoteAccess.h
@@ -39,15 +39,19 @@
 
 namespace bes {
 
-/** @brief utility class for the gateway remote request mechanism
+/** @brief Embodies a configuration based remote access white list
+ * and provides a simple API Is_Whitelisted() for determining what
+ * resources may be accessed.
  *
  */
 class RemoteAccess {
+private:
+    static bool is_init;
     static std::vector<std::string> WhiteList;
+    static void init();
 
 public:
 
-    static void Initialize();
     static bool Is_Whitelisted(const std::string &url);
 };
 

--- a/dispatch/RemoteAccess.h
+++ b/dispatch/RemoteAccess.h
@@ -1,4 +1,4 @@
-// RempteAccess.h
+// RemoteAccess.h
 
 // -*- mode: c++; c-basic-offset:4 -*-
 

--- a/dispatch/unit-tests/.gitignore
+++ b/dispatch/unit-tests/.gitignore
@@ -3,3 +3,4 @@ containerT
 lockT
 uncompressT
 
+/RemoteAccessTest

--- a/dispatch/unit-tests/Makefile.am
+++ b/dispatch/unit-tests/Makefile.am
@@ -32,7 +32,7 @@ if CPPUNIT
 TESTS = constraintT defT keysT pfileT plistT pvolT replistT		\
 reqhandlerT reqlistT resplistT infoT agglistT debugT utilT regexT	\
 scrubT checkT servicesT fsT urlT BESCatalogListUnitTest containerT	\
-uncompressT cacheT
+uncompressT cacheT RemoteAccessTest
 
 # This is tool to look at CatalogEntry objects. jhrg 3.5.18
 # complete_catalog_lister
@@ -139,6 +139,8 @@ regexT_SOURCES = regexT.cc
 scrubT_SOURCES = scrubT.cc
 
 checkT_SOURCES = checkT.cc
+
+RemoteAccessTest_SOURCES = RemoteAccessTest.cc
 
 servicesT_SOURCES = servicesT.cc
 servicesT_CPPFLAGS = $(AM_CPPFLAGS) $(XML2_CFLAGS)

--- a/dispatch/unit-tests/Makefile.am
+++ b/dispatch/unit-tests/Makefile.am
@@ -67,7 +67,7 @@ EXTRA_DIST = $(CACHE) catalog_test catalog_test_baselines bad_keys1.ini \
 	persistence_file1.txt persistence_file2.txt \
 	persistence_file3.txt persistence_file4.txt \
 	persistence_file_test.txt test_config.h.in \
-    bes.conf
+    bes.conf remote_access_test.ini
 
 DISTCLEANFILES = 
 

--- a/dispatch/unit-tests/Makefile.am
+++ b/dispatch/unit-tests/Makefile.am
@@ -141,6 +141,7 @@ scrubT_SOURCES = scrubT.cc
 checkT_SOURCES = checkT.cc
 
 RemoteAccessTest_SOURCES = RemoteAccessTest.cc
+RemoteAccessTest_LDADD = ../RemoteAccess.o $(LDADD)
 
 servicesT_SOURCES = servicesT.cc
 servicesT_CPPFLAGS = $(AM_CPPFLAGS) $(XML2_CFLAGS)

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -47,12 +47,15 @@ using std::cerr;
 using std::cout;
 using std::endl;
 
+#include <test_config.h>
+
 #include "RemoteAccess.h"
 #include <TheBESKeys.h>
-#include <test_config.h>
+#include <BESDebug.h>
 #include <GetOpt.h>
 
 static bool debug = false;
+static bool bes_debug = false;
 
 #undef DBG
 #define DBG(x) do { if (debug) (x); } while(false);
@@ -60,7 +63,7 @@ static bool debug = false;
 class plistT: public TestFixture {
 private:
 
-#if 0
+#if 1
     void show_file(std::string filename){
         std::ifstream t(filename.c_str());
         //std::ifstream t;
@@ -87,6 +90,8 @@ public:
 
     void setUp()
     {
+        if (bes_debug) BESDebug::SetUp("cerr,bes");
+
 
 //        Gateway.Whitelist=http://localhost
 //        Gateway.Whitelist+=http://test.opendap.org/opendap/
@@ -97,7 +102,7 @@ public:
         std::string bes_conf = (std::string) TEST_SRC_DIR + "/remote_access_test.ini";
         TheBESKeys::ConfigFile = bes_conf;
 
-        // if(debug) show_file(bes_conf);
+        if(bes_debug) show_file(bes_conf);
     }
 
     void tearDown()
@@ -134,7 +139,11 @@ public:
 
         CPPUNIT_ASSERT( can_access("http://cloudydap.opendap.org/opendap/Arch-2/ebs/samples/3A-MO.GPM.GMI.GRID2014R1.20140601-S000000-E235959.06.V03A.h5") );
 
+        CPPUNIT_ASSERT( !can_access("file://foo") );
+        CPPUNIT_ASSERT( can_access("file:///usr/share/hyrax/data/nc/fnoc1.nc") );
+        CPPUNIT_ASSERT( !can_access("file://usr/share/hyrax/data/nc/fnoc1.nc") );
 
+        CPPUNIT_ASSERT( !can_access("file:///etc/password") );
 
 
 
@@ -147,12 +156,15 @@ CPPUNIT_TEST_SUITE_REGISTRATION( plistT );
 int main(int argc, char*argv[])
 {
 
-    GetOpt getopt(argc, argv, "dh");
+    GetOpt getopt(argc, argv, "dhb");
     char option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':
             debug = 1;  // debug is a static global
+            break;
+        case 'b':
+            bes_debug = 1;  // debug is a static global
             break;
         case 'h': {     // help - show test names
             cerr << "Usage: plistT has the following tests:" << endl;

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -106,17 +106,13 @@ public:
         TheBESKeys::ConfigFile = bes_conf;
 
         try {
-        BESCatalogList *tcl = BESCatalogList::TheCatalogList();
-
-        if(tcl){
+            BESCatalogList *tcl = BESCatalogList::TheCatalogList();
             if (!tcl->ref_catalog(BES_DEFAULT_CATALOG)) {
                 tcl->add_catalog(new BESCatalogDirectory(BES_DEFAULT_CATALOG));
             }
         }
-        }
         catch ( BESError &be){
-            cerr << be.get_message() << endl;
-
+            cerr << endl << endl << "setUp() - OUCH! Could not initialize the BES Catalog! Message:  " << be.get_message() << endl;
         }
         if(bes_debug) show_file(bes_conf);
     }
@@ -146,23 +142,20 @@ public:
 
         CPPUNIT_ASSERT( !can_access("http://google.com") );
 
-        CPPUNIT_ASSERT( can_access("http://test.opendap.org/opendap/data/nc/fnoc1.nc") );
+        CPPUNIT_ASSERT(  can_access("http://test.opendap.org/opendap/data/nc/fnoc1.nc") );
 
-        CPPUNIT_ASSERT( can_access("https://s3.amazonaws.com/somewhereovertherainbow/data/nc/fnoc1.nc") );
+        CPPUNIT_ASSERT(  can_access("https://s3.amazonaws.com/somewhereovertherainbow/data/nc/fnoc1.nc") );
         CPPUNIT_ASSERT( !can_access("http://s3.amazonaws.com/somewhereovertherainbow/data/nc/fnoc1.nc") );
 
-        CPPUNIT_ASSERT( can_access("http://thredds.ucar.edu/thredds/dodsC/data/nc/fnoc1.nc") );
+        CPPUNIT_ASSERT(  can_access("http://thredds.ucar.edu/thredds/dodsC/data/nc/fnoc1.nc") );
         CPPUNIT_ASSERT( !can_access("https://thredds.ucar.edu/thredds/dodsC/data/nc/fnoc1.nc") );
 
-        CPPUNIT_ASSERT( can_access("http://cloudydap.opendap.org/opendap/Arch-2/ebs/samples/3A-MO.GPM.GMI.GRID2014R1.20140601-S000000-E235959.06.V03A.h5") );
+        CPPUNIT_ASSERT(  can_access("http://cloudydap.opendap.org/opendap/Arch-2/ebs/samples/3A-MO.GPM.GMI.GRID2014R1.20140601-S000000-E235959.06.V03A.h5") );
 
         CPPUNIT_ASSERT( !can_access("file://foo") );
-        CPPUNIT_ASSERT( can_access("file:///usr/share/hyrax/data/nc/fnoc1.nc") );
-        CPPUNIT_ASSERT( !can_access("file://usr/share/hyrax/data/nc/fnoc1.nc") );
-
+        CPPUNIT_ASSERT(  can_access("file:///tmp/nc/fnoc1.nc") );
+        CPPUNIT_ASSERT( !can_access("file://tmp/data/nc/fnoc1.nc") );
         CPPUNIT_ASSERT( !can_access("file:///etc/password") );
-
-
 
 
     }

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -60,6 +60,7 @@ static bool debug = false;
 class plistT: public TestFixture {
 private:
 
+#if 0
     void show_file(std::string filename){
         std::ifstream t(filename.c_str());
         //std::ifstream t;
@@ -74,6 +75,8 @@ private:
             cout << ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . " << endl;
         }
     }
+#endif
+
 public:
     plistT()
     {
@@ -94,7 +97,7 @@ public:
         std::string bes_conf = (std::string) TEST_SRC_DIR + "/remote_access_test.ini";
         TheBESKeys::ConfigFile = bes_conf;
 
-        if(debug) show_file(bes_conf);
+        // if(debug) show_file(bes_conf);
     }
 
     void tearDown()

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -93,9 +93,6 @@ public:
 
         TheBESKeys::TheKeys()->set_key("BES.Catalog.catalog.RootDirectory",catalog_root_dir);
 
-//        BES.Catalog.catalog.RootDirectory=/tmp
-
-
         try {
             BESCatalogList *tcl = BESCatalogList::TheCatalogList();
             if (!tcl->ref_catalog(BES_DEFAULT_CATALOG)) {
@@ -130,9 +127,7 @@ public:
 
     void do_test()
     {
-
         string catalog_root_url = "file://" + catalog_root_dir;
-
 
         CPPUNIT_ASSERT(!can_access("http://google.com"));
 
@@ -149,8 +144,7 @@ public:
 
         CPPUNIT_ASSERT(!can_access("file://foo"));
 
-        string s = BESUtil::assemblePath(catalog_root_url,"nc/fnoc1.nc");
-        CPPUNIT_ASSERT(can_access(s));
+        CPPUNIT_ASSERT(can_access(BESUtil::assemblePath(catalog_root_url, "nc/fnoc1.nc")));
 
         CPPUNIT_ASSERT(!can_access("file://tmp/data/nc/fnoc1.nc"));
         CPPUNIT_ASSERT(!can_access("file:///etc/password"));
@@ -161,7 +155,6 @@ CPPUNIT_TEST_SUITE_REGISTRATION(RemoteAccessTest);
 
 int main(int argc, char*argv[])
 {
-
     GetOpt getopt(argc, argv, "dhb");
     char option_char;
     while ((option_char = getopt()) != EOF)

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -51,6 +51,8 @@ using namespace CppUnit;
 static bool debug = false;
 static bool bes_debug = false;
 
+const string catalog_root_dir = BESUtil::assemblePath(TEST_SRC_DIR,"catalog_test");
+
 #undef DBG
 #define DBG(x) do { if (debug) (x); } while(false);
 
@@ -85,8 +87,14 @@ public:
     {
         if (bes_debug) BESDebug::SetUp("cerr,all");
 
+
         string bes_conf = (string) TEST_SRC_DIR + "/remote_access_test.ini";
         TheBESKeys::ConfigFile = bes_conf;
+
+        TheBESKeys::TheKeys()->set_key("BES.Catalog.catalog.RootDirectory",catalog_root_dir);
+
+//        BES.Catalog.catalog.RootDirectory=/tmp
+
 
         try {
             BESCatalogList *tcl = BESCatalogList::TheCatalogList();
@@ -122,6 +130,10 @@ public:
 
     void do_test()
     {
+
+        string catalog_root_url = "file://" + catalog_root_dir;
+
+
         CPPUNIT_ASSERT(!can_access("http://google.com"));
 
         CPPUNIT_ASSERT(can_access("http://test.opendap.org/opendap/data/nc/fnoc1.nc"));
@@ -136,7 +148,10 @@ public:
             can_access("http://cloudydap.opendap.org/opendap/Arch-2/ebs/samples/3A-MO.GPM.GMI.GRID2014R1.20140601-S000000-E235959.06.V03A.h5"));
 
         CPPUNIT_ASSERT(!can_access("file://foo"));
-        CPPUNIT_ASSERT(can_access("file:///tmp/nc/fnoc1.nc"));
+
+        string s = BESUtil::assemblePath(catalog_root_url,"nc/fnoc1.nc");
+        CPPUNIT_ASSERT(can_access(s));
+
         CPPUNIT_ASSERT(!can_access("file://tmp/data/nc/fnoc1.nc"));
         CPPUNIT_ASSERT(!can_access("file:///etc/password"));
     }

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -85,7 +85,7 @@ public:
     {
         if (bes_debug) BESDebug::SetUp("cerr,all");
 
-        string bes_conf = (string) TEST_BUILD_DIR + "/remote_access_test.ini";
+        string bes_conf = (string) TEST_SRC_DIR + "/remote_access_test.ini";
         TheBESKeys::ConfigFile = bes_conf;
 
         try {

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -61,15 +61,18 @@ class plistT: public TestFixture {
 private:
 
     void show_file(std::string filename){
-        cout << endl << "##################################################################" << endl;
-        cout << "file: " << filename << endl;
-        cout << ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . " << endl;
         // std::ifstream t(filename);
-        std::ifstream t(filename, std::ifstream::in);
-        std::string file_content((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
-        cout << file_content << endl;
-        cout << ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . " << endl;
-
+        std::ifstream t;
+        t.open(filename, std::ifstream::in);
+        if(t.is_open()){
+            std::string file_content((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
+            t.close();
+            cout << endl << "##################################################################" << endl;
+            cout << "file: " << filename << endl;
+            cout << ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . " << endl;
+            cout << file_content << endl;
+            cout << ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . " << endl;
+        }
     }
 public:
     plistT()

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -85,7 +85,7 @@ public:
     {
         if (bes_debug) BESDebug::SetUp("cerr,all");
 
-        string bes_conf = (string) TEST_SRC_DIR + "/remote_access_test.ini";
+        string bes_conf = (string) TEST_BUILD_DIR + "/remote_access_test.ini";
         TheBESKeys::ConfigFile = bes_conf;
 
         try {

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -64,7 +64,8 @@ private:
         cout << endl << "##################################################################" << endl;
         cout << "file: " << filename << endl;
         cout << ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . " << endl;
-        std::ifstream t(filename);
+        // std::ifstream t(filename);
+        std::ifstream t(filename, std::ifstream::in);
         std::string file_content((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
         cout << file_content << endl;
         cout << ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . " << endl;

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -113,7 +113,7 @@ public:
 
     void do_test()
     {
-        bes::RemoteAccess::Initialize();
+        // bes::RemoteAccess::Initialize();
 
         CPPUNIT_ASSERT( !can_access("http://google.com") );
 

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -76,6 +76,7 @@ public:
     RemoteAccessTest()
     {
     }
+
     ~RemoteAccessTest()
     {
     }
@@ -121,8 +122,6 @@ public:
 
     void do_test()
     {
-        // bes::RemoteAccess::Initialize();
-
         CPPUNIT_ASSERT(!can_access("http://google.com"));
 
         CPPUNIT_ASSERT(can_access("http://test.opendap.org/opendap/data/nc/fnoc1.nc"));

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -61,9 +61,9 @@ class plistT: public TestFixture {
 private:
 
     void show_file(std::string filename){
-        // std::ifstream t(filename);
-        std::ifstream t;
-        t.open(filename, std::ifstream::in);
+        std::ifstream t(filename.c_str());
+        //std::ifstream t;
+        //t.open(filename.c_str(), std::ifstream::in);
         if(t.is_open()){
             std::string file_content((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
             t.close();

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -1,10 +1,11 @@
-// plistT.C
+// -*- mode: c++; c-basic-offset:4 -*-
 
-// This file is part of bes, A C++ back-end server implementation framework
-// for the OPeNDAP Data Access Protocol.
+// This file is part of the OPeNDAP Back-End Server (BES)
+// and embodies a whitelist of remote system that may be
+// accessed by the server as part of it's routine operation.
 
-// Copyright (c) 2004-2009 University Corporation for Atmospheric Research
-// Author: Patrick West <pwest@ucar.edu> and Jose Garcia <jgarcia@ucar.edu>
+// Copyright (c) 2018 OPeNDAP, Inc.
+// Author: Nathan D. Potter <ndp@opendap.org>
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
@@ -20,21 +21,11 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
-// You can contact University Corporation for Atmospheric Research at
-// 3080 Center Green Drive, Boulder, CO 80301
-
-// (c) COPYRIGHT University Corporation for Atmospheric Research 2004-2005
-// Please read the full copyright statement in the file COPYRIGHT_UCAR.
-//
-// Authors:
-//      pwest       Patrick West <pwest@ucar.edu>
-//      jgarcia     Jose Garcia <jgarcia@ucar.edu>
+// You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
 
 #include <cppunit/TextTestRunner.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/extensions/HelperMacros.h>
-
-using namespace CppUnit;
 
 #include <string>
 #include <iostream>
@@ -42,21 +33,20 @@ using namespace CppUnit;
 #include <fstream>
 #include <streambuf>
 
-
-using std::cerr;
-using std::cout;
-using std::endl;
-
-#include <test_config.h>
+#include <GetOpt.h>
 #include <BESCatalog.h>
 #include <BESCatalogDirectory.h>
 #include <BESCatalogList.h>
 #include <BESCatalogUtils.h>
 
-#include "RemoteAccess.h"
 #include <TheBESKeys.h>
 #include <BESDebug.h>
-#include <GetOpt.h>
+
+#include "test_config.h"
+#include "RemoteAccess.h"
+
+using namespace std;
+using namespace CppUnit;
 
 static bool debug = false;
 static bool bes_debug = false;
@@ -64,16 +54,15 @@ static bool bes_debug = false;
 #undef DBG
 #define DBG(x) do { if (debug) (x); } while(false);
 
-class plistT: public TestFixture {
+class RemoteAccessTest: public TestFixture {
 private:
 
-#if 1
-    void show_file(std::string filename){
-        std::ifstream t(filename.c_str());
-        //std::ifstream t;
-        //t.open(filename.c_str(), std::ifstream::in);
-        if(t.is_open()){
-            std::string file_content((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
+    void show_file(string filename)
+    {
+        ifstream t(filename.c_str());
+
+        if (t.is_open()) {
+            string file_content((istreambuf_iterator<char>(t)), istreambuf_iterator<char>());
             t.close();
             cout << endl << "##################################################################" << endl;
             cout << "file: " << filename << endl;
@@ -82,13 +71,12 @@ private:
             cout << ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . " << endl;
         }
     }
-#endif
 
 public:
-    plistT()
+    RemoteAccessTest()
     {
     }
-    ~plistT()
+    ~RemoteAccessTest()
     {
     }
 
@@ -96,13 +84,7 @@ public:
     {
         if (bes_debug) BESDebug::SetUp("cerr,all");
 
-//        Gateway.Whitelist=http://localhost
-//        Gateway.Whitelist+=http://test.opendap.org/opendap/
-//        Gateway.Whitelist+=http://cloudydap.opendap.org/opendap/
-//        Gateway.Whitelist+=http://thredds.ucar.edu/thredds/
-//        Gateway.Whitelist+=https://s3.amazonaws.com/somewhereovertherainbow/
-
-        std::string bes_conf = (std::string) TEST_SRC_DIR + "/remote_access_test.ini";
+        string bes_conf = (string) TEST_SRC_DIR + "/remote_access_test.ini";
         TheBESKeys::ConfigFile = bes_conf;
 
         try {
@@ -111,10 +93,11 @@ public:
                 tcl->add_catalog(new BESCatalogDirectory(BES_DEFAULT_CATALOG));
             }
         }
-        catch ( BESError &be){
+        catch (BESError &be) {
             cerr << endl << endl << "setUp() - OUCH! Could not initialize the BES Catalog! Message:  " << be.get_message() << endl;
         }
-        if(bes_debug) show_file(bes_conf);
+
+        if (bes_debug) show_file(bes_conf);
     }
 
     void tearDown()
@@ -122,17 +105,17 @@ public:
         BESCatalogList::TheCatalogList()->deref_catalog(BES_DEFAULT_CATALOG);
     }
 
-    CPPUNIT_TEST_SUITE( plistT );
+    CPPUNIT_TEST_SUITE( RemoteAccessTest );
 
-    CPPUNIT_TEST( do_test );
+    CPPUNIT_TEST(do_test);
 
     CPPUNIT_TEST_SUITE_END();
 
-
-    bool can_access(std::string url){
-        if(debug) cout << "Checking remote access permission for url: '" << url << "' result: ";
-        bool result =  bes::RemoteAccess::Is_Whitelisted(url);
-        if(debug) cout << (result?"true":"false") << endl;
+    bool can_access(string url)
+    {
+        if (debug) cout << "Checking remote access permission for url: '" << url << "' result: ";
+        bool result = bes::RemoteAccess::Is_Whitelisted(url);
+        if (debug) cout << (result ? "true" : "false") << endl;
         return result;
     }
 
@@ -140,28 +123,27 @@ public:
     {
         // bes::RemoteAccess::Initialize();
 
-        CPPUNIT_ASSERT( !can_access("http://google.com") );
+        CPPUNIT_ASSERT(!can_access("http://google.com"));
 
-        CPPUNIT_ASSERT(  can_access("http://test.opendap.org/opendap/data/nc/fnoc1.nc") );
+        CPPUNIT_ASSERT(can_access("http://test.opendap.org/opendap/data/nc/fnoc1.nc"));
 
-        CPPUNIT_ASSERT(  can_access("https://s3.amazonaws.com/somewhereovertherainbow/data/nc/fnoc1.nc") );
-        CPPUNIT_ASSERT( !can_access("http://s3.amazonaws.com/somewhereovertherainbow/data/nc/fnoc1.nc") );
+        CPPUNIT_ASSERT(can_access("https://s3.amazonaws.com/somewhereovertherainbow/data/nc/fnoc1.nc"));
+        CPPUNIT_ASSERT(!can_access("http://s3.amazonaws.com/somewhereovertherainbow/data/nc/fnoc1.nc"));
 
-        CPPUNIT_ASSERT(  can_access("http://thredds.ucar.edu/thredds/dodsC/data/nc/fnoc1.nc") );
-        CPPUNIT_ASSERT( !can_access("https://thredds.ucar.edu/thredds/dodsC/data/nc/fnoc1.nc") );
+        CPPUNIT_ASSERT(can_access("http://thredds.ucar.edu/thredds/dodsC/data/nc/fnoc1.nc"));
+        CPPUNIT_ASSERT(!can_access("https://thredds.ucar.edu/thredds/dodsC/data/nc/fnoc1.nc"));
 
-        CPPUNIT_ASSERT(  can_access("http://cloudydap.opendap.org/opendap/Arch-2/ebs/samples/3A-MO.GPM.GMI.GRID2014R1.20140601-S000000-E235959.06.V03A.h5") );
+        CPPUNIT_ASSERT(
+            can_access("http://cloudydap.opendap.org/opendap/Arch-2/ebs/samples/3A-MO.GPM.GMI.GRID2014R1.20140601-S000000-E235959.06.V03A.h5"));
 
-        CPPUNIT_ASSERT( !can_access("file://foo") );
-        CPPUNIT_ASSERT(  can_access("file:///tmp/nc/fnoc1.nc") );
-        CPPUNIT_ASSERT( !can_access("file://tmp/data/nc/fnoc1.nc") );
-        CPPUNIT_ASSERT( !can_access("file:///etc/password") );
-
-
+        CPPUNIT_ASSERT(!can_access("file://foo"));
+        CPPUNIT_ASSERT(can_access("file:///tmp/nc/fnoc1.nc"));
+        CPPUNIT_ASSERT(!can_access("file://tmp/data/nc/fnoc1.nc"));
+        CPPUNIT_ASSERT(!can_access("file:///etc/password"));
     }
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION( plistT );
+CPPUNIT_TEST_SUITE_REGISTRATION(RemoteAccessTest);
 
 int main(int argc, char*argv[])
 {
@@ -178,9 +160,9 @@ int main(int argc, char*argv[])
             break;
         case 'h': {     // help - show test names
             cerr << "Usage: plistT has the following tests:" << endl;
-            const std::vector<Test*> &tests = plistT::suite()->getTests();
-            unsigned int prefix_len = plistT::suite()->getName().append("::").length();
-            for (std::vector<Test*>::const_iterator i = tests.begin(), e = tests.end(); i != e; ++i) {
+            const vector<Test*> &tests = RemoteAccessTest::suite()->getTests();
+            unsigned int prefix_len = RemoteAccessTest::suite()->getName().append("::").length();
+            for (vector<Test*>::const_iterator i = tests.begin(), e = tests.end(); i != e; ++i) {
                 cerr << (*i)->getName().replace(0, prefix_len, "") << endl;
             }
             break;
@@ -202,7 +184,7 @@ int main(int argc, char*argv[])
     else {
         while (i < argc) {
             if (debug) cerr << "Running " << argv[i] << endl;
-            test = plistT::suite()->getName().append("::").append(argv[i]);
+            test = RemoteAccessTest::suite()->getName().append("::").append(argv[i]);
             wasSuccessful = wasSuccessful && runner.run(test);
         }
     }

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -48,6 +48,10 @@ using std::cout;
 using std::endl;
 
 #include <test_config.h>
+#include <BESCatalog.h>
+#include <BESCatalogDirectory.h>
+#include <BESCatalogList.h>
+#include <BESCatalogUtils.h>
 
 #include "RemoteAccess.h"
 #include <TheBESKeys.h>
@@ -90,8 +94,7 @@ public:
 
     void setUp()
     {
-        if (bes_debug) BESDebug::SetUp("cerr,bes");
-
+        if (bes_debug) BESDebug::SetUp("cerr,all");
 
 //        Gateway.Whitelist=http://localhost
 //        Gateway.Whitelist+=http://test.opendap.org/opendap/
@@ -102,11 +105,25 @@ public:
         std::string bes_conf = (std::string) TEST_SRC_DIR + "/remote_access_test.ini";
         TheBESKeys::ConfigFile = bes_conf;
 
+        try {
+        BESCatalogList *tcl = BESCatalogList::TheCatalogList();
+
+        if(tcl){
+            if (!tcl->ref_catalog(BES_DEFAULT_CATALOG)) {
+                tcl->add_catalog(new BESCatalogDirectory(BES_DEFAULT_CATALOG));
+            }
+        }
+        }
+        catch ( BESError &be){
+            cerr << be.get_message() << endl;
+
+        }
         if(bes_debug) show_file(bes_conf);
     }
 
     void tearDown()
     {
+        BESCatalogList::TheCatalogList()->deref_catalog(BES_DEFAULT_CATALOG);
     }
 
     CPPUNIT_TEST_SUITE( plistT );

--- a/dispatch/unit-tests/RemoteAccessTest.cc
+++ b/dispatch/unit-tests/RemoteAccessTest.cc
@@ -1,0 +1,183 @@
+// plistT.C
+
+// This file is part of bes, A C++ back-end server implementation framework
+// for the OPeNDAP Data Access Protocol.
+
+// Copyright (c) 2004-2009 University Corporation for Atmospheric Research
+// Author: Patrick West <pwest@ucar.edu> and Jose Garcia <jgarcia@ucar.edu>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+// You can contact University Corporation for Atmospheric Research at
+// 3080 Center Green Drive, Boulder, CO 80301
+
+// (c) COPYRIGHT University Corporation for Atmospheric Research 2004-2005
+// Please read the full copyright statement in the file COPYRIGHT_UCAR.
+//
+// Authors:
+//      pwest       Patrick West <pwest@ucar.edu>
+//      jgarcia     Jose Garcia <jgarcia@ucar.edu>
+
+#include <cppunit/TextTestRunner.h>
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+using namespace CppUnit;
+
+#include <string>
+#include <iostream>
+#include <cstdlib>
+#include <fstream>
+#include <streambuf>
+
+
+using std::cerr;
+using std::cout;
+using std::endl;
+
+#include "RemoteAccess.h"
+#include <TheBESKeys.h>
+#include <test_config.h>
+#include <GetOpt.h>
+
+static bool debug = false;
+
+#undef DBG
+#define DBG(x) do { if (debug) (x); } while(false);
+
+class plistT: public TestFixture {
+private:
+
+    void show_file(std::string filename){
+        cout << endl << "##################################################################" << endl;
+        cout << "file: " << filename << endl;
+        cout << ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . " << endl;
+        std::ifstream t(filename);
+        std::string file_content((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
+        cout << file_content << endl;
+        cout << ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . " << endl;
+
+    }
+public:
+    plistT()
+    {
+    }
+    ~plistT()
+    {
+    }
+
+    void setUp()
+    {
+
+//        Gateway.Whitelist=http://localhost
+//        Gateway.Whitelist+=http://test.opendap.org/opendap/
+//        Gateway.Whitelist+=http://cloudydap.opendap.org/opendap/
+//        Gateway.Whitelist+=http://thredds.ucar.edu/thredds/
+//        Gateway.Whitelist+=https://s3.amazonaws.com/somewhereovertherainbow/
+
+        std::string bes_conf = (std::string) TEST_SRC_DIR + "/remote_access_test.ini";
+        TheBESKeys::ConfigFile = bes_conf;
+
+        if(debug) show_file(bes_conf);
+    }
+
+    void tearDown()
+    {
+    }
+
+    CPPUNIT_TEST_SUITE( plistT );
+
+    CPPUNIT_TEST( do_test );
+
+    CPPUNIT_TEST_SUITE_END();
+
+
+    bool can_access(std::string url){
+        if(debug) cout << "Checking remote access permission for url: '" << url << "' result: ";
+        bool result =  bes::RemoteAccess::Is_Whitelisted(url);
+        if(debug) cout << (result?"true":"false") << endl;
+        return result;
+    }
+
+    void do_test()
+    {
+        bes::RemoteAccess::Initialize();
+
+        CPPUNIT_ASSERT( !can_access("http://google.com") );
+
+        CPPUNIT_ASSERT( can_access("http://test.opendap.org/opendap/data/nc/fnoc1.nc") );
+
+        CPPUNIT_ASSERT( can_access("https://s3.amazonaws.com/somewhereovertherainbow/data/nc/fnoc1.nc") );
+        CPPUNIT_ASSERT( !can_access("http://s3.amazonaws.com/somewhereovertherainbow/data/nc/fnoc1.nc") );
+
+        CPPUNIT_ASSERT( can_access("http://thredds.ucar.edu/thredds/dodsC/data/nc/fnoc1.nc") );
+        CPPUNIT_ASSERT( !can_access("https://thredds.ucar.edu/thredds/dodsC/data/nc/fnoc1.nc") );
+
+        CPPUNIT_ASSERT( can_access("http://cloudydap.opendap.org/opendap/Arch-2/ebs/samples/3A-MO.GPM.GMI.GRID2014R1.20140601-S000000-E235959.06.V03A.h5") );
+
+
+
+
+
+
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( plistT );
+
+int main(int argc, char*argv[])
+{
+
+    GetOpt getopt(argc, argv, "dh");
+    char option_char;
+    while ((option_char = getopt()) != EOF)
+        switch (option_char) {
+        case 'd':
+            debug = 1;  // debug is a static global
+            break;
+        case 'h': {     // help - show test names
+            cerr << "Usage: plistT has the following tests:" << endl;
+            const std::vector<Test*> &tests = plistT::suite()->getTests();
+            unsigned int prefix_len = plistT::suite()->getName().append("::").length();
+            for (std::vector<Test*>::const_iterator i = tests.begin(), e = tests.end(); i != e; ++i) {
+                cerr << (*i)->getName().replace(0, prefix_len, "") << endl;
+            }
+            break;
+        }
+        default:
+            break;
+        }
+
+    CppUnit::TextTestRunner runner;
+    runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
+
+    bool wasSuccessful = true;
+    string test = "";
+    int i = getopt.optind;
+    if (i == argc) {
+        // run them all
+        wasSuccessful = runner.run("");
+    }
+    else {
+        while (i < argc) {
+            if (debug) cerr << "Running " << argv[i] << endl;
+            test = plistT::suite()->getName().append("::").append(argv[i]);
+            wasSuccessful = wasSuccessful && runner.run(test);
+        }
+    }
+
+    return wasSuccessful ? 0 : 1;
+}
+

--- a/dispatch/unit-tests/remote_access_test.ini
+++ b/dispatch/unit-tests/remote_access_test.ini
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------#
+# Gateway module specific parameters
+#-----------------------------------------------------------------------#
+# Gateway.Whitelist - provides a list of URL of the form
+#       protocol://host.domain:port
+# that are allowed to be passed through the gateway module. If none
+# specified, then an error will be thrown during BES initialization. One
+# URL per line, as in the example below.
+#
+# example:
+# Gateway.Whitelist=http://test.opendap.org/opendap
+# Gateway.Whitelist+=http://opendap.rpi.edu/opendap
+#
+Gateway.Whitelist=http://localhost
+Gateway.Whitelist+=http://test.opendap.org/opendap/
+Gateway.Whitelist+=http://cloudydap.opendap.org/opendap/
+Gateway.Whitelist+=http://thredds.ucar.edu/thredds/
+Gateway.Whitelist+=https://s3.amazonaws.com/somewhereovertherainbow/

--- a/dispatch/unit-tests/remote_access_test.ini
+++ b/dispatch/unit-tests/remote_access_test.ini
@@ -16,3 +16,6 @@ Gateway.Whitelist+=http://test.opendap.org/opendap/
 Gateway.Whitelist+=http://cloudydap.opendap.org/opendap/
 Gateway.Whitelist+=http://thredds.ucar.edu/thredds/
 Gateway.Whitelist+=https://s3.amazonaws.com/somewhereovertherainbow/
+
+BES.Catalog.Default=catalog
+BES.Catalog.catalog.RootDirectory=/usr/share/hyrax

--- a/dispatch/unit-tests/remote_access_test.ini
+++ b/dispatch/unit-tests/remote_access_test.ini
@@ -19,3 +19,6 @@ Gateway.Whitelist+=https://s3.amazonaws.com/somewhereovertherainbow/
 
 BES.Catalog.Default=catalog
 BES.Catalog.catalog.RootDirectory=/tmp
+# The TypeMatch is required, but since these tests don't actually use the value,
+# it can be anything that matches the form of '<thing>:<regex>;' jhrg 7/6/18
+BES.Catalog.catalog.TypeMatch=something:regex;

--- a/dispatch/unit-tests/remote_access_test.ini
+++ b/dispatch/unit-tests/remote_access_test.ini
@@ -18,4 +18,4 @@ Gateway.Whitelist+=http://thredds.ucar.edu/thredds/
 Gateway.Whitelist+=https://s3.amazonaws.com/somewhereovertherainbow/
 
 BES.Catalog.Default=catalog
-BES.Catalog.catalog.RootDirectory=/usr/share/hyrax
+BES.Catalog.catalog.RootDirectory=/tmp

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -29,16 +29,23 @@
 #include <curl/curl.h>
 #include <curl/multi.h>
 
+#include "BESDebug.h"
 #include "BESInternalError.h"
+#include "BESForbiddenError.h"
+#include "RemoteAccess.h"
 
 #include "CurlHandlePool.h"
 #include "Chunk.h"
 #include "DmrppRequestHandler.h"
 
+
+
+
 #define MAX_WAIT_MSECS 30*1000 /* Wait max. 30 seconds */
 
 using namespace dmrpp;
 using namespace std;
+using bes::RemoteAccess;
 
 dmrpp_easy_handle::dmrpp_easy_handle()
 {
@@ -203,6 +210,12 @@ CurlHandlePool::get_easy_handle(Chunk *chunk)
         // Once here, d_easy_handle holds a CURL* we can use.
         handle->d_in_use = true;
         handle->d_url = chunk->get_data_url();
+        if(!RemoteAccess::Is_Whitelisted(handle->d_url)){
+            string msg;
+            msg = "ERROR!! The chunk url " + handle->d_url + " does not match the white-list rule. ";
+            BESDEBUG("dmrpp",msg << endl);
+            throw BESForbiddenError(msg ,__FILE__,__LINE__);
+        }
         handle->d_chunk = chunk;
 
         CURLcode res = curl_easy_setopt(handle->d_handle, CURLOPT_URL, chunk->get_data_url().c_str());

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -210,12 +210,14 @@ CurlHandlePool::get_easy_handle(Chunk *chunk)
         // Once here, d_easy_handle holds a CURL* we can use.
         handle->d_in_use = true;
         handle->d_url = chunk->get_data_url();
+
+        // Here we check to make sure that the we are only going to
+        // access an approved location with this easy_handle
         if(!RemoteAccess::Is_Whitelisted(handle->d_url)){
-            string msg;
-            msg = "ERROR!! The chunk url " + handle->d_url + " does not match any white-list rule. ";
-            BESDEBUG("dmrpp",msg << endl);
+            string msg = "ERROR!! The chunk url " + handle->d_url + " does not match any white-list rule. ";
             throw BESForbiddenError(msg ,__FILE__,__LINE__);
         }
+
         handle->d_chunk = chunk;
 
         CURLcode res = curl_easy_setopt(handle->d_handle, CURLOPT_URL, chunk->get_data_url().c_str());

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -212,7 +212,7 @@ CurlHandlePool::get_easy_handle(Chunk *chunk)
         handle->d_url = chunk->get_data_url();
         if(!RemoteAccess::Is_Whitelisted(handle->d_url)){
             string msg;
-            msg = "ERROR!! The chunk url " + handle->d_url + " does not match the white-list rule. ";
+            msg = "ERROR!! The chunk url " + handle->d_url + " does not match any white-list rule. ";
             BESDEBUG("dmrpp",msg << endl);
             throw BESForbiddenError(msg ,__FILE__,__LINE__);
         }

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -38,9 +38,6 @@
 #include "Chunk.h"
 #include "DmrppRequestHandler.h"
 
-
-
-
 #define MAX_WAIT_MSECS 30*1000 /* Wait max. 30 seconds */
 
 using namespace dmrpp;

--- a/modules/dmrpp_module/tests/Makefile.am
+++ b/modules/dmrpp_module/tests/Makefile.am
@@ -30,8 +30,9 @@ $(builddir)/mds_for_tests:
 	cp -r $(top_srcdir)/modules/dmrpp_module/data/mds_for_tests $(builddir)/mds_for_tests
 	chmod -R a+w $(builddir)/mds_for_tests
 	(cd $(builddir)/mds_for_tests && \
+	 clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
 	 for d in *.in; \
-		do sed -e "s%[@]abs_top_srcdir[@]%${abs_top_srcdir}%" $$d > `basename $$d .in`; \
+		do sed -e "s%[@]abs_top_srcdir[@]%$${clean_abs_top_srcdir}%" $$d > `basename $$d .in`; \
 	 done)
 
 ############## Autotest follows #####################

--- a/modules/dmrpp_module/tests/bes_mds_tests.conf.in
+++ b/modules/dmrpp_module/tests/bes_mds_tests.conf.in
@@ -56,6 +56,3 @@ DAP.GlobalMetadataStore.ledger = @abs_top_builddir@/modules/dmrpp_module/tests/m
 DAP.Use.Dmrpp = yes
 # dmrpp is the default value
 # DAP.Dmrpp.Name = dmrpp
-
-# Pretty liberal... jhrg 7/6/18
-Gateway.Whitelist=file:

--- a/modules/dmrpp_module/tests/bes_mds_tests.conf.in
+++ b/modules/dmrpp_module/tests/bes_mds_tests.conf.in
@@ -56,3 +56,6 @@ DAP.GlobalMetadataStore.ledger = @abs_top_builddir@/modules/dmrpp_module/tests/m
 DAP.Use.Dmrpp = yes
 # dmrpp is the default value
 # DAP.Dmrpp.Name = dmrpp
+
+# Pretty liberal... jhrg 7/6/18
+Gateway.Whitelist=file:

--- a/modules/gateway_module/GatewayContainer.cc
+++ b/modules/gateway_module/GatewayContainer.cc
@@ -32,6 +32,7 @@
 #include <BESDebug.h>
 #include <BESUtil.h>
 #include <TheBESKeys.h>
+#include <RemoteAccess.h>
 
 #include "GatewayContainer.h"
 #include "GatewayUtils.h"
@@ -40,6 +41,7 @@
 
 using namespace std;
 using namespace gateway;
+using bes::RemoteAccess;
 
 /** @brief Creates an instances of GatewayContainer with symbolic name and real
  * name, which is the remote request.
@@ -64,17 +66,7 @@ GatewayContainer::GatewayContainer(const string &sym_name,
     url_parts.psswd = "";
     string use_real_name = BESUtil::url_create(url_parts);
 
-    vector<string>::const_iterator i = GatewayUtils::WhiteList.begin();
-    vector<string>::const_iterator e = GatewayUtils::WhiteList.end();
-    bool done = false;
-    for (; i != e && !done; i++) {
-        if ((*i).length() <= use_real_name.length()) {
-            if (use_real_name.substr(0, (*i).length()) == (*i)) {
-                done = true;
-            }
-        }
-    }
-    if (!done) {
+    if (!RemoteAccess::Is_Whitelisted(use_real_name)) {
         string err = (string) "The specified URL " + real_name
                 + " does not match any of the accessible services in"
                 + " the white list.";

--- a/modules/gateway_module/GatewayUtils.cc
+++ b/modules/gateway_module/GatewayUtils.cc
@@ -54,8 +54,10 @@
 using namespace libdap;
 using namespace gateway;
 
-vector<string> GatewayUtils::WhiteList;
-map<string, string> GatewayUtils::MimeList;
+#if 0
+std::vector<string> GatewayUtils::WhiteList;
+#endif
+std::map<string, string> GatewayUtils::MimeList;
 string GatewayUtils::ProxyProtocol;
 string GatewayUtils::ProxyHost;
 string GatewayUtils::ProxyUser;
@@ -71,6 +73,7 @@ string GatewayUtils::NoProxyRegex;
 // and keys, like the white list, the MimeTypes translation.
 void GatewayUtils::Initialize()
 {
+#if 0
     // Whitelist - list of domain that the gateway is allowed to
     // communicate with.
     bool found = false;
@@ -82,15 +85,16 @@ void GatewayUtils::Initialize()
         throw BESSyntaxUserError(err, __FILE__, __LINE__);
 
     }
+#endif
 
     // MimeTypes - translate from a mime type to a module name
-    found = false;
-    key = Gateway_MIMELIST;
-    vector<string> vals;
+    bool found = false;
+    std::string key = Gateway_MIMELIST;
+    std::vector<string> vals;
     TheBESKeys::TheKeys()->get_values(key, vals, found);
     if (found && vals.size()) {
-        vector<string>::iterator i = vals.begin();
-        vector<string>::iterator e = vals.end();
+        std::vector<string>::iterator i = vals.begin();
+        std::vector<string>::iterator e = vals.end();
         for (; i != e; i++) {
             size_t colon = (*i).find(":");
             if (colon == string::npos) {
@@ -389,3 +393,24 @@ void GatewayUtils::Get_type_from_url(const string &url, string &type)
         }
     }
 }
+
+#if 0
+bool GatewayUtils::Is_Whitelisted(const std::string &url){
+    bool whitelisted = false;
+    std::vector<std::string>::const_iterator i = WhiteList.begin();
+    std::vector<std::string>::const_iterator e = WhiteList.end();
+    for (; i != e && !whitelisted; i++) {
+        if ((*i).length() <= url.length()) {
+            if (url.substr(0, (*i).length()) == (*i)) {
+                whitelisted = true;
+            }
+        }
+    }
+    return whitelisted;
+}
+
+#endif
+
+
+
+


### PR DESCRIPTION
I moved the `gateway_module` whitelist functionality into the class `bes/dispatch/RemoteAccess` which allows both the `gateway_module` and the `dmrpp_module` to utilize it as a single source of truth for what can be accessed. `RemoteAccess` also handles the case where the presented URL is a `file://` URL by comparing the path to the default catalog's `root` and if there is a match the access is considered whitelisted.

I suspect that we will want to move the proxy server configuration management out of the gateway_module and into RemoteAccess as well. 