### PR TITLE
Ncml memory fixes

### DIFF
--- a/modules/ncml_module/AggregationElement.cc
+++ b/modules/ncml_module/AggregationElement.cc
@@ -864,7 +864,15 @@ void AggregationElement::processAggVarJoinNewForArray(DDS& aggDDS, const libdap:
     BESDEBUG("ncml",
         "Adding new ArrayAggregateOnOuterDimension with name=" << arrayTemplate.name() << " to aggregated dataset!" << endl);
 
+    // Replaced the copy version of DDS::add_var() with the nocopy version. This saves
+    // a deep copy, but more importantly, is a workaround for a memory issue in the
+    // ArrayAggregateOnOuterDimension or ArrayAggreagtionBase copy constructor, which
+    // triggers a memory error deep in libdap::Array::Array(const Array&).
+#if 0
     aggDDS.add_var(pAggArray.get());
+#endif
+
+    aggDDS.add_var_nocopy(pAggArray.release());
 }
 
 void AggregationElement::processAggVarJoinNewForGrid(DDS& aggDDS, const Grid& gridTemplate,
@@ -880,6 +888,7 @@ void AggregationElement::processAggVarJoinNewForGrid(DDS& aggDDS, const Grid& gr
     // OPTIMIZE change to add_var_no_copy when it exists.
     BESDEBUG("ncml",
         "Adding new GridAggregateOnOuterDimension with name=" << gridTemplate.name() << " to aggregated dataset!" << endl);
+
     aggDDS.add_var(pAggGrid.get());
 
     // processParentDatasetCompleteForJoinNew() will
@@ -909,7 +918,11 @@ void AggregationElement::processAggVarJoinExistingForArray(DDS& aggDDS, const li
     BESDEBUG("ncml",
         "Adding new ArrayJoinExistingAggregation with name=" << arrayTemplate.name() << " to aggregated dataset!" << endl);
 
+#if 0
     aggDDS.add_var(pAggArray.get());
+#endif
+
+    aggDDS.add_var_nocopy(pAggArray.release());
 }
 
 void AggregationElement::processAggVarJoinExistingForGrid(DDS& aggDDS, const Grid& gridTemplate,

--- a/modules/ncml_module/AggregationElement.cc
+++ b/modules/ncml_module/AggregationElement.cc
@@ -867,7 +867,8 @@ void AggregationElement::processAggVarJoinNewForArray(DDS& aggDDS, const libdap:
     // Replaced the copy version of DDS::add_var() with the nocopy version. This saves
     // a deep copy, but more importantly, is a workaround for a memory issue in the
     // ArrayAggregateOnOuterDimension or ArrayAggreagtionBase copy constructor, which
-    // triggers a memory error deep in libdap::Array::Array(const Array&).
+    // triggers a memory error deep in libdap::Array::Array(const Array&). See similar
+    // changes below. This and related changes fix HYRAX-803. jhrg 8/3/18
 #if 0
     aggDDS.add_var(pAggArray.get());
 #endif
@@ -889,7 +890,11 @@ void AggregationElement::processAggVarJoinNewForGrid(DDS& aggDDS, const Grid& gr
     BESDEBUG("ncml",
         "Adding new GridAggregateOnOuterDimension with name=" << gridTemplate.name() << " to aggregated dataset!" << endl);
 
+#if 0
     aggDDS.add_var(pAggGrid.get());
+#endif
+
+    aggDDS.add_var_nocopy(pAggGrid.release());
 
     // processParentDatasetCompleteForJoinNew() will
     // make sure the correct new map vector gets added
@@ -937,7 +942,12 @@ void AggregationElement::processAggVarJoinExistingForGrid(DDS& aggDDS, const Gri
 
     BESDEBUG("ncml",
         "Adding new GridJoinExistingAggregation with name=" << gridTemplate.name() << " to aggregated dataset!" << endl);
+
+#if 0
     aggDDS.add_var(pAggGrid.get()); // will copy
+#endif
+
+    aggDDS.add_var_nocopy(pAggGrid.release());
 }
 
 void AggregationElement::processParentDatasetCompleteForJoinNew()

--- a/modules/ncml_module/AggregationElement.cc
+++ b/modules/ncml_module/AggregationElement.cc
@@ -1252,7 +1252,10 @@ AggregationElement::processDeferredCoordinateVariable(libdap::BaseType* pBT, con
     // Add the new one, which will copy it (argh! we need to fix this in libdap!)
     // OPTIMIZE  use non copy add when available.
     BESDEBUG("ncml", "Adding CV: " << pNewArrCV->name() << endl);
+#if 0
     pDDS->add_var(pNewArrCV.get()); // use raw ptr for the copy.
+#endif
+    pDDS->add_var_nocopy(pNewArrCV.release());
 
     // Pull out the copy we just added and hand it back
     Array* pArrCV = static_cast<Array*>(AggregationUtil::getVariableNoRecurse(*pDDS, dim.name));
@@ -1284,11 +1287,11 @@ AggregationElement::createAndAddCoordinateVariableForNewDimension(DDS& dds, cons
         "AgregationElement::createCoordinateVariableForNewDimension() failed to create a coordinate variable!");
 
     // Add it to the DDS, which will make a copy
-    // (TODO change this when we add noncopy add_var to DDS)
+    // (change this when we add noncopy add_var to DDS)
     //
     // Fix. This will append the variable to the DDS; we need these CVs to be
     // prefixes to the Grids (so that old versions of the netCDF library will
-    // recognize them. jhrg 10/17/11
+    // recognize them). jhrg 10/17/11
     BESDEBUG("ncml2", "AggregationElement::createAndAddCoordinateVariableForNewDimension: " << pNewCV->name());
 #if 0
     dds.add_var(pNewCV.get());

--- a/modules/ncml_module/MyBaseTypeFactory.cc
+++ b/modules/ncml_module/MyBaseTypeFactory.cc
@@ -229,55 +229,55 @@ std::auto_ptr<libdap::Array> MyBaseTypeFactory::makeArrayTemplateVariable(const 
     if (type == "Array<Byte>") {
         pNew = new NCMLArray<dods_byte>(name);
         if (makeTemplateVar) {
-            pNew->add_var(makeVariable("Byte", name).get());
+            pNew->add_var_nocopy(makeVariable("Byte", name).release());
         }
     }
     else if (type == "Array<Int16>") {
         pNew = new NCMLArray<dods_int16>(name);
         if (makeTemplateVar) {
-            pNew->add_var(makeVariable("Int16", name).get());
+            pNew->add_var_nocopy(makeVariable("Int16", name).release());
         }
     }
     else if (type == "Array<UInt16>") {
         pNew = new NCMLArray<dods_uint16>(name);
         if (makeTemplateVar) {
-            pNew->add_var(makeVariable("UInt16", name).get());
+            pNew->add_var_nocopy(makeVariable("UInt16", name).release());
         }
     }
     else if (type == "Array<Int32>") {
         pNew = new NCMLArray<dods_int32>(name);
         if (makeTemplateVar) {
-            pNew->add_var(makeVariable("Int32", name).get());
+            pNew->add_var_nocopy(makeVariable("Int32", name).release());
         }
     }
     else if (type == "Array<UInt32>") {
         pNew = new NCMLArray<dods_uint32>(name);
         if (makeTemplateVar) {
-            pNew->add_var(makeVariable("UInt32", name).get());
+            pNew->add_var_nocopy(makeVariable("UInt32", name).release());
         }
     }
     else if (type == "Array<Float32>") {
         pNew = new NCMLArray<dods_float32>(name);
         if (makeTemplateVar) {
-            pNew->add_var(makeVariable("Float32", name).get());
+            pNew->add_var_nocopy(makeVariable("Float32", name).release());
         }
     }
     else if (type == "Array<Float64>") {
         pNew = new NCMLArray<dods_float64>(name);
         if (makeTemplateVar) {
-            pNew->add_var(makeVariable("Float64", name).get());
+            pNew->add_var_nocopy(makeVariable("Float64", name).release());
         }
     }
     else if (type == "Array<String>" || type == "Array<Str>") {
         pNew = new NCMLArray<std::string>(name);
         if (makeTemplateVar) {
-            pNew->add_var(makeVariable("String", name).get());
+            pNew->add_var_nocopy(makeVariable("String", name).release());
         }
     }
     else if (type == "Array<URL>" || type == "Array<Url>") {
         pNew = new NCMLArray<std::string>(name);
         if (makeTemplateVar) {
-            pNew->add_var(makeVariable("URL", name).get());
+            pNew->add_var_nocopy(makeVariable("URL", name).release());
         }
     }
     else {

--- a/modules/ncml_module/NCMLArray.h
+++ b/modules/ncml_module/NCMLArray.h
@@ -153,7 +153,8 @@ public:
 
         // OK, now that we have it, we need to copy the attribute table and the prototype variable
         set_attr_table(from.get_attr_table());
-        add_var(from.var()->ptr_duplicate()); // TODO This may leak memory
+        // switched to add_var_ncopy() to avoid memory leak. jhrg 8/3/18
+        add_var_nocopy(from.var()->ptr_duplicate()); // This may leak memory. Fixed.
 
         // add all the dimensions
         Array::Dim_iter endIt = from.dim_end();

--- a/modules/ncml_module/RenamedArrayWrapper.cc
+++ b/modules/ncml_module/RenamedArrayWrapper.cc
@@ -250,6 +250,11 @@ void RenamedArrayWrapper::add_var(BaseType *bt, Part part /* = nil */)
     _pArray->add_var(bt, part);
 }
 
+void RenamedArrayWrapper::add_var_nocopy(BaseType *bt, Part part /* = nil */)
+{
+    _pArray->add_var_nocopy(bt, part);
+}
+
 #if 0
 bool
 RenamedArrayWrapper::check_semantics(string &msg, bool all /* = false*/)

--- a/modules/ncml_module/RenamedArrayWrapper.h
+++ b/modules/ncml_module/RenamedArrayWrapper.h
@@ -121,6 +121,7 @@ public:
     virtual BaseType *var(const string &name = "", bool exact_match = true, btp_stack *s = 0);
     virtual BaseType *var(const string &name, btp_stack &s);
     virtual void add_var(BaseType *bt, Part part = nil);
+    virtual void add_var_nocopy(BaseType *bt, Part part = nil);
 
 #if 0
     virtual bool check_semantics(string &msg, bool all = false);

--- a/modules/ncml_module/VariableElement.cc
+++ b/modules/ncml_module/VariableElement.cc
@@ -488,7 +488,11 @@ void VariableElement::processNewArray(NCMLParser& p, const std::string& dapType)
 
     // Now make the template variable of the array entry type with the same name and add it
     auto_ptr<BaseType> pTemplateVar = MyBaseTypeFactory::makeVariable(dapType, _name);
+#if 0
     pNewVar->add_var(pTemplateVar.get());
+#endif
+
+    pNewVar->add_var_nocopy(pTemplateVar.release());
 
     // For each dimension in the shape, append it to make an N-D array...
     for (unsigned int i = 0; i < _shapeTokens.size(); ++i) {

--- a/modules/ncml_module/tests/testsuite.at
+++ b/modules/ncml_module/tests/testsuite.at
@@ -8,7 +8,7 @@ m4_define([datadir], [/data/ncml])
 m4_define([baselines_path],[${abs_srcdir}/baselines])
 m4_define([full_data_path],[${abs_srcdir}/../data/ncml])
 
-AT_INIT([ncml autotest testsuite (bes/modules/ncml_module/tests])
+AT_INIT([ncml autotest testsuite (bes/modules/ncml_module/tests)])
 
 dnl $1 == ncml_filename
 dnl $2 == {das | dds | dods | ddx }

--- a/modules/ncml_module/tests/testsuite.at
+++ b/modules/ncml_module/tests/testsuite.at
@@ -8,7 +8,7 @@ m4_define([datadir], [/data/ncml])
 m4_define([baselines_path],[${abs_srcdir}/baselines])
 m4_define([full_data_path],[${abs_srcdir}/../data/ncml])
 
-AT_INIT([ncml autotest testsuite])
+AT_INIT([ncml autotest testsuite (bes/modules/ncml_module/tests])
 
 dnl $1 == ncml_filename
 dnl $2 == {das | dds | dods | ddx }


### PR DESCRIPTION
Really a patch - There's a problem with the use of the Array copy constructor, but the NCML code doesn't need to copy the variables. Instead it can use the add_var_nocopy() methods of DDS and Array instead of the add_var() methods that trigger a copy. This patches the problem and is more efficient, but it means that the bug is still there waiting for just the right hack to baffle us once more...