### PR TITLE
Fixed a problem in showNode

### DIFF
--- a/dispatch/CatalogNode.cc
+++ b/dispatch/CatalogNode.cc
@@ -30,6 +30,7 @@
 #include <sstream>
 
 #include "BESIndent.h"
+#include "BESUtil.h"
 
 #include "BESCatalogList.h"
 #include "BESInfo.h"
@@ -77,8 +78,12 @@ CatalogNode::encode_node(BESInfo *info)
 {
     map<string, string> props;
 
-    props["name"] = get_name();
-    props["catalog"] = get_catalog_name();
+   if(get_catalog_name() != BESCatalogList::TheCatalogList()->default_catalog_name())
+        props["name"] = BESUtil::assemblePath(get_catalog_name(), get_name(), true);
+   else
+        props["name"] = get_name();
+
+    // props["catalog"] = get_catalog_name();
     props["lastModified"] = get_lmt();
     ostringstream oss;
     oss << get_item_count();

--- a/dispatch/ShowNodeResponseHandler.cc
+++ b/dispatch/ShowNodeResponseHandler.cc
@@ -139,6 +139,14 @@ void ShowNodeResponseHandler::execute(BESDataHandlerInterface &dhi)
     }
     //---------------------------------------------------------------
 
+    /*
+    if(catalog != datCatalogList->default_catalog()){
+        string name = BESUtil::assemblePath(catalog->get_catalog_name(), node->get_name(), true);
+        node->set_name(name);
+    }
+*/
+
+
     BESInfo *info = BESInfoList::TheList()->build_info();
 
     // Transfer the catalog's node info to the BESInfo object

--- a/dispatch/ShowNodeResponseHandler.cc
+++ b/dispatch/ShowNodeResponseHandler.cc
@@ -139,14 +139,6 @@ void ShowNodeResponseHandler::execute(BESDataHandlerInterface &dhi)
     }
     //---------------------------------------------------------------
 
-    /*
-    if(catalog != datCatalogList->default_catalog()){
-        string name = BESUtil::assemblePath(catalog->get_catalog_name(), node->get_name(), true);
-        node->set_name(name);
-    }
-*/
-
-
     BESInfo *info = BESInfoList::TheList()->build_info();
 
     // Transfer the catalog's node info to the BESInfo object

--- a/dispatch/unit-tests/catalog_test_baselines/show_node_test_1.txt
+++ b/dispatch/unit-tests/catalog_test_baselines/show_node_test_1.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <response xmlns="http://xml.opendap.org/ns/bes/1.0#">
     <showNode>
-        <node catalog="default" count="0" lastModified="07-07-07T07:07:07" name="/test"/>
+        <node count="0" lastModified="07-07-07T07:07:07" name="/test"/>
     </showNode>
 </response>

--- a/dispatch/unit-tests/catalog_test_baselines/show_node_test_2.txt
+++ b/dispatch/unit-tests/catalog_test_baselines/show_node_test_2.txt
@@ -1,5 +1,4 @@
 node
-    catalog: default
     count: 0
     lastModified: 07-07-07T07:07:07
     name: /test

--- a/xmlcommand/tests/bescmd/show_node_1.bescmd.baseline
+++ b/xmlcommand/tests/bescmd/show_node_1.bescmd.baseline
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <response reqID="[thread:http-nio-8080-exec-4-42][bes_client:/-2]" xmlns="http://xml.opendap.org/ns/bes/1.0#">
     <showNode>
-        <node catalog="default" count="7" lastModified="removed date-time" name="/">
+        <node count="7" lastModified="removed date-time" name="/">
             <item lastModified="removed date-time" name="dap2" type="node"/>
             <item lastModified="removed date-time" name="dap4" type="node"/>
             <item lastModified="removed date-time" name="second" type="node"/>

--- a/xmlcommand/tests/bescmd/show_node_2.bescmd.baseline
+++ b/xmlcommand/tests/bescmd/show_node_2.bescmd.baseline
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <response reqID="[thread:http-nio-8080-exec-4-42][bes_client:/-2]" xmlns="http://xml.opendap.org/ns/bes/1.0#">
     <showNode>
-        <node catalog="default" count="11" lastModified="removed date-time" name="/dap2">
+        <node count="11" lastModified="removed date-time" name="/dap2">
             <item isData="true" lastModified="removed date-time" name="coads.das" size="1644" type="leaf"/>
             <item isData="true" lastModified="removed date-time" name="coads.data" size="3122830" type="leaf"/>
             <item isData="true" lastModified="removed date-time" name="fnoc1.das" size="927" type="leaf"/>

--- a/xmlcommand/tests/bescmd/show_node_3.bescmd.baseline
+++ b/xmlcommand/tests/bescmd/show_node_3.bescmd.baseline
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <response reqID="[thread:http-nio-8080-exec-4-42][bes_client:/-2]" xmlns="http://xml.opendap.org/ns/bes/1.0#">
     <showNode>
-        <node catalog="default" count="3" lastModified="removed date-time" name="/dap4/data-responses">
+        <node count="3" lastModified="removed date-time" name="/dap4/data-responses">
             <item isData="false" lastModified="removed date-time" name="README" size="105" type="leaf"/>
             <item isData="true" lastModified="removed date-time" name="one_int.dap" size="242" type="leaf"/>
             <item isData="true" lastModified="removed date-time" name="zero_length_array.dap" size="2606" type="leaf"/>

--- a/xmlcommand/tests/bescmd/show_node_4.bescmd.baseline
+++ b/xmlcommand/tests/bescmd/show_node_4.bescmd.baseline
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <response reqID="[thread:http-nio-8080-exec-4-42][bes_client:/-2]" xmlns="http://xml.opendap.org/ns/bes/1.0#">
     <showNode>
-        <node catalog="second" count="3" lastModified="removed date-time" name="/">
+        <node count="3" lastModified="removed date-time" name="/second">
             <item lastModified="removed date-time" name="dap4" type="node"/>
             <item isData="false" lastModified="removed date-time" name="README" size="127" type="leaf"/>
             <item isData="true" lastModified="removed date-time" name="fnoc1.data" size="46155" type="leaf"/>

--- a/xmlcommand/tests/bescmd/show_node_5.bescmd.baseline
+++ b/xmlcommand/tests/bescmd/show_node_5.bescmd.baseline
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <response reqID="[thread:http-nio-8080-exec-4-42][bes_client:/-2]" xmlns="http://xml.opendap.org/ns/bes/1.0#">
     <showNode>
-        <node catalog="second" count="2" lastModified="removed date-time" name="/dap4">
+        <node count="2" lastModified="removed date-time" name="/second/dap4">
             <item isData="false" lastModified="removed date-time" name="Readme.md" size="145" type="leaf"/>
             <item isData="true" lastModified="removed date-time" name="one_int.dap" size="242" type="leaf"/>
         </node>


### PR DESCRIPTION
 In which the catalog name, which prefixes the path for catalogs other than the default catalog,
was being dropped from the returned node name.

Additionally, the deprecated _catalog_ attribute was still being included in the returned node.

These issues have been corrected and the test baselines adjusted to reflect the changes.