### PR TITLE
Added a fix from Aron.Bartle@mechdyne.com.

### DIFF
--- a/modules/fileout_netcdf/FONcSequence.cc
+++ b/modules/fileout_netcdf/FONcSequence.cc
@@ -42,15 +42,12 @@
  * @param b A DAP BaseType that should be a Sequence
  * @throws BESInternalError if the BaseType is not a Sequence
  */
-FONcSequence::FONcSequence( BaseType *b )
-    : FONcBaseType(), _s( 0 )
+FONcSequence::FONcSequence(BaseType *b) :
+    FONcBaseType(), _s(0)
 {
-    _s = dynamic_cast<Sequence *>(b) ;
-    if( !_s )
-    {
-	string s = (string)"File out netcdf, FONcSequence was passed a "
-		   + "variable that is not a DAP Sequence" ;
-	throw BESInternalError( s, __FILE__, __LINE__ ) ;
+    _s = dynamic_cast<Sequence *>(b);
+    if (!_s) {
+        throw BESInternalError("File out netcdf, FONcSequence was passed a variable that is not a DAP Sequence", __FILE__, __LINE__);
     }
 }
 
@@ -72,11 +69,10 @@ FONcSequence::~FONcSequence()
  * @throws BESInternalError if there is a problem converting the
  * Byte
  */
-void
-FONcSequence::convert( vector<string> embed )
+void FONcSequence::convert(vector<string> embed)
 {
-    FONcBaseType::convert( embed ) ;
-    _varname = FONcUtils::gen_name( embed, _varname, _orig_varname ) ;
+    FONcBaseType::convert(embed);
+    _varname = FONcUtils::gen_name(embed, _varname, _orig_varname);
 }
 
 /** @brief define the DAP Sequence in the netcdf file
@@ -89,22 +85,16 @@ FONcSequence::convert( vector<string> embed )
  * @throws BESInternalError if there is a problem writing out the
  * attribute
  */
-void
-FONcSequence::define( int ncid )
+void FONcSequence::define(int ncid)
 {
     // for now we are simply going to add a global variable noting the
     // presence of the sequence, the name of the sequence, and that the
     // sequences has been elided.
-    string val = (string)"The sequence " + _varname
-		 + " is a member of this dataset and has been elided." ;
-    int stax = nc_put_att_text( ncid, NC_GLOBAL, _varname.c_str(),
-				val.length(), val.c_str() ) ;
-    if( stax != NC_NOERR )
-    {
-	string err = (string)"File out netcdf, "
-		     + "failed to write string attribute for sequence "
-		     + _varname ;
-	FONcUtils::handle_error( stax, err, __FILE__, __LINE__ ) ;
+    string val = (string) "The sequence " + _varname + " is a member of this dataset and has been elided.";
+    int stax = nc_put_att_text(ncid, NC_GLOBAL, _varname.c_str(), val.length(), val.c_str());
+    if (stax != NC_NOERR) {
+        string err = (string) "File out netcdf, " + "failed to write string attribute for sequence " + _varname;
+        FONcUtils::handle_error(stax, err, __FILE__, __LINE__);
     }
 }
 
@@ -117,15 +107,13 @@ FONcSequence::define( int ncid )
  * @throws BESInternalError if there is a problem writing the value out
  * to the netcdf file
  */
-void
-FONcSequence::write( int /*ncid*/ )
+void FONcSequence::write(int /*ncid*/)
 {
 }
 
-string
-FONcSequence::name()
+string FONcSequence::name()
 {
-    return _s->name() ;
+    return _s->name();
 }
 
 /** @brief dumps information about this object for debugging purposes
@@ -134,13 +122,11 @@ FONcSequence::name()
  *
  * @param strm C++ i/o stream to dump the information to
  */
-void
-FONcSequence::dump( ostream &strm ) const
+void FONcSequence::dump(ostream &strm) const
 {
-    strm << BESIndent::LMarg << "FONcSequence::dump - ("
-			     << (void *)this << ")" << endl ;
-    BESIndent::Indent() ;
-    strm << BESIndent::LMarg << "name = " << _s->name()  << endl ;
-    BESIndent::UnIndent() ;
+    strm << BESIndent::LMarg << "FONcSequence::dump - (" << (void *) this << ")" << endl;
+    BESIndent::Indent();
+    strm << BESIndent::LMarg << "name = " << _s->name() << endl;
+    BESIndent::UnIndent();
 }
 

--- a/modules/fileout_netcdf/FONcStructure.cc
+++ b/modules/fileout_netcdf/FONcStructure.cc
@@ -106,6 +106,7 @@ void FONcStructure::convert(vector<string> embed)
         if (bt->send_p()) {
             BESDEBUG("fonc", "FONcStructure::convert - converting " << bt->name() << endl);
             FONcBaseType *fbt = FONcUtils::convert(bt);
+            fbt->setVersion(this->_ncVersion);
             _vars.push_back(fbt);
             fbt->convert(embed);
         }


### PR DESCRIPTION
Netcdf file responses were not compressed when they should have been
if the dataset had Structures. Fixed by patching FONcStructure as Aron
suggested.