### PR TITLE
Travis rpm use awscli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ jobs:
     - docker run --volume $prefix/rpmbuild:/root/rpmbuild --volume $TRAVIS_BUILD_DIR:/root/travis
                  --env OS=centos6 --env DIST=el6 --env LIBDAP_RPM_VERSION=$LIBDAP_RPM_VERSION
                  --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-                 opendap/centos6_hyrax_builder:1.2 /root/travis/build-rpm.sh
+                 opendap/centos6_hyrax_builder:1.3 /root/travis/build-rpm.sh
 
   - stage: package
     script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ jobs:
     - mkdir -p $prefix/rpmbuild
     - docker run --volume $prefix/rpmbuild:/root/rpmbuild --volume $TRAVIS_BUILD_DIR:/root/travis
                  --env OS=centos6 --env DIST=el6 --env LIBDAP_RPM_VERSION=$LIBDAP_RPM_VERSION
-                 opendap/centos6_hyrax_builder:1.1 /root/travis/build-rpm.sh
+                 opendap/centos6_hyrax_builder:1.2 /root/travis/build-rpm.sh
 
   - stage: package
     script: 
@@ -116,7 +116,7 @@ jobs:
     - mkdir -p $prefix/rpmbuild
     - docker run --volume $prefix/rpmbuild:/root/rpmbuild --volume $TRAVIS_BUILD_DIR:/root/travis
                  --env OS=centos7 --env DIST=el7 --env LIBDAP_RPM_VERSION=$LIBDAP_RPM_VERSION
-                 opendap/centos7_hyrax_builder:1.1 /root/travis/build-rpm.sh
+                 opendap/centos7_hyrax_builder:1.2 /root/travis/build-rpm.sh
     
 after_script:
 - ./upload-test-results.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,7 @@ jobs:
     - mkdir -p $prefix/rpmbuild
     - docker run --volume $prefix/rpmbuild:/root/rpmbuild --volume $TRAVIS_BUILD_DIR:/root/travis
                  --env OS=centos6 --env DIST=el6 --env LIBDAP_RPM_VERSION=$LIBDAP_RPM_VERSION
+                 --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
                  opendap/centos6_hyrax_builder:1.2 /root/travis/build-rpm.sh
 
   - stage: package
@@ -116,6 +117,7 @@ jobs:
     - mkdir -p $prefix/rpmbuild
     - docker run --volume $prefix/rpmbuild:/root/rpmbuild --volume $TRAVIS_BUILD_DIR:/root/travis
                  --env OS=centos7 --env DIST=el7 --env LIBDAP_RPM_VERSION=$LIBDAP_RPM_VERSION
+                 --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
                  opendap/centos7_hyrax_builder:1.2 /root/travis/build-rpm.sh
     
 after_script:

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -33,8 +33,6 @@ then
     exit 1
 fi
 
-pip install --user awscli
-
 # Get the pre-built dependencies (all static libraries). $OS is 'centos6' or 'centos7'
 # aws s3 cp s3://opendap.travis.build/
 (cd /tmp && aws s3 cp s3://opendap.travis.build/hyrax-dependencies-$OS-static.tar.gz)

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -33,8 +33,11 @@ then
     exit 1
 fi
 
+pip install --user awscli
+
 # Get the pre-built dependencies (all static libraries). $OS is 'centos6' or 'centos7'
-(cd /tmp && curl -s -O https://s3.amazonaws.com/opendap.travis.build/hyrax-dependencies-$OS-static.tar.gz)
+# aws s3 cp s3://opendap.travis.build/
+(cd /tmp && aws s3 cp s3://opendap.travis.build/hyrax-dependencies-$OS-static.tar.gz)
 
 # This dumps the dependencies in $HOME/install/deps/{lib,bin,...}
 tar -xzvf /tmp/hyrax-dependencies-$OS-static.tar.gz
@@ -42,8 +45,8 @@ tar -xzvf /tmp/hyrax-dependencies-$OS-static.tar.gz
 # Then get the libdap RPMs packages
 # libdap-3.20.0-1.el6.x86_64.rpm libdap-devel-3.20.0-1.el6.x86_64.rpm
 # $DIST is 'el6' or 'el7'; $LIBDAP_RPM_VERSION is 3.20.0-1 (set by Travis)
-(cd /tmp && curl -s -O https://s3.amazonaws.com/opendap.travis.build/libdap-$LIBDAP_RPM_VERSION.$DIST.x86_64.rpm)
-(cd /tmp && curl -s -O https://s3.amazonaws.com/opendap.travis.build/libdap-devel-$LIBDAP_RPM_VERSION.$DIST.x86_64.rpm)
+(cd /tmp && aws s3 cp s3://opendap.travis.build/libdap-$LIBDAP_RPM_VERSION.$DIST.x86_64.rpm)
+(cd /tmp && aws s3 cp s3://opendap.travis.build/libdap-devel-$LIBDAP_RPM_VERSION.$DIST.x86_64.rpm)
 
 yum install -y /tmp/*.rpm
 

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -33,6 +33,11 @@ then
     exit 1
 fi
 
+if ! which aws && test -x /root/.local/bin/aws
+then
+    export PATH=$PATH:/root/.local/bin
+fi
+
 # Get the pre-built dependencies (all static libraries). $OS is 'centos6' or 'centos7'
 # aws s3 cp s3://opendap.travis.build/
 aws s3 cp s3://opendap.travis.build/hyrax-dependencies-$OS-static.tar.gz /tmp/

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -35,7 +35,7 @@ fi
 
 # Get the pre-built dependencies (all static libraries). $OS is 'centos6' or 'centos7'
 # aws s3 cp s3://opendap.travis.build/
-(cd /tmp && aws s3 cp s3://opendap.travis.build/hyrax-dependencies-$OS-static.tar.gz)
+aws s3 cp s3://opendap.travis.build/hyrax-dependencies-$OS-static.tar.gz /tmp/
 
 # This dumps the dependencies in $HOME/install/deps/{lib,bin,...}
 tar -xzvf /tmp/hyrax-dependencies-$OS-static.tar.gz
@@ -43,8 +43,8 @@ tar -xzvf /tmp/hyrax-dependencies-$OS-static.tar.gz
 # Then get the libdap RPMs packages
 # libdap-3.20.0-1.el6.x86_64.rpm libdap-devel-3.20.0-1.el6.x86_64.rpm
 # $DIST is 'el6' or 'el7'; $LIBDAP_RPM_VERSION is 3.20.0-1 (set by Travis)
-(cd /tmp && aws s3 cp s3://opendap.travis.build/libdap-$LIBDAP_RPM_VERSION.$DIST.x86_64.rpm)
-(cd /tmp && aws s3 cp s3://opendap.travis.build/libdap-devel-$LIBDAP_RPM_VERSION.$DIST.x86_64.rpm)
+aws s3 cp s3://opendap.travis.build/libdap-$LIBDAP_RPM_VERSION.$DIST.x86_64.rpm /tmp/
+aws s3 cp s3://opendap.travis.build/libdap-devel-$LIBDAP_RPM_VERSION.$DIST.x86_64.rpm /tmp/
 
 yum install -y /tmp/*.rpm
 


### PR DESCRIPTION
I modified the 'regular' travis build to use the AWS cli tools in favor of curl. Now I've modified the RPM builds in the 'package' section of the build to use them, too. This required a new set of docker containers.