### PR TITLE
Bes leak fix

### DIFF
--- a/modules/dmrpp_module/DmrppParserSax2.cc
+++ b/modules/dmrpp_module/DmrppParserSax2.cc
@@ -1476,7 +1476,8 @@ void DmrppParserSax2::cleanup_parse()
     bool wellFormed = context->wellFormed;
     bool valid = context->valid;
 
-    // FIXME jhrg 6/19/19 context->sax = NULL;
+    // context->sax = NULL;
+    // Leak. Removed the above. jhrg 6/19/19
     xmlFreeParserCtxt(context);
 
     delete d_enum_def;
@@ -1640,8 +1641,6 @@ void DmrppParserSax2::intern(const char *buffer, int size, DMR *dest_dmr, bool d
     push_state(parser_start);
     context = xmlCreatePushParserCtxt(&dmrpp_sax_parser, this, buffer, size, "stream");
     context->validate = true;
-    //push_state(parser_start);
-    //xmlParseChunk(context, buffer, size, 0);
 
     // This call ends the parse.
     xmlParseChunk(context, buffer, 0, 1/*terminate*/);

--- a/modules/dmrpp_module/DmrppParserSax2.cc
+++ b/modules/dmrpp_module/DmrppParserSax2.cc
@@ -1476,7 +1476,7 @@ void DmrppParserSax2::cleanup_parse()
     bool wellFormed = context->wellFormed;
     bool valid = context->valid;
 
-    context->sax = NULL;
+    // FIXME jhrg 6/19/19 context->sax = NULL;
     xmlFreeParserCtxt(context);
 
     delete d_enum_def;

--- a/modules/dmrpp_module/DmrppParserSax2.h
+++ b/modules/dmrpp_module/DmrppParserSax2.h
@@ -105,6 +105,7 @@ private:
 
         parser_end
     };
+
     char d_parse_buffer[D4_PARSE_BUFF_SIZE+1]; // Buff size plus one byte for NULL termination.
 
     xmlSAXHandler dmrpp_sax_parser;

--- a/modules/ncml_module/SaxParserWrapper.cc
+++ b/modules/ncml_module/SaxParserWrapper.cc
@@ -325,8 +325,12 @@ bool SaxParserWrapper::parse(const string& ncmlFilename)
     // OK, now we're parsing
     _state = PARSING;
 
+
     setupParser(ncmlFilename);
 
+    success = xmlSAXUserParseFile(&_handler, this, ncmlFilename.c_str());
+
+#if 0
     // Old way where we have no context.
     //  int errNo = xmlSAXUserParseFile(&_handler, this, ncmlFilename.c_str());
     //  success = (errNo == 0);
@@ -339,6 +343,7 @@ bool SaxParserWrapper::parse(const string& ncmlFilename)
     success = (_context->errNo == 0);
 
     cleanupParser();
+#endif
 
     // If we deferred an exception during the libxml parse call, now's the time to rethrow it.
     if (isExceptionState()) {
@@ -477,6 +482,8 @@ void SaxParserWrapper::setupParser(const string& filename)
     // Create the non-validating parser context for the file
     // using this as the userData for making exception-safe
     // C++ calls.
+
+#if 0
     _context = xmlCreateFileParserCtxt(filename.c_str());
     if (!_context) {
         THROW_NCML_PARSE_ERROR(-1, "Cannot parse: Unable to create a libxml parse context for " + filename);
@@ -484,10 +491,12 @@ void SaxParserWrapper::setupParser(const string& filename)
     _context->sax = &_handler;
     _context->userData = this;
     _context->validate = false;
+#endif
 }
 
 void SaxParserWrapper::cleanupParser() throw ()
 {
+#if 0
     if (_context) {
         // Remove our handler from it.
         _context->sax = NULL;
@@ -496,5 +505,6 @@ void SaxParserWrapper::cleanupParser() throw ()
         xmlFreeParserCtxt(_context);
         _context = 0;
     }
+#endif
 }
 

--- a/modules/ncml_module/SaxParserWrapper.cc
+++ b/modules/ncml_module/SaxParserWrapper.cc
@@ -301,8 +301,8 @@ static void ncmlFatalError(void* userData, const char* msg, ...)
 // class SaxParserWrapper impl
 
 SaxParserWrapper::SaxParserWrapper(SaxParser& parser) :
-    _parser(parser), _handler() // inits to all nulls.
-    , _context(0), _state(NOT_PARSING), _errorMsg(""), _errorType(0), _errorFile(""), _errorLine(-1)
+    _parser(parser), _handler(), // inits to all nulls.
+    /*_context(0),*/ _state(NOT_PARSING), _errorMsg(""), _errorType(0), _errorFile(""), _errorLine(-1)
 {
 }
 
@@ -310,7 +310,11 @@ SaxParserWrapper::~SaxParserWrapper()
 {
     // Really not much to do...  everything cleans itself up.
     _state = NOT_PARSING;
+#if 0
+    // Leak fix. jhrg 6/21/19
     cleanupParser();
+#endif
+
 }
 
 bool SaxParserWrapper::parse(const string& ncmlFilename)
@@ -400,12 +404,15 @@ void SaxParserWrapper::rethrowException()
 
 int SaxParserWrapper::getCurrentParseLine() const
 {
+#if 0
     if (_context) {
         return xmlSAX2GetLineNumber(_context);
     }
     else {
         return -1;
     }
+#endif
+    return -1;  //FIXME part of leak fix. jhrg 6.21.19
 }
 
 static void setAllHandlerCBToNulls(xmlSAXHandler& h)
@@ -484,6 +491,7 @@ void SaxParserWrapper::setupParser(const string& filename)
     // C++ calls.
 
 #if 0
+    // Leak fix. jhrg 6/21/19
     _context = xmlCreateFileParserCtxt(filename.c_str());
     if (!_context) {
         THROW_NCML_PARSE_ERROR(-1, "Cannot parse: Unable to create a libxml parse context for " + filename);
@@ -494,9 +502,12 @@ void SaxParserWrapper::setupParser(const string& filename)
 #endif
 }
 
+#if 0
+// Leak fix. jhrg 6/21/19
 void SaxParserWrapper::cleanupParser() throw ()
 {
 #if 0
+    // Leak fix. jhrg 6/21/19
     if (_context) {
         // Remove our handler from it.
         _context->sax = NULL;
@@ -507,4 +518,6 @@ void SaxParserWrapper::cleanupParser() throw ()
     }
 #endif
 }
+#endif
+
 

--- a/modules/ncml_module/SaxParserWrapper.h
+++ b/modules/ncml_module/SaxParserWrapper.h
@@ -85,10 +85,13 @@ private:
      */
     xmlSAXHandler _handler;
 
+#if 0
     /** the xml parser context (internals) so we can get access to line numbers
      *  in the parse and pass them along for better debug output on exception.
      */
     xmlParserCtxtPtr _context;
+#endif
+
 
     /** Current state of the parser.  If EXCEPTION, _error will be the deferred exception. */
     ParserState _state;
@@ -167,8 +170,12 @@ private:
     /** Prepare the parser to load the given filename, setting up the handler and context */
     void setupParser(const string& filename);
 
+#if 0
+    // Leak fix. jhrg 6/21/19
     /** Clean the _context and any other state */
     void cleanupParser() throw ();
+#endif
+
 
 };
 // class SaxParserWrapper


### PR DESCRIPTION
This is an improvement over the previous state where each call to the libxml2-based SAX parser leaked 256 bytes. But it's not perfect - there's still memory from libcurl being leaked and I think it is libxml2 using libcurl that is causing these leaks.