### PR TITLE
Changed how errors are processed. Now uses the Curl Error buffer.

### DIFF
--- a/modules/dmrpp_module/CurlHandlePool.h
+++ b/modules/dmrpp_module/CurlHandlePool.h
@@ -62,6 +62,7 @@ class dmrpp_easy_handle {
     bool d_in_use;      ///< Is this easy_handle in use?
     std::string d_url;  ///< The libcurl handle reads from this URL.
     Chunk *d_chunk;     ///< This easy_handle reads the data for \arg chunk.
+    char d_errbuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
     CURL *d_handle;     ///< The libcurl handle object.
 
     friend class CurlHandlePool;


### PR DESCRIPTION
This is supposed to produce more verbose error messages.