### PR TITLE
Switched DmrppParserSax2 to chunk based parsing (and not line based)

### DIFF
--- a/dapreader/tests/dap/DMR_0.1.xml.dmr.bescmd.baseline
+++ b/dapreader/tests/dap/DMR_0.1.xml.dmr.bescmd.baseline
@@ -17,6 +17,8 @@
         <Attribute name="temp" type="Float32">
             <Value>98.6</Value>
         </Attribute>
-        <Attribute name="xmltest" type="OtherXML">            <xml>barf</xml>        </Attribute>
+        <Attribute name="xmltest" type="OtherXML">
+            <xml>barf</xml>
+        </Attribute>
     </Attribute>
 </Dataset>

--- a/dapreader/tests/dap/DMR_3.1.xml.dmr.bescmd.baseline
+++ b/dapreader/tests/dap/DMR_3.1.xml.dmr.bescmd.baseline
@@ -24,7 +24,9 @@
             <Attribute name="temp" type="Float32">
                 <Value>98.6</Value>
             </Attribute>
-            <Attribute name="xmltest" type="OtherXML">                <xml>barf</xml>            </Attribute>
+            <Attribute name="xmltest" type="OtherXML">
+                <xml>barf</xml>
+            </Attribute>
         </Attribute>
     </Byte>
 </Dataset>

--- a/dapreader/tests/dap/DMR_3.3.xml.dmr.bescmd.baseline
+++ b/dapreader/tests/dap/DMR_3.3.xml.dmr.bescmd.baseline
@@ -26,7 +26,9 @@
             <Attribute name="temp" type="Float32">
                 <Value>98.6</Value>
             </Attribute>
-            <Attribute name="xmltest" type="OtherXML">                <xml>barf</xml>            </Attribute>
+            <Attribute name="xmltest" type="OtherXML">
+                <xml>barf</xml>
+            </Attribute>
         </Attribute>
     </Byte>
 </Dataset>

--- a/modules/dmrpp_module/DmrppParserSax2.cc
+++ b/modules/dmrpp_module/DmrppParserSax2.cc
@@ -1526,6 +1526,7 @@ void DmrppParserSax2::intern(istream &f, DMR *dest_dmr, bool debug)
 
     d_dmr = dest_dmr; // dump values here
 
+#if 0
     int line_num = 1;
     string line;
 
@@ -1555,6 +1556,43 @@ void DmrppParserSax2::intern(istream &f, DMR *dest_dmr, bool debug)
 
     // This call ends the parse.
     xmlParseChunk(context, line.c_str(), 0, 1/*terminate*/);
+#else
+    int line_num = 1;
+    string line;
+
+    // Get the XML prolog line (looks like: <?xml ... ?> )
+    getline(f, line);
+    if (line.length() == 0) throw Error("No input found while parsing the DMR.");
+
+    if (debug) cerr << "line: (" << line_num << "): " << endl << line << endl << endl;
+
+    context = xmlCreatePushParserCtxt(&dmrpp_sax_parser, this, line.c_str(), line.length(), "stream");
+    context->validate = true;
+    push_state(parser_start);
+
+    // Get the first chunk of the stuff
+    long chunk_count = 0;
+    long chunk_size = 0;
+
+    f.read(d_parse_buffer, D4_PARSE_BUFF_SIZE);
+    chunk_size=f.gcount();
+    d_parse_buffer[chunk_size]=0; // null terminate the string. We can do it this way because the buffer is +1 bigger than D4_PARSE_BUFF_SIZE
+    if (debug) cerr << "chunk: (" << chunk_count++ << "): " << endl << d_parse_buffer << endl << endl;
+
+    while(!f.eof()  && (get_state() != parser_end)){
+
+        xmlParseChunk(context, d_parse_buffer, chunk_size, 0);
+
+        // There is more to read. Get the next chunk
+        f.read(d_parse_buffer, D4_PARSE_BUFF_SIZE);
+        chunk_size=f.gcount();
+        d_parse_buffer[chunk_size]=0; // null terminate the string. We can do it this way because the buffer is +1 bigger than D4_PARSE_BUFF_SIZE
+        if (debug) cerr << "chunk: (" << chunk_count++ << "): " << endl << d_parse_buffer << endl << endl;
+    }
+
+    // This call ends the parse.
+    xmlParseChunk(context, d_parse_buffer, chunk_size, 1/*terminate*/);
+#endif
 
     // This checks that the state on the parser stack is parser_end and throws
     // an exception if it's not (i.e., the loop exited with gcount() == 0).

--- a/modules/dmrpp_module/DmrppParserSax2.h
+++ b/modules/dmrpp_module/DmrppParserSax2.h
@@ -41,6 +41,7 @@
 #include <Type.h>   // from libdap
 
 #define CRLF "\r\n"
+#define D4_PARSE_BUFF_SIZE 1048576
 
 namespace libdap {
 class DMR;
@@ -104,6 +105,7 @@ private:
 
         parser_end
     };
+    char d_parse_buffer[D4_PARSE_BUFF_SIZE+1]; // Buff size plus one byte for NULL termination.
 
     xmlSAXHandler dmrpp_sax_parser;
 


### PR DESCRIPTION
which will preserve newlines in Attribute Values. Fixed baselines affacted by similar changes in libdap4