### PR TITLE
Unlinking cache files when retrival from remote fails.

### DIFF
--- a/modules/cmr_module/curl_utils.cc
+++ b/modules/cmr_module/curl_utils.cc
@@ -53,7 +53,7 @@ const char *http_client_errors[CLIENT_ERR_MAX - CLIENT_ERR_MIN +1] =
         "Payment Required.",
         "Forbidden: Contact the server administrator.",
         "Not Found: The data source or server could not be found.\n"
-        "Often this means that the OPeNDAP server is missing or needs attention;\n"
+        "Often this means that the OPeNDAP server is missing or needs attention.\n"
         "Please contact the server administrator.",
         "Method Not Allowed.",
         "Not Acceptable.",

--- a/modules/gateway_module/RemoteHttpResource.cc
+++ b/modules/gateway_module/RemoteHttpResource.cc
@@ -172,7 +172,14 @@ void RemoteHttpResource::retrieveResource()
         if (cache->create_and_lock(d_resourceCacheFileName, d_fd)) {
 
             // Write the remote resource to the cache file.
-            writeResourceToFile(d_fd);
+            try {
+                writeResourceToFile(d_fd);
+            }
+            catch(...){
+                // If things went south then we need to dump the file because we'll end up with an empty/bogus file clogging the cache
+                unlink(d_resourceCacheFileName.c_str());
+                throw;
+            }
 
             // #########################################################################################################
             // I think right here is where I would be able to cache the data type/response headers. While I have

--- a/modules/gateway_module/curl_utils.cc
+++ b/modules/gateway_module/curl_utils.cc
@@ -51,7 +51,7 @@ const char *http_client_errors[CLIENT_ERR_MAX - CLIENT_ERR_MIN +1] =
         "Payment Required.",
         "Forbidden: Contact the server administrator.",
         "Not Found: The data source or server could not be found.\n"
-            "Often this means that the OPeNDAP server is missing or needs attention;\n"
+            "Often this means that the OPeNDAP server is missing or needs attention.\n"
             "Please contact the server administrator.",
         "Method Not Allowed.",
         "Not Acceptable.",

--- a/modules/httpd_catalog_module/curl_utils.cc
+++ b/modules/httpd_catalog_module/curl_utils.cc
@@ -51,12 +51,28 @@ int curl_trace = 0;
 
 #define CLIENT_ERR_MIN 400
 #define CLIENT_ERR_MAX 417
-const char *http_client_errors[CLIENT_ERR_MAX - CLIENT_ERR_MIN + 1] = { "Bad Request:", "Unauthorized: Contact the server administrator.",
-    "Payment Required.", "Forbidden: Contact the server administrator.", "Not Found: The data source or server could not be found.\n"
-        "Often this means that the OPeNDAP server is missing or needs attention;\n"
-        "Please contact the server administrator.", "Method Not Allowed.", "Not Acceptable.", "Proxy Authentication Required.", "Request Time-out.",
-    "Conflict.", "Gone:.", "Length Required.", "Precondition Failed.", "Request Entity Too Large.", "Request URI Too Large.",
-    "Unsupported Media Type.", "Requested Range Not Satisfiable.", "Expectation Failed." };
+const char *http_client_errors[CLIENT_ERR_MAX - CLIENT_ERR_MIN + 1] = {
+    "Bad Request:",
+    "Unauthorized: Contact the server administrator.",
+    "Payment Required.",
+    "Forbidden: Contact the server administrator.",
+    "Not Found: The data source or server could not be found.\n"
+        "Often this means that the OPeNDAP server is missing or needs attention.\n"
+        "Please contact the server administrator.",
+    "Method Not Allowed.",
+    "Not Acceptable.",
+    "Proxy Authentication Required.",
+    "Request Time-out.",
+    "Conflict.",
+    "Gone.",
+    "Length Required.",
+    "Precondition Failed.",
+    "Request Entity Too Large.",
+    "Request URI Too Large.",
+    "Unsupported Media Type.",
+    "Requested Range Not Satisfiable.",
+    "Expectation Failed."
+};
 
 #define SERVER_ERR_MIN 500
 #define SERVER_ERR_MAX 505


### PR DESCRIPTION
 This patch should remove cache files associated with failed attempts to retrieve remote resources. This affects *cmr_module*, *gateway_module*, and *httpd_catalog_module*.