### PR TITLE
Hk 311

### DIFF
--- a/modules/httpd_catalog_module/HttpdDirScraper.cc
+++ b/modules/httpd_catalog_module/HttpdDirScraper.cc
@@ -242,7 +242,7 @@ string HttpdDirScraper::httpd_time_to_iso_8601_new(const string httpd_time) cons
     BESDEBUG(MODULE, prolog << "tm struct: " << endl << show_tm_struct(tm));
 
     time_t theTime = mktime(&tm);
-    BESDEBUG(MODULE, prolog << "theTime: " << theTime << endl);
+    BESDEBUG(MODULE, prolog << "ISO-8601 Time: " << theTime << endl);
     return BESUtil::get_time(theTime, false);
 }
 
@@ -369,7 +369,7 @@ void HttpdDirScraper::createHttpdDirectoryPageMap(std::string url, std::map<std:
                         leafItem->set_type(CatalogItem::leaf);
                         leafItem->set_name(href);
                         leafItem->set_is_data(cat_utils->is_data(href));
-                        string iso_8601_time = httpd_time_to_iso_8601(time_str);
+                        string iso_8601_time = httpd_time_to_iso_8601_new(time_str);
                         leafItem->set_lmt(iso_8601_time);
                         long size = get_size_val(size_str);
                         leafItem->set_size(size);

--- a/modules/httpd_catalog_module/HttpdDirScraper.h
+++ b/modules/httpd_catalog_module/HttpdDirScraper.h
@@ -48,6 +48,7 @@ private:
     void createHttpdDirectoryPageMap(std::string url, std::map<std::string, bes::CatalogItem *> &items) const;
     long get_size_val(const string size_str) const;
     string httpd_time_to_iso_8601(const string httpd_time) const;
+    string httpd_time_to_iso_8601_new(const string httpd_time) const;
 
 public:
     HttpdDirScraper();

--- a/modules/httpd_catalog_module/HttpdDirScraper.h
+++ b/modules/httpd_catalog_module/HttpdDirScraper.h
@@ -42,18 +42,20 @@ namespace httpd_catalog {
  */
 class HttpdDirScraper {
 private:
-    map<string,int> d_months;
+    std::map<std::string,int> d_months;
 
-    int getNextElementText(const string &page_str, string element_name, int startIndex, string &resultText, bool trim=true) const;
+    int getNextElementText(const std::string &page_str, std::string element_name, int startIndex, std::string &resultText, bool trim=true) const;
     void createHttpdDirectoryPageMap(std::string url, std::map<std::string, bes::CatalogItem *> &items) const;
-    long get_size_val(const string size_str) const;
-    string httpd_time_to_iso_8601(const string httpd_time) const;
-    string httpd_time_to_iso_8601_new(const string httpd_time) const;
+    long get_size_val(const std::string size_str) const;
+    std::string httpd_time_to_iso_8601(const std::string httpd_time) const;
+    std::string httpd_time_to_iso_8601_new(const string httpd_time) const;
+    time_t parse_time_format_A(const std::vector<std::string> tokens) const;
+    time_t parse_time_format_B(const std::vector<std::string> tokens) const;
 
 public:
     HttpdDirScraper();
     ~HttpdDirScraper() { }
-    virtual bes::CatalogNode *get_node(const string &url, const string &path) const;
+    virtual bes::CatalogNode *get_node(const std::string &url, const std::string &path) const;
 };
 } // namespace httpd_catalog
 


### PR DESCRIPTION
This patch adds a second time format to the time parsing code used by httpd_catalog_module. This change fixes a problem caused by a change in Apache httpd (either configuration or an upgrade) causes the time string format to change from:

 *  "DD-MM-YYY hh:mm" example: "19-Oct-2018 19:32"

to
* "YYYY-MM-DD hh:mm" example: "2012-01-02 10:03"