### PR TITLE
Response limit fix

### DIFF
--- a/dap/BESDapResponseBuilder.cc
+++ b/dap/BESDapResponseBuilder.cc
@@ -461,6 +461,23 @@ void BESDapResponseBuilder::split_ce(ConstraintEvaluator &eval, const string &ex
     BESDEBUG("dap", "BESDapResponseBuilder::split_ce() - END" << endl);
 }
 
+/**
+ * @brief convenience function for the response limit test.
+ * The DDS stores the response size limit in Bytes even though the context
+ * param uses KB. The DMR uses KB throughout.
+ * @param dds
+ */
+static void
+throw_if_dap2_response_too_big(DDS *dds)
+{
+    if (dds->get_response_limit() != 0 && ((dds->get_request_size(true)) > dds->get_response_limit())) {
+        string msg = "The Request for " + long_to_string(dds->get_request_size(true) / 1024)
+            + "KB is too large; requests on this server are limited to "
+            + long_to_string(dds->get_response_limit() /1024) + "KB.";
+        throw Error(msg);
+    }
+}
+
 /** This function formats and prints an ASCII representation of a
  DAS on stdout.  This has the effect of sending the DAS object
  back to the client program.
@@ -1024,12 +1041,15 @@ BESDapResponseBuilder::intern_dap2_data(BESResponseObject *obj, BESDataHandlerIn
 
     dds->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
-    if (dds->get_response_limit() != 0 && ((dds->get_request_size(true) / 1024) > dds->get_response_limit())) {
+    throw_if_dap2_response_too_big(dds);
+#if 0
+    if (dds->get_response_limit() != 0 && ((dds->get_request_size(true)) > dds->get_response_limit())) {
         string msg = "The Request for " + long_to_string(dds->get_request_size(true) / 1024)
-            + "KB is too large; requests for this user are limited to "
-            + long_to_string(dds->get_response_limit()) + "KB.";
+        + "KB is too large; requests for this user are limited to "
+        + long_to_string(dds->get_response_limit() /1024) + "KB.";
         throw Error(msg);
     }
+#endif
 
     // Iterate through the variables in the DataDDS and read
     // in the data if the variable has the send flag set.
@@ -1102,12 +1122,16 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
 
         (*dds)->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
-        if ((*dds)->get_response_limit() != 0 && (((*dds)->get_request_size(true) / 1024) > (*dds)->get_response_limit())) {
+        throw_if_dap2_response_too_big(*dds);
+
+#if 0
+        if ((*dds)->get_response_limit() != 0 && (((*dds)->get_request_size(true)) > (*dds)->get_response_limit())) {
             string msg = "The Request for " + long_to_string((*dds)->get_request_size(true) / 1024)
-                + "KB is too large; requests for this user are limited to "
-                + long_to_string((*dds)->get_response_limit()) + "KB.";
+            + "KB is too large; requests for this user are limited to "
+            + long_to_string((*dds)->get_response_limit() / 1024) + "KB.";
             throw Error(msg);
         }
+#endif
 
         if (with_mime_headers)
             set_mime_binary(data_stream, dods_data, x_plain, last_modified_time(d_dataset), (*dds)->get_dap_version());
@@ -1129,12 +1153,16 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
 
         (*dds)->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
-        if ((*dds)->get_response_limit() != 0 && (((*dds)->get_request_size(true) / 1024) > (*dds)->get_response_limit())) {
+        throw_if_dap2_response_too_big(*dds);
+
+#if 0
+        if ((*dds)->get_response_limit() != 0 && (((*dds)->get_request_size(true)) > (*dds)->get_response_limit())) {
             string msg = "The Request for " + long_to_string((*dds)->get_request_size(true) /1024)
-                + "KB is too large; requests for this user are limited to "
-                + long_to_string((*dds)->get_response_limit()) + "KB.";
+            + "KB is too large; requests for this user are limited to "
+            + long_to_string((*dds)->get_response_limit() / 1024) + "KB.";
             throw Error(msg);
         }
+#endif
 
         if (with_mime_headers)
             set_mime_binary(data_stream, dods_data, x_plain, last_modified_time(d_dataset), (*dds)->get_dap_version());

--- a/dap/BESDapResponseBuilder.cc
+++ b/dap/BESDapResponseBuilder.cc
@@ -1024,10 +1024,10 @@ BESDapResponseBuilder::intern_dap2_data(BESResponseObject *obj, BESDataHandlerIn
 
     dds->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
-    if (dds->get_response_limit() != 0 && dds->get_request_size(true) > dds->get_response_limit()) {
+    if (dds->get_response_limit() != 0 && ((dds->get_request_size(true) / 1024) > dds->get_response_limit())) {
         string msg = "The Request for " + long_to_string(dds->get_request_size(true) / 1024)
             + "KB is too large; requests for this user are limited to "
-            + long_to_string(dds->get_response_limit() / 1024) + "KB.";
+            + long_to_string(dds->get_response_limit()) + "KB.";
         throw Error(msg);
     }
 
@@ -1102,10 +1102,10 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
 
         (*dds)->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
-        if ((*dds)->get_response_limit() != 0 && (*dds)->get_request_size(true) > (*dds)->get_response_limit()) {
+        if ((*dds)->get_response_limit() != 0 && (((*dds)->get_request_size(true) / 1024) > (*dds)->get_response_limit())) {
             string msg = "The Request for " + long_to_string((*dds)->get_request_size(true) / 1024)
                 + "KB is too large; requests for this user are limited to "
-                + long_to_string((*dds)->get_response_limit() / 1024) + "KB.";
+                + long_to_string((*dds)->get_response_limit()) + "KB.";
             throw Error(msg);
         }
 
@@ -1129,10 +1129,10 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
 
         (*dds)->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
-        if ((*dds)->get_response_limit() != 0 && (*dds)->get_request_size(true) > (*dds)->get_response_limit()) {
-            string msg = "The Request for " + long_to_string((*dds)->get_request_size(true) / 1024)
+        if ((*dds)->get_response_limit() != 0 && (((*dds)->get_request_size(true) / 1024) > (*dds)->get_response_limit())) {
+            string msg = "The Request for " + long_to_string((*dds)->get_request_size(true) /1024)
                 + "KB is too large; requests for this user are limited to "
-                + long_to_string((*dds)->get_response_limit() / 1024) + "KB.";
+                + long_to_string((*dds)->get_response_limit()) + "KB.";
             throw Error(msg);
         }
 
@@ -1282,10 +1282,10 @@ void BESDapResponseBuilder::send_dap4_data_using_ce(ostream &out, DMR &dmr, bool
         dmr.root()->set_send_p(true);
     }
 
-    if (dmr.response_limit() != 0 && dmr.request_size(true) > dmr.response_limit()) {
-        string msg = "The Request for " + long_to_string(dmr.request_size(true) / 1024)
-            + "MB is too large; requests for this user are limited to " + long_to_string(dmr.response_limit() / 1024)
-            + "MB.";
+    if (dmr.response_limit() != 0 && (dmr.request_size(true) > dmr.response_limit())) {
+        string msg = "The Request for " + long_to_string(dmr.request_size(true))
+            + "KB is too large; requests for this user are limited to " + long_to_string(dmr.response_limit())
+            + "KB.";
         throw Error(msg);
     }
 

--- a/dap/BESDapResponseBuilder.cc
+++ b/dap/BESDapResponseBuilder.cc
@@ -1312,7 +1312,7 @@ void BESDapResponseBuilder::send_dap4_data_using_ce(ostream &out, DMR &dmr, bool
 
     if (dmr.response_limit() != 0 && (dmr.request_size(true) > dmr.response_limit())) {
         string msg = "The Request for " + long_to_string(dmr.request_size(true))
-            + "KB is too large; requests for this user are limited to " + long_to_string(dmr.response_limit())
+            + "KB is too large; requests for this server are limited to " + long_to_string(dmr.response_limit())
             + "KB.";
         throw Error(msg);
     }

--- a/dap/BESDapResponseBuilder.cc
+++ b/dap/BESDapResponseBuilder.cc
@@ -1042,14 +1042,6 @@ BESDapResponseBuilder::intern_dap2_data(BESResponseObject *obj, BESDataHandlerIn
     dds->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
     throw_if_dap2_response_too_big(dds);
-#if 0
-    if (dds->get_response_limit() != 0 && ((dds->get_request_size(true)) > dds->get_response_limit())) {
-        string msg = "The Request for " + long_to_string(dds->get_request_size(true) / 1024)
-        + "KB is too large; requests for this user are limited to "
-        + long_to_string(dds->get_response_limit() /1024) + "KB.";
-        throw Error(msg);
-    }
-#endif
 
     // Iterate through the variables in the DataDDS and read
     // in the data if the variable has the send flag set.
@@ -1124,15 +1116,6 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
 
         throw_if_dap2_response_too_big(*dds);
 
-#if 0
-        if ((*dds)->get_response_limit() != 0 && (((*dds)->get_request_size(true)) > (*dds)->get_response_limit())) {
-            string msg = "The Request for " + long_to_string((*dds)->get_request_size(true) / 1024)
-            + "KB is too large; requests for this user are limited to "
-            + long_to_string((*dds)->get_response_limit() / 1024) + "KB.";
-            throw Error(msg);
-        }
-#endif
-
         if (with_mime_headers)
             set_mime_binary(data_stream, dods_data, x_plain, last_modified_time(d_dataset), (*dds)->get_dap_version());
 
@@ -1154,15 +1137,6 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
         (*dds)->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
         throw_if_dap2_response_too_big(*dds);
-
-#if 0
-        if ((*dds)->get_response_limit() != 0 && (((*dds)->get_request_size(true)) > (*dds)->get_response_limit())) {
-            string msg = "The Request for " + long_to_string((*dds)->get_request_size(true) /1024)
-            + "KB is too large; requests for this user are limited to "
-            + long_to_string((*dds)->get_response_limit() / 1024) + "KB.";
-            throw Error(msg);
-        }
-#endif
 
         if (with_mime_headers)
             set_mime_binary(data_stream, dods_data, x_plain, last_modified_time(d_dataset), (*dds)->get_dap_version());

--- a/dap/tests/bes.conf.in
+++ b/dap/tests/bes.conf.in
@@ -8,11 +8,12 @@ BES.Group=group_name
 BES.LogName=./bes.log
 BES.LogVerbose=no
 
-BES.modules=dap,cmd,dapreader
+BES.modules=dap,cmd,dapreader,ascii
 
 BES.module.dap=@abs_top_builddir@/dap/.libs/libdap_module.so
 BES.module.cmd=@abs_top_builddir@/xmlcommand/.libs/libdap_xml_module.so
 BES.module.dapreader=@abs_top_builddir@/dapreader/.libs/libdapreader_module.so
+BES.module.ascii=@abs_top_builddir@/modules/asciival/.libs/libascii_module.so
 
 BES.Catalog.catalog.RootDirectory=@abs_top_srcdir@/dap
 BES.Data.RootDirectory=/dev/null

--- a/dap/tests/bescmd/req_limit_ascii2.bescmd
+++ b/dap/tests/bescmd/req_limit_ascii2.bescmd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bes:request xmlns:bes="http://xml.opendap.org/ns/bes/1.0#" reqID="[thread:http-nio-8080-exec-9-36][bes_client:/-0]">
+  <bes:setContext name="bes_timeout">3000</bes:setContext>
+  <bes:setContext name="xdap_accept">2.0</bes:setContext>
+  <bes:setContext name="dap_explicit_containers">no</bes:setContext>
+  <bes:setContext name="errors">xml</bes:setContext>
+  <bes:setContext name="max_response_size">10</bes:setContext>
+  <bes:setContainer name="c">/data/coads.dods</bes:setContainer>
+  <bes:define name="d" space="default">
+    <bes:container name="c">
+      <bes:constraint>SST</bes:constraint>
+    </bes:container>
+  </bes:define>
+  <bes:get type="dods" definition="d" returnAs="ascii"/>
+</bes:request>

--- a/dap/tests/bescmd/req_limit_ascii2_2.bescmd
+++ b/dap/tests/bescmd/req_limit_ascii2_2.bescmd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bes:request xmlns:bes="http://xml.opendap.org/ns/bes/1.0#" reqID="[thread:http-nio-8080-exec-9-36][bes_client:/-0]">
+  <bes:setContext name="bes_timeout">3000</bes:setContext>
+  <bes:setContext name="xdap_accept">2.0</bes:setContext>
+  <bes:setContext name="dap_explicit_containers">no</bes:setContext>
+  <bes:setContext name="errors">xml</bes:setContext>
+  <bes:setContext name="max_response_size">1000</bes:setContext>
+  <bes:setContainer name="c">/data/coads.dods</bes:setContainer>
+  <bes:define name="d" space="default">
+    <bes:container name="c">
+      <bes:constraint>SST</bes:constraint>
+    </bes:container>
+  </bes:define>
+  <bes:get type="dods" definition="d" returnAs="ascii"/>
+</bes:request>

--- a/dap/tests/bescmd/req_limit_ascii4.bescmd
+++ b/dap/tests/bescmd/req_limit_ascii4.bescmd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bes:request xmlns:bes="http://xml.opendap.org/ns/bes/1.0#" reqID="[thread:http-nio-8080-exec-9-36][bes_client:/-0]">
+  <bes:setContext name="bes_timeout">3000</bes:setContext>
+  <bes:setContext name="xdap_accept">2.0</bes:setContext>
+  <bes:setContext name="dap_explicit_containers">no</bes:setContext>
+  <bes:setContext name="errors">xml</bes:setContext>
+  <bes:setContext name="max_response_size">10</bes:setContext>
+  <bes:setContainer name="c">/data/coads.dods</bes:setContainer>
+  <bes:define name="d" space="default">
+    <bes:container name="c">
+      <bes:dap4constraint>SST</bes:dap4constraint>
+    </bes:container>
+  </bes:define>
+  <bes:get type="dap" definition="d" returnAs="ascii"/>
+</bes:request>

--- a/dap/tests/bescmd/req_limit_ascii4_2.bescmd
+++ b/dap/tests/bescmd/req_limit_ascii4_2.bescmd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bes:request xmlns:bes="http://xml.opendap.org/ns/bes/1.0#" reqID="[thread:http-nio-8080-exec-9-36][bes_client:/-0]">
+  <bes:setContext name="bes_timeout">3000</bes:setContext>
+  <bes:setContext name="xdap_accept">2.0</bes:setContext>
+  <bes:setContext name="dap_explicit_containers">no</bes:setContext>
+  <bes:setContext name="errors">xml</bes:setContext>
+  <bes:setContext name="max_response_size">1000</bes:setContext>
+  <bes:setContainer name="c">/data/coads.dods</bes:setContainer>
+  <bes:define name="d" space="default">
+    <bes:container name="c">
+      <bes:dap4constraint>SST</bes:dap4constraint>
+    </bes:container>
+  </bes:define>
+  <bes:get type="dap" definition="d" returnAs="ascii"/>
+</bes:request>

--- a/dap/tests/bescmd/req_limit_dap.bescmd
+++ b/dap/tests/bescmd/req_limit_dap.bescmd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bes:request xmlns:bes="http://xml.opendap.org/ns/bes/1.0#" reqID="[thread:http-nio-8080-exec-9-36][bes_client:/-0]">
+  <bes:setContext name="bes_timeout">3000</bes:setContext>
+  <bes:setContext name="xdap_accept">2.0</bes:setContext>
+  <bes:setContext name="dap_explicit_containers">no</bes:setContext>
+  <bes:setContext name="errors">xml</bes:setContext>
+  <bes:setContext name="max_response_size">10</bes:setContext>
+  <bes:setContainer name="c">/data/coads.dods</bes:setContainer>
+  <bes:define name="d" space="default">
+    <bes:container name="c">
+      <bes:dap4constraint>SST</bes:dap4constraint>
+    </bes:container>
+  </bes:define>
+  <bes:get type="dap" definition="d"/>
+</bes:request>

--- a/dap/tests/bescmd/req_limit_dods.bescmd
+++ b/dap/tests/bescmd/req_limit_dods.bescmd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bes:request xmlns:bes="http://xml.opendap.org/ns/bes/1.0#" reqID="[thread:http-nio-8080-exec-9-36][bes_client:/-0]">
+  <bes:setContext name="bes_timeout">3000</bes:setContext>
+  <bes:setContext name="xdap_accept">2.0</bes:setContext>
+  <bes:setContext name="dap_explicit_containers">no</bes:setContext>
+  <bes:setContext name="errors">xml</bes:setContext>
+  <bes:setContext name="max_response_size">10</bes:setContext>
+  <bes:setContainer name="c">/data/coads.dods</bes:setContainer>
+  <bes:define name="d" space="default">
+    <bes:container name="c">
+      <bes:constraint>SST</bes:constraint>
+    </bes:container>
+  </bes:define>
+  <bes:get type="dods" definition="d"/>
+</bes:request>

--- a/modules/asciival/BESAsciiTransmit.cc
+++ b/modules/asciival/BESAsciiTransmit.cc
@@ -134,7 +134,7 @@ void BESAsciiTransmit::send_dap4_csv(BESResponseObject *obj, BESDataHandlerInter
     try {
         // @TODO Handle *functional* constraint expressions specially
         // Use the D4FunctionDriver class and evaluate the functions, building
-        // an new DMR, then evaluate the D4CE in the context of that DMR.
+        // a new DMR, then evaluate the D4CE in the context of that DMR.
         // This might be coded as "if (there's a function) do this else process the CE".
         // Or it might be coded as "if (there's a function) build the new DMR, then fall
         // through and process the CE but on the new DMR". jhrg 9/3/14
@@ -147,6 +147,14 @@ void BESAsciiTransmit::send_dap4_csv(BESResponseObject *obj, BESDataHandlerInter
         else {
             dmr->root()->set_send_p(true);
         }
+
+        if (dmr->response_limit() != 0 && (dmr->request_size(true) > dmr->response_limit())) {
+            string msg = "The Request for " + long_to_string(dmr->request_size(true))
+                + "KB is too large; requests for this server are limited to " + long_to_string(dmr->response_limit())
+                + "KB.";
+            throw Error(msg);
+        }
+
         // Now that we are ready to start building the response data we
         // cancel any pending timeout alarm according to the configuration.
         BESUtil::conditional_timeout_cancel();

--- a/xmlcommand/BESXMLInterface.cc
+++ b/xmlcommand/BESXMLInterface.cc
@@ -218,7 +218,7 @@ void BESXMLInterface::execute_data_request_plan()
     vector<BESXMLCommand *>::iterator i = d_xml_cmd_list.begin();
     vector<BESXMLCommand *>::iterator e = d_xml_cmd_list.end();
     for (; i != e; i++) {
-        (*i)->prep_request();   // TODO remove this if possible jhrg 1//7/19
+        (*i)->prep_request();   // TODO remove this if possible jhrg 1/7/19
 
         d_dhi_ptr = &(*i)->get_xmlcmd_dhi();
 


### PR DESCRIPTION
Fixes HK-22 - Response Limit not working. This works with besstandalone, bescmdln and the OLFS (incl the IFH). The problem was a mixup in the way the size was recorded versus computed combined with differences in the way the parameter value was processed by the DAP2 and DAP4 implementations.