### PR TITLE
Whitelist file patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ branches:
   - coverity_scan
 
 addons:
+  ssh_known_hosts: www.opendap.org
   coverity_scan:
     project:
       name: "OPENDAP/bes"
@@ -41,25 +42,34 @@ addons:
     - lintian
     - fakeroot
     - build-essential
+    - sshpass
 
 env:
   global:
-  # NB: This value of $prefix must be shared between the hyrax-deps, libdap and bes builds.
-  - prefix=$HOME/install
-  - PATH=$prefix/bin:$prefix/deps/bin:$PATH
-  - TESTSUITEFLAGS=-j7
-  # Change this when libdap version numbers change
-  - LIBDAP_RPM_VERSION=3.20.4-1
-  # SONAR_LOGIN, made using "travis encrypt --org -r OPENDAP/bes SONAR_LOGIN=335df..."
-  - secure: "TmoFcgeIyAEjFyrlqB6rhdUhDqPJfxVZmT5fewgVHj0xm767VZ6DU21mM6ZHgNGyk99TzX0Gx/dwSqbsUj18hSSAvEa7fJQSKJ5IBJvTeMKhXn1DPPG9VpuZ4ti5afRDiNr6EJKbVxwBTkz+3798S8LajPuXGupYupir8IJQCt8="
-  # SONAR_MODULES_LOGIN, using "travis encrypt --org -r OPENDAP/bes SONAR_MODULES_LOGIN=42ba..."
-  - secure: "V3fMZgzMRRB0xFQMTvXf2fFPHIdwvg2y6bNFKqSGI5HP2sZEtc7XqSC4hjboR9RjnyZY/H1L/EuYQCS45gmJMsmtzo4g1Cn0oTfuPRJzDSi00jRlB1wUl5p1pU0Fdv2ffrGF4m6/SRfYFT0KkR/Tp8hdIoYx5/8R4MajysABMT4="
-  # COVERITY_SCAN_TOKEN
-  - secure: "KNE6gkK7+WEQkNLiW/oap/3E/YSq6nzH6icXWpgA3MZj2KX0i6IzQgteeEGFUC1vDTzkCpqSidvGxdd22V33s0sHDuLRI5e17VFMjI5WyWjRQaXMhWmyO5/ofx7AArvaCWq6w6zfn1T/LiIuHXc14Rg8uuWEgDGWM0USiSbMepc="
-  # AWS_ACCESS_KEY_ID
-  - secure: "NNcSfmrBN9ctc8LoRVeLcYPzf2wYCSLUNCdNuVEsBdOMa5JLTdFMBEhfrgkLmiUSf1K+V97tw3rJuRcdwAXbwBMuJ0o8+gDG4c63clDDWYDXa08gdpKhy0FFqlUohVeMNpfCawvTm46/p6P0SlKg245by5OcVZ4HfjIGUasJHEw="
-  # AWS_SECRET_ACCESS_KEY
-  - secure: "BVETDaGI/cwfUHdvsGPkV1o7jd6OnqyvtFCPk0WsmCWh6PdpwXQ8D4yFdk4jejWxa0YFdRiCgK3ThHqqzv+6pDxrMnpYOx2O+ZjK//ErECjDa+OCJr2ObCwlqOPE6+4aVmPDz5ecjd2inVR5CfL5/Kt3Zgn4U9fNBUz9OMYpRF4="
+    # NB: This value of $prefix must be shared between the hyrax-deps, libdap and bes builds.
+    - prefix=$HOME/install
+    - PATH=$prefix/bin:$prefix/deps/bin:$PATH
+    - TESTSUITEFLAGS=-j7
+    # Change this when libdap version numbers change
+    - LIBDAP_RPM_VERSION=3.20.4-1
+    # SONAR_LOGIN, made using "travis encrypt --org -r OPENDAP/bes SONAR_LOGIN=335df..."
+    - secure: "TmoFcgeIyAEjFyrlqB6rhdUhDqPJfxVZmT5fewgVHj0xm767VZ6DU21mM6ZHgNGyk99TzX0Gx/dwSqbsUj18hSSAvEa7fJQSKJ5IBJvTeMKhXn1DPPG9VpuZ4ti5afRDiNr6EJKbVxwBTkz+3798S8LajPuXGupYupir8IJQCt8="
+    # SONAR_MODULES_LOGIN, using "travis encrypt --org -r OPENDAP/bes SONAR_MODULES_LOGIN=42ba..."
+    - secure: "V3fMZgzMRRB0xFQMTvXf2fFPHIdwvg2y6bNFKqSGI5HP2sZEtc7XqSC4hjboR9RjnyZY/H1L/EuYQCS45gmJMsmtzo4g1Cn0oTfuPRJzDSi00jRlB1wUl5p1pU0Fdv2ffrGF4m6/SRfYFT0KkR/Tp8hdIoYx5/8R4MajysABMT4="
+    # COVERITY_SCAN_TOKEN
+    - secure: "KNE6gkK7+WEQkNLiW/oap/3E/YSq6nzH6icXWpgA3MZj2KX0i6IzQgteeEGFUC1vDTzkCpqSidvGxdd22V33s0sHDuLRI5e17VFMjI5WyWjRQaXMhWmyO5/ofx7AArvaCWq6w6zfn1T/LiIuHXc14Rg8uuWEgDGWM0USiSbMepc="
+    # AWS_ACCESS_KEY_ID
+    - secure: "NNcSfmrBN9ctc8LoRVeLcYPzf2wYCSLUNCdNuVEsBdOMa5JLTdFMBEhfrgkLmiUSf1K+V97tw3rJuRcdwAXbwBMuJ0o8+gDG4c63clDDWYDXa08gdpKhy0FFqlUohVeMNpfCawvTm46/p6P0SlKg245by5OcVZ4HfjIGUasJHEw="
+    # AWS_SECRET_ACCESS_KEY
+    - secure: "BVETDaGI/cwfUHdvsGPkV1o7jd6OnqyvtFCPk0WsmCWh6PdpwXQ8D4yFdk4jejWxa0YFdRiCgK3ThHqqzv+6pDxrMnpYOx2O+ZjK//ErECjDa+OCJr2ObCwlqOPE6+4aVmPDz5ecjd2inVR5CfL5/Kt3Zgn4U9fNBUz9OMYpRF4="
+    # GIT_UID travis-ci-opendap
+    - secure: "eUL/RY4kJD9sb3q98Xbfbcdhs6eyFWkfWNb0tvRzksBi/+tYiuojsek0qoBFZnRnO0wwyDAaDrZgu2yoLQTBxGSTqCsYaoDiFtw2m8aW3r+FdjpfmyVR52U9vMoZtpiPGYYM9utlyQ6YRNhzq+XzDJ4juygoIlzbp7qXTALqIL8="
+    # GIT_PSWD for travis-ci-opendap
+    - secure: "jdEmVdM35qoAmIXTqTCL11IbjEMh6I+jrov/nqQ4wdoJf79O7H7tuuDVkIJ+5RSIjUXsIYgfQAG8Cn+DIJRMnv7mj7TrWGS9LT22bBGErzCcCkrHGKMDH4okbd8cCNQcnb/9woYSYZ38U8QCBsYH1Ma2r4bFU4jAY2KiMOyaY6w="    
+    # WOO_UID for travis
+    - secure: "YKSsiV7fjngZ+Xha9oyHUT2Xirz8Iy7bghAzlGk2TyXZwWGbZyFDMeTfE0ZGaAEykhNF9fsqsD6XMzFlwBcYIB5ocP6LfnQ1qMualHVTVbVldo/T2e8uv/9jVIAnfwwT2IbgWpVUXZ1I24kIqHCxnZWYZpbfclSEDnQnkYG9tMg="
+
+
 
 before_install:
 - pip install --user awscli
@@ -119,7 +129,8 @@ jobs:
     - export BES_BUILD=distcheck
     - ./configure --disable-dependency-tracking --prefix=$prefix --with-dependencies=$prefix/deps --enable-developer 
     - make distcheck -j7
-
+  
+  # Debian Target (unused)
   # - stage: package
   #  script: 
   #  - export BES_BUILD=deb
@@ -145,24 +156,132 @@ jobs:
                  --env OS=centos7 --env DIST=el7 --env LIBDAP_RPM_VERSION=$LIBDAP_RPM_VERSION
                  --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
                  opendap/centos7_hyrax_builder:1.2 /root/travis/build-rpm.sh
+
+  - stage: package
+    script:
+    - export BES_BUILD=srcdist
+    - ./configure --disable-dependency-tracking --prefix=$prefix --with-dependencies=$prefix/deps --enable-developer 
+    - make dist -j7
+    - cp bes-*.tar.gz bes-snapshot.tar.gz;
+    #- echo "Test is a test my besty." > bes-3.20.1999.tar.gz;
+    #- cp bes-3.20.1999.tar.gz bes-snapshot.tar.gz;
+
     
 after_script:
 - ./upload-test-results.sh
 
 before_deploy:
-- test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
-- if test $BES_BUILD = deb; then mv $TRAVIS_BUILD_DIR/../bes*-*_amd64.deb $TRAVIS_BUILD_DIR/package/; fi
-- if test "$BES_BUILD" = "centos6"; then cp $prefix/rpmbuild/RPMS/x86_64/* $TRAVIS_BUILD_DIR/package/; fi
-- if test "$BES_BUILD" = "centos7"; then cp $prefix/rpmbuild/RPMS/x86_64/* $TRAVIS_BUILD_DIR/package/; fi
+# Make sure that we have the target dir...
+- test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package;
+#
+# Get creds for pushing snapshots to w.o.o.
+- if  test "$BES_BUILD" = "srcdist" || test "$BES_BUILD" = "centos6" || test "$BES_BUILD" = "centos7" ; 
+    then
+        ls -l ./travis;
+        openssl aes-256-cbc -K $encrypted_f3adba893add_key -iv $encrypted_f3adba893add_iv -in ./travis/woo_deploy_rsa_enc -out /tmp/woo_deploy_rsa -d;
+        eval "$(ssh-agent -s)";
+        chmod 600 /tmp/woo_deploy_rsa;
+        ssh-add /tmp/woo_deploy_rsa;
+    fi
+# Source distribution prep
+- if test "$BES_BUILD" = "srcdist"; 
+    then
+        cp bes-*.tar.gz $TRAVIS_BUILD_DIR/package;
+        cp bes-snapshot.tar.gz $TRAVIS_BUILD_DIR/package;
+    fi
+    
+# The following is part of deb(ian) target
+# - if test $BES_BUILD = deb; then mv $TRAVIS_BUILD_DIR/../bes*-*_amd64.deb $TRAVIS_BUILD_DIR/package/; fi
+
+# CentOS-7  distribution prep
+- if test "$BES_BUILD" = "centos6"; 
+   then 
+        cp $prefix/rpmbuild/RPMS/x86_64/* $TRAVIS_BUILD_DIR/package/; 
+        for file in ${prefix}/rpmbuild/RPMS/x86_64/*; do
+            echo "Updating BES CentOS-6 snapshot with ${file}";
+            ver=`basename ${file} | sed -e "s|bes-debuginfo-||g" -e "s|bes-devel-||g" -e "s|bes-||g" -e "s|.static.el6.x86_64.rpm||g"`;
+            snap=`basename ${file} | sed "s|${ver}|snapshot|g"`;
+            cp ${file} ${TRAVIS_BUILD_DIR}/package/${snap};
+        done
+    fi
+# CentOS-6 distribution prep
+- if test "$BES_BUILD" = "centos7"; 
+    then 
+        cp $prefix/rpmbuild/RPMS/x86_64/* $TRAVIS_BUILD_DIR/package/;
+        for file in ${prefix}/rpmbuild/RPMS/x86_64/*; do
+            echo "Updating BES CentOS-7 snapshot with ${file}";
+            ver=`basename ${file} | sed -e "s|bes-debuginfo-||g" -e "s|bes-devel-||g" -e "s|bes-||g" -e "s|.static.el7.x86_64.rpm||g"`;
+            snap=`basename ${file} | sed "s|${ver}|snapshot|g"`;
+            cp ${file} ${TRAVIS_BUILD_DIR}/package/${snap};
+        done
+    fi
+# Check for the stuff...
 - ls -l $TRAVIS_BUILD_DIR/package
 
+# The deploy section copies the snapshot build product our S3 bucket and to www.opendap.org
 deploy:
-  provider: s3
-  access_key_id: $AWS_ACCESS_KEY_ID
-  secret_access_key: $AWS_SECRET_ACCESS_KEY
-  bucket: opendap.travis.build
-  skip_cleanup: true
-  local_dir: $TRAVIS_BUILD_DIR/package
-  on:
-    branch: master
-    condition: $BES_BUILD =~ ^deb|centos7|centos6$
+  - provider: s3
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    bucket: opendap.travis.build
+    skip_cleanup: true
+    local_dir: $TRAVIS_BUILD_DIR/package
+    on:
+      branch: master
+      condition: $BES_BUILD =~ ^deb|centos7|centos6|srcdist$
+  
+  # Push CentOS-7 snapshot rpms to w.o.o
+  - provider: script
+    skip_cleanup: true
+    script: 
+      - scp -v $TRAVIS_BUILD_DIR/package/*snapshot*el7* $WOO_UID@www.opendap.org:/httpdocs/webdav/pub/binary/hyrax-snapshot/centos-7.x;
+    on:
+      branch: master
+      condition: $BES_BUILD =~ ^centos7$
+
+  # Push CentOS-6 snapshot rpms to w.o.o
+  - provider: script
+    skip_cleanup: true
+    script: 
+      - scp -v $TRAVIS_BUILD_DIR/package/*snapshot*el6* $WOO_UID@www.opendap.org:/httpdocs/webdav/pub/binary/hyrax-snapshot/centos-6.x;
+    on:
+      branch: master
+      condition: $BES_BUILD =~ ^centos6$
+
+  # Push source snapshot rpms to w.o.o
+  - provider: script
+    skip_cleanup: true
+    script: 
+      - scp -v $TRAVIS_BUILD_DIR/package/*snapshot.tar.gz $WOO_UID@www.opendap.org:/httpdocs/webdav/pub/binary/hyrax-snapshot/src;
+    on:
+      branch: master
+      condition: $BES_BUILD =~ ^srcdist$
+
+# The after_deploy section grabs the hyrax-docker project, sets the current snapshot time 
+# and pushes the result to GitHub. This push triggers TravisCI to build the Docker containers
+# for all of the Hyrax snapshot products. 
+after_deploy:
+- echo "-- -- -- -- -- -- -- -- -- after_deploy BEGIN -- -- -- -- -- -- -- -- --";
+- echo "$BES_BUILD";
+- if test "$BES_BUILD" = "centos7"; 
+    then  
+        echo "New CentOS-7 snapshot of BES pushed. Triggering a Docker build"; 
+        git clone https://github.com/OPENDAP/hyrax-docker;
+        git config --global user.name "The-Robot-Travis";
+        git config --global user.email "npotter@opendap.org";
+        cd hyrax-docker/hyrax-snapshot;
+        date +%s | tee -a snapshot.time;
+        cat snapshot.time;
+        git commit -am "The BES has produced new snapshot files. Triggering Hyrax-Docker image builds for snapshots.";
+        git status;
+        git push https://$GIT_UID:$GIT_PSWD@github.com/opendap/hyrax-docker --all;
+    elif test "$BES_BUILD" = "centos6"; 
+    then  
+        echo "New CentOS-6 snapshot of BES pushed. No Docker build initiated";     
+    elif test "$BES_BUILD" = "srcdist"; 
+    then  
+        echo "New source snapshot pushed. No Docker build initiated.";     
+    fi
+- echo "-- -- -- -- -- -- -- -- -- after_deploy END -- -- -- -- -- -- -- -- --";
+        
+

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Hyrax 1.16 has prototype support for subset-in-place of HDF5 and NetCDF4
 data files that are stored on AWS S3. See the preliminary documentation in
 https://github.com/OPENDAP/bes/blob/master/modules/dmrpp_module/data/README.md.
 
-The new support includes software that can configure data in Se and on
+The new support includes software that can configure data in S3 and on
 disk so that it can be served (and subset) in-place from S3 without reformatting
 the original data files. Support for other web object stores besides S3
 has also been demonstrated.

--- a/dap/BESDASResponseHandler.cc
+++ b/dap/BESDASResponseHandler.cc
@@ -85,7 +85,7 @@ BESDASResponseHandler::execute( BESDataHandlerInterface &dhi )
     GlobalMetadataStore::MDSReadLock lock;
 
     dhi.first_container();
-    if (mds) lock = mds->is_das_available(dhi.container->get_relative_name());
+    if (mds) lock = mds->is_das_available(*(dhi.container));
 
     if (mds && lock()) {
         // send the response

--- a/dap/BESDDSResponseHandler.cc
+++ b/dap/BESDDSResponseHandler.cc
@@ -101,7 +101,7 @@ void BESDDSResponseHandler::execute(BESDataHandlerInterface &dhi)
     GlobalMetadataStore::MDSReadLock lock;
 
     dhi.first_container();
-    if (mds) lock = mds->is_dds_available(dhi.container->get_relative_name());
+    if (mds) lock = mds->is_dds_available(*(dhi.container));
 
     if (mds && lock() && dhi.container->get_constraint().empty()) {
         // Unconstrained DDS requests; send the stored response

--- a/dap/BESDDXResponseHandler.cc
+++ b/dap/BESDDXResponseHandler.cc
@@ -99,7 +99,7 @@ void BESDDXResponseHandler::execute(BESDataHandlerInterface &dhi)
     GlobalMetadataStore::MDSReadLock lock;
 
     dhi.first_container();
-    if (mds) lock = mds->is_dds_available(dhi.container->get_relative_name());
+    if (mds) lock = mds->is_dds_available(*(dhi.container));
 
     if (mds && lock() && !function_in_ce(dhi.container->get_constraint())) {
         DDS *dds = mds->get_dds_object(dhi.container->get_relative_name());

--- a/dap/BESDMRResponseHandler.cc
+++ b/dap/BESDMRResponseHandler.cc
@@ -87,7 +87,7 @@ void BESDMRResponseHandler::execute(BESDataHandlerInterface &dhi)
     GlobalMetadataStore::MDSReadLock lock;
 
     dhi.first_container();
-    if (mds) lock = mds->is_dmr_available(dhi.container->get_relative_name());
+    if (mds) lock = mds->is_dmr_available(*(dhi.container));
 
     if (mds && lock() && dhi.container->get_dap4_constraint().empty() && dhi.container->get_dap4_function().empty()) {    // no CE
         // send the response

--- a/dap/BESDap4ResponseHandler.cc
+++ b/dap/BESDap4ResponseHandler.cc
@@ -67,7 +67,7 @@ void BESDap4ResponseHandler::execute(BESDataHandlerInterface &dhi)
 
         GlobalMetadataStore::MDSReadLock lock;
         dhi.first_container();
-        if (mds) lock = mds->is_dmrpp_available(dhi.container->get_relative_name());
+        if (mds) lock = mds->is_dmrpp_available(*(dhi.container));
 
         // If we were able to lock the DMR++ it must exist; use it.
         if (mds && lock()) {

--- a/dap/BESDataResponseHandler.cc
+++ b/dap/BESDataResponseHandler.cc
@@ -86,7 +86,7 @@ void BESDataResponseHandler::execute(BESDataHandlerInterface &dhi)
 
         GlobalMetadataStore::MDSReadLock lock;
         dhi.first_container();
-        if (mds) lock = mds->is_dmrpp_available(dhi.container->get_relative_name());
+        if (mds) lock = mds->is_dmrpp_available(*(dhi.container));
 
         // If we were able to lock the DMR++ it must exist; use it.
         if (mds && lock()) {

--- a/dap/GlobalMetadataStore.cc
+++ b/dap/GlobalMetadataStore.cc
@@ -35,11 +35,12 @@
 #include <fstream>
 #include <sstream>
 #include <functional>
+#include <DAS.h>
 #include <memory>
+#include <sys/stat.h>
 
 #include <DapObj.h>
 #include <DDS.h>
-#include <DAS.h>
 #include <DMR.h>
 #include <D4ParserSax2.h>
 #include <XMLWriter.h>
@@ -54,6 +55,9 @@
 #include "BESLog.h"
 #include "BESContextManager.h"
 #include "BESDebug.h"
+#include "BESRequestHandler.h"
+#include "BESRequestHandlerList.h"
+#include "BESNotFoundError.h"
 
 #include "BESInternalError.h"
 #include "BESInternalFatalError.h"
@@ -544,8 +548,6 @@ GlobalMetadataStore::store_dap_response(StreamDAP &writer, const string &key, co
 
     int fd;
     if (create_and_lock(item_name, fd)) {
-        // If here, the cache_file_name could not be locked for read access;
-        // try to build it. First make an empty files and get an exclusive lock on them.
         BESDEBUG(DEBUG_KEY,__FUNCTION__ << " Storing " << item_name << endl);
 
         // Get an output stream directed at the locked cache file
@@ -732,6 +734,7 @@ GlobalMetadataStore::get_read_lock_helper(const string &name, const string &suff
  }
 
 /**
+ * @Deprecated - 6.25.19 SBL
  * @brief Is the DMR response for \arg name in the MDS?
  *
  * Look in the MDS to see if the DMR response has been stored/cached for
@@ -751,10 +754,59 @@ GlobalMetadataStore::get_read_lock_helper(const string &name, const string &suff
 GlobalMetadataStore::MDSReadLock
 GlobalMetadataStore::is_dmr_available(const string &name)
 {
-    return get_read_lock_helper(name, "dmr_r", "DMR");
-}
+	return get_read_lock_helper(name,"dmr_r","DMR");
+}//end is_dmr_available(string)
+
+GlobalMetadataStore::MDSReadLock
+GlobalMetadataStore::is_dmr_available(const BESContainer &container)
+{
+	//call get_read_lock_helper
+	MDSReadLock lock = get_read_lock_helper(container.get_relative_name(), "dmr_r", "DMR");
+	if (lock()){
+
+		bool reload = is_available_helper(container.get_real_name(), container.get_relative_name(), container.get_container_type(), "dmr_r");
+
+		if(reload){
+			lock.clearLock();
+			return lock;
+		}//end if
+		else{
+			return lock;
+		}//end else
+
+	}//end if(is locked)
+	else{
+		return lock;
+	}//end else
+
+}//end is_dmr_available(BESContainer)
+
+GlobalMetadataStore::MDSReadLock
+GlobalMetadataStore::is_dmr_available(const std::string &realName, const std::string &relativeName, const std::string &fileType)
+{
+	//call get_read_lock_helper
+	MDSReadLock lock = get_read_lock_helper(relativeName,"dmr_r","DMR");
+	if (lock()){
+
+		bool reload = is_available_helper(realName, relativeName, fileType, "dmr_r");
+
+		if(reload){
+			lock.clearLock();
+			return lock;
+		}//end if
+		else{
+			return lock;
+		}//end else
+
+	}//end if(is locked)
+	else{
+		return lock;
+	}//end else
+
+}//end is_dmr_available(string, string, string)
 
 /**
+ * @Deprecated - 6.25.19 SBL
  * @brief Is the DDS response for \arg name in the MDS?
  * @param name Find the DDS response for \arg name.
  * @return A MDSReadLock object.
@@ -763,10 +815,35 @@ GlobalMetadataStore::is_dmr_available(const string &name)
 GlobalMetadataStore::MDSReadLock
 GlobalMetadataStore::is_dds_available(const string &name)
 {
-    return get_read_lock_helper(name, "dds_r", "DDS");
-}
+	return get_read_lock_helper(name,"dds_r","DDS");
+}//end is_dds_available(string)
+
+GlobalMetadataStore::MDSReadLock
+GlobalMetadataStore::is_dds_available(const BESContainer &container)
+{
+	//call get_read_lock_helper
+	MDSReadLock lock = get_read_lock_helper(container.get_relative_name(),"dds_r","DDS");
+	if (lock()){
+
+		bool reload = is_available_helper(container.get_real_name(), container.get_relative_name(), container.get_container_type(), "dds_r");
+
+		if(reload){
+			lock.clearLock();
+			return lock;
+		}//end if
+		else{
+			return lock;
+		}//end else
+
+	}//end if(is locked)
+	else{
+		return lock;
+	}//end else
+
+}//end is_dds_available(BESContainer)
 
 /**
+ * @Deprecated - 6.25.19 SBL
  * @brief Is the DAS response for \arg name in the MDS?
  * @param name Find the DAS response for \arg name.
  * @return A MDSReadLock object.
@@ -775,10 +852,36 @@ GlobalMetadataStore::is_dds_available(const string &name)
 GlobalMetadataStore::MDSReadLock
 GlobalMetadataStore::is_das_available(const string &name)
 {
-    return get_read_lock_helper(name, "das_r", "DAS");
-}
+	return get_read_lock_helper(name,"das_r","DAS");
+}//end is_das_available(string)
+
+GlobalMetadataStore::MDSReadLock
+GlobalMetadataStore::is_das_available(const BESContainer &container)
+{
+    //return get_read_lock_helper(name, "das_r", "DAS");
+	//call get_read_lock_helper
+	MDSReadLock lock = get_read_lock_helper(container.get_relative_name(),"das_r","DAS");
+	if (lock()){
+
+		bool reload = is_available_helper(container.get_real_name(), container.get_relative_name(), container.get_container_type(), "das_r");
+
+		if(reload){
+			lock.clearLock();
+			return lock;
+		}//end if
+		else{
+			return lock;
+		}//end else
+
+	}//end if(is locked)
+	else{
+		return lock;
+	}//end else
+
+}//end is_das_available(BESContainer)
 
 /**
+ * @Deprecated - 6.25.19 SBL
  * @brief Is the DMR++ response for \arg name in the MDS?
  *
  * Look in the MDS to see if the DMR++ response has been stored/cached for
@@ -798,8 +901,84 @@ GlobalMetadataStore::is_das_available(const string &name)
 GlobalMetadataStore::MDSReadLock
 GlobalMetadataStore::is_dmrpp_available(const string &name)
 {
-    return get_read_lock_helper(name, "dmrpp_r", "DMR++");
+	return get_read_lock_helper(name,"dmrpp_r","DMR++");
+}//end is_dmrpp_available(string)
+
+GlobalMetadataStore::MDSReadLock
+GlobalMetadataStore::is_dmrpp_available(const BESContainer &container)
+{
+    //return get_read_lock_helper(name, "dmrpp_r", "DMR++");
+	//call get_read_lock_helper
+	MDSReadLock lock = get_read_lock_helper(container.get_relative_name(),"dmrpp_r","DMR++");
+	if (lock()){
+
+		bool reload = is_available_helper(container.get_real_name(), container.get_relative_name(), container.get_container_type(), "dmrpp_r");
+
+		if(reload){
+			lock.clearLock();
+			return lock;
+		}//end if
+		else{
+			return lock;
+		}//end else
+
+	}//end if(is locked)
+	else{
+		return lock;
+	}//end else
+
+}//end is_dmrpp_available(BESContainer)
+
+/**
+ * @brief helper function that checks if last modified time is greater than cached file
+ *
+ * @param realName - complete path to file used to find actual file
+ * @param relativeName - relative filename used to find cached file
+ * @param fileType - used to retrieve correct BESRequestHandler from BESRequestHandlerList
+ * @param suffix - One of 'dmr_r', 'dds_r', 'das_r' or 'dmrpp_r'
+ *
+ * @return true if actual file has been modified since cached file has been created, false otherwiseS
+ */
+bool
+GlobalMetadataStore::is_available_helper(const string &realName, const string &relativeName, const string &fileType, const string &suffix)
+{
+	//use type with find_handler() to get handler
+	BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler(fileType);
+
+	//use handler.get_lmt()
+	time_t file_time = besRH->get_lmt(realName);
+
+	//get the cache time of the handler
+	time_t cache_time = get_cache_lmt(relativeName, suffix);
+
+	//compare file lmt and time of creation of cache
+	if (file_time > cache_time){
+		return true;
+	}//end if(file > cache)
+	else {
+		return false;
+	}//end else
 }
+
+/**
+ * @brief Get the last modified time for the cached object file
+ *
+ * @param name - name of the object
+ * @param suffix - suffix of the object
+ * @return The last modified time.
+ */
+time_t
+GlobalMetadataStore::get_cache_lmt(const string &fileName, const string &suffix)
+{
+	string item_name = get_cache_file_name(get_hash(fileName + suffix), false);
+	struct stat statbuf;
+
+	if (stat(item_name.c_str(), &statbuf) == -1){
+		throw BESNotFoundError(strerror(errno), __FILE__, __LINE__);
+	}//end if(error)
+
+	return statbuf.st_mtime;
+}//end get_cache_lmt()
 
 ///@name write_response_helper
 ///@{

--- a/dap/GlobalMetadataStore.h
+++ b/dap/GlobalMetadataStore.h
@@ -30,6 +30,7 @@
 
 #include "BESFileLockingCache.h"
 #include "BESInternalFatalError.h"
+#include "BESContainer.h"
 
 /// Setting XML_BASE_MISSING_MEANS_OMIT_ATTRIBUTE to zero causes the MDS to throw
 /// BESInternalError when the xml:base context is not defined and a DMR/++ response
@@ -197,6 +198,12 @@ public:
         }
 
          virtual bool operator()() { return locked; }
+
+         //used to set 'locked' to false to force reload of file in cache. SBL 6/7/19
+         virtual void clearLock() {
+        	 if (locked) mds->unlock_and_close(name);
+        	 locked = false;
+         }//end clearLock()
      };
 
     typedef struct MDSReadLock MDSReadLock;
@@ -231,9 +238,22 @@ public:
     virtual bool add_responses(libdap::DMR *dmr, const std::string &name);
 
     virtual MDSReadLock is_dmr_available(const std::string &name);
+    virtual MDSReadLock is_dmr_available(const BESContainer &container);
+    //added a third method here to handle case in build_dmrpp.cc - SBL 6.19.19
+    virtual MDSReadLock is_dmr_available(const std::string &realName, const std::string &relativeName, const std::string &fileType);
+
     virtual MDSReadLock is_dds_available(const std::string &name);
+    virtual MDSReadLock is_dds_available(const BESContainer &container);
+
     virtual MDSReadLock is_das_available(const std::string &name);
+    virtual MDSReadLock is_das_available(const BESContainer &container);
+
     virtual MDSReadLock is_dmrpp_available(const std::string &name);
+    virtual MDSReadLock is_dmrpp_available(const BESContainer &container);
+
+    virtual bool is_available_helper(const std::string &realName, const std::string &relativeName, const std::string &fileType, const std::string &suffix);
+
+    virtual time_t get_cache_lmt(const string &fileName, const string &suffix);
 
     virtual void write_dds_response(const std::string &name, std::ostream &os);
     virtual void write_das_response(const std::string &name, std::ostream &os);

--- a/dap/unit-tests/GlobalMetadataStoreTest.cc
+++ b/dap/unit-tests/GlobalMetadataStoreTest.cc
@@ -26,6 +26,7 @@
 
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 
 #include <cppunit/TextTestRunner.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
@@ -49,8 +50,12 @@
 
 #include "TheBESKeys.h"
 #include "BESContextManager.h"
+#include "BESFileContainer.h"
+#include "BESRequestHandlerList.h"
+#include "BESRequestHandler.h"
 #include "BESDebug.h"
 #include "BESInternalError.h"
+#include "BESNotFoundError.h"
 
 #include "GlobalMetadataStore.h"
 
@@ -88,6 +93,9 @@ private:
     string d_mds_dir;
     GlobalMetadataStore *d_mds;
 
+    // BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler(type);
+    BESRequestHandler d_handler;
+
     /**
      * This is like SetUp() but is run selectively by tests. It won't work
      * for all of the tests (like test_ctor_1, where get_instance() should not
@@ -100,6 +108,9 @@ private:
             // of the tests.
             d_mds = GlobalMetadataStore::get_instance(d_mds_dir, c_mds_prefix, 1000);
             DBG(cerr << "Retrieved GlobalMetadataStore object: " << d_mds << endl);
+
+            // Get a DDS to cache.
+            string file_name = string(TEST_BUILD_DIR).append("/input-files/sequence_1.dds");
 
             // Get a DDS to cache.
             d_test_dds = new DDS(&d_btf);
@@ -157,6 +168,8 @@ private:
         }
     }
 
+    string tmp = string(TEST_BUILD_DIR) + "/tmp";
+
 #if 0
     void init_dmrpp_and_mds()
     {
@@ -193,12 +206,16 @@ private:
 
 public:
     GlobalMetadataStoreTest() :
-        d_test_dds(0), d_test_dmr(0), d_mds_dir(string(TEST_BUILD_DIR).append(c_mds_name)), d_mds(0)
+        d_test_dds(0), d_test_dmr(0), d_mds_dir(string(TEST_BUILD_DIR).append(c_mds_name)), d_mds(0),
+		d_handler("test_handler")
     {
+    	BESRequestHandlerList::TheList()->add_handler("test_handler", &d_handler);
+    	mkdir(tmp.c_str(),0755);
     }
 
     ~GlobalMetadataStoreTest()
     {
+    	rmdir(tmp.c_str());
     }
 
     void setUp()
@@ -421,6 +438,1039 @@ public:
 
         DBG(cerr << __func__ << " - END" << endl);
     }
+
+    void get_cache_lmt_test(){
+    	init_dmr_and_mds();
+
+    	string real_name = string(TEST_SRC_DIR) + "/input-files/test_01.dmr";
+		BESFileContainer cont("cont", real_name, "test_handler");
+		cont.set_relative_name("/input-files/test_01.dmr");
+
+		BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	CPPUNIT_ASSERT(besRH != 0);
+
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dmr_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		struct stat statbuf;
+
+    		if (stat(item_name.c_str(), &statbuf) == -1){
+    			throw BESNotFoundError(strerror(errno), __FILE__, __LINE__);
+    		}//end if(error)
+
+    		time_t ctime = statbuf.st_ctime;
+    		DBG(cerr << "ctime: " << ctime << endl);
+    		time_t mtime = d_mds->get_cache_lmt("/input-files/test_01.dmr", "dmr_r");
+    		DBG(cerr << "mtime: " << mtime << endl);
+
+    		bool test = ((ctime - mtime) <= 2);
+    		CPPUNIT_ASSERT(test);
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    }//get_cache_lmt_test()
+
+	void is_available_helper_dmr_test_1(){
+    	init_dmr_and_mds();
+
+    	string real_name = string(TEST_SRC_DIR) + "/input-files/test_01.dmr";
+		BESFileContainer cont("cont", real_name, "test_handler");
+		cont.set_relative_name("/input-files/test_01.dmr");
+
+		BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	CPPUNIT_ASSERT(besRH != 0);
+
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dmr_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		bool reload = d_mds->is_available_helper(cont.get_real_name(), cont.get_relative_name(), cont.get_container_type(), "dmr_r");
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(!reload);
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    }//end is_available_helper_dmr_test_1()
+
+    void is_available_helper_dmr_test_2(){
+    	init_dmr_and_mds();
+
+    	string relative_file = "/tmp/temp_01.dmr";
+    	string real_name = string(TEST_BUILD_DIR) + relative_file;
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name(relative_file);
+
+		BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	CPPUNIT_ASSERT(besRH != 0);
+
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dmr_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		sleep(3);
+
+    		int gd = open(real_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(gd != -1);
+
+    		bool reload = d_mds->is_available_helper(cont.get_real_name(), cont.get_relative_name(), cont.get_container_type(), "dmr_r");
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(reload);
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    	unlink(real_name.c_str());
+    }//end is_available_helper_dmr_test_2()
+
+    void is_available_helper_dds_test_1(){
+    	init_dds_and_mds();
+
+    	string real_name = string(TEST_SRC_DIR) + "/input-files/sequence_1.dds";
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name("/input-files/sequence_1.dds");
+
+		BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	CPPUNIT_ASSERT(besRH != 0);
+
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dds_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		bool reload = d_mds->is_available_helper(cont.get_real_name(), cont.get_relative_name(), cont.get_container_type(), "dds_r");
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(!reload);
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    }//end is_available_helper_dds_test_1()
+
+    void is_available_helper_dds_test_2(){
+    	init_dds_and_mds();
+
+    	string relative_file = "/tmp/temp_02.dds";
+    	string real_name = string(TEST_BUILD_DIR) + relative_file;
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name(relative_file);
+
+		BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	CPPUNIT_ASSERT(besRH != 0);
+
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dds_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		sleep(3);
+
+    		int gd = open(real_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(gd != -1);
+
+    		bool reload = d_mds->is_available_helper(cont.get_real_name(), cont.get_relative_name(), cont.get_container_type(), "dds_r");
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(reload);
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    	unlink(real_name.c_str());
+    }//end is_available_helper_dds_test_2()
+
+    void is_available_helper_das_test_1(){
+    	init_dds_and_mds();
+
+    	string real_name = string(TEST_BUILD_DIR) + "/tmp/test_01.das";
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name("/tmp/test_01.das");
+
+		BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	CPPUNIT_ASSERT(besRH != 0);
+
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "das_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int gd = open(real_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(gd != -1);
+
+    		sleep(3);
+
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		bool reload = d_mds->is_available_helper(cont.get_real_name(), cont.get_relative_name(), cont.get_container_type(), "das_r");
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(!reload);
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    	unlink(real_name.c_str());
+    }//end is_available_helper_das_test_1()
+
+    void is_available_helper_das_test_2(){
+    	init_dds_and_mds();
+
+    	string relative_file = "/tmp/temp_03.das";
+    	string real_name = string(TEST_BUILD_DIR) + relative_file;
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name(relative_file);
+
+		BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	CPPUNIT_ASSERT(besRH != 0);
+
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "das_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		sleep(3);
+
+    		int gd = open(real_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(gd != -1);
+
+    		bool reload = d_mds->is_available_helper(cont.get_real_name(), cont.get_relative_name(), cont.get_container_type(), "das_r");
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(reload);
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    	unlink(real_name.c_str());
+    }//end is_available_helper_das_test_2()
+
+    void is_available_helper_dmrpp_test_1(){
+    	init_dmr_and_mds();
+
+    	string real_name = string(TEST_SRC_DIR) + "/input-files/chunked_fourD.h5.dmrpp";
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name("/input-files/chunked_fourD.h5.dmrpp");
+
+		BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	CPPUNIT_ASSERT(besRH != 0);
+
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dmrpp_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		bool reload = d_mds->is_available_helper(cont.get_real_name(), cont.get_relative_name(), cont.get_container_type(), "dmrpp_r");
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(!reload);
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    }//end is_available_helper_dmrpp_test_1()
+
+    void is_available_helper_dmrpp_test_2(){
+    	init_dmr_and_mds();
+
+    	string relative_file = "/tmp/temp_04.dmrpp";
+    	string real_name = string(TEST_BUILD_DIR) + relative_file;
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name(relative_file);
+
+		BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	CPPUNIT_ASSERT(besRH != 0);
+
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dmrpp_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		sleep(3);
+
+    		int gd = open(real_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(gd != -1);
+
+    		bool reload = d_mds->is_available_helper(cont.get_real_name(), cont.get_relative_name(), cont.get_container_type(), "dmrpp_r");
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(reload);
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    	unlink(real_name.c_str());
+    }//end is_available_helper_dmrpp_test_2()
+
+    // TODO This test depends on the path /relative/name not existing. Fix.
+    void is_dmr_available_test_1() {
+    	init_dmr_and_mds();
+
+    	BESFileContainer cont("cont", "/real/relative/name", "test_handler");
+    	cont.set_relative_name("/relative/name");
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == "/real/relative/name");
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/relative/name");
+
+    	GlobalMetadataStore::MDSReadLock lock = d_mds->is_dmr_available(cont);
+    	CPPUNIT_ASSERT(!lock()); // The path /relative/name should not exist
+    }//end is_dmr_available_test_1()
+
+    void is_dmr_available_test_2() {
+    	init_dmr_and_mds();
+    	// BESFileContainer(const string &sym_name, const string &real_name, const string &type);
+    	string real_name = string(TEST_SRC_DIR) + "/input-files/test_01.dmr";
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name("/input-files/test_01.dmr");
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == real_name);
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/input-files/test_01.dmr");
+
+    	BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	DBG(cerr << "besRH: " << (void*)besRH << endl);
+    	DBG(cerr << "d_handler: " << (void*)&d_handler << endl);
+    	CPPUNIT_ASSERT(besRH != 0);
+    	DBG(cerr << "d_handler.get_name(): " << d_handler.get_name() << endl);
+    	DBG(cerr << "besRH->get_name(): " << besRH->get_name() << endl);
+
+    	//string item_name = get_cache_file_name(get_hash(cont.get_relative_name() + "dmr_r"), false);
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dmr_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		GlobalMetadataStore::MDSReadLock lock = d_mds->is_dmr_available(cont);
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(lock());
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    }//end is_dmr_available_test_2()
+
+    void is_dmr_available_test_3() {
+    	init_dmr_and_mds();
+
+    	// BESFileContainer(const string &sym_name, const string &real_name, const string &type);
+    	string relative_file = "/tmp/temp_01.dmr";
+    	string real_name = string(TEST_BUILD_DIR) + relative_file;
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name(relative_file);
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == real_name);
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/tmp/temp_01.dmr");
+
+    	BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	DBG(cerr << "besRH: " << (void*)besRH << endl);
+    	DBG(cerr << "d_handler: " << (void*)&d_handler << endl);
+    	CPPUNIT_ASSERT(besRH != 0);
+    	DBG(cerr << "d_handler.get_name(): " << d_handler.get_name() << endl);
+    	DBG(cerr << "besRH->get_name(): " << besRH->get_name() << endl);
+
+    	//string item_name = get_cache_file_name(get_hash(cont.get_relative_name() + "dmr_r"), false);
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dmr_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		sleep(3);
+
+    		int gd = open(real_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(gd != -1);
+
+    		GlobalMetadataStore::MDSReadLock lock = d_mds->is_dmr_available(cont);
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(!lock());
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    	unlink(real_name.c_str());
+    }//end is_dmr_available_test_3()
+
+    void is_dmr_available_test_4() {
+    	init_dmr_and_mds();
+    	// BESFileContainer(const string &sym_name, const string &real_name, const string &type);
+    	string real_name = string(TEST_SRC_DIR) + "/input-files/test_01.dmr";
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name("/input-files/test_01.dmr");
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+    	DBG(cerr << "cont.get_container_type: " << cont.get_container_type() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == real_name);
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/input-files/test_01.dmr");
+
+    	BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	DBG(cerr << "besRH: " << (void*)besRH << endl);
+    	DBG(cerr << "d_handler: " << (void*)&d_handler << endl);
+    	CPPUNIT_ASSERT(besRH != 0);
+    	DBG(cerr << "d_handler.get_name(): " << d_handler.get_name() << endl);
+    	DBG(cerr << "besRH->get_name(): " << besRH->get_name() << endl);
+
+    	//string item_name = get_cache_file_name(get_hash(cont.get_relative_name() + "dmr_r"), false);
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dmr_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		GlobalMetadataStore::MDSReadLock lock = d_mds->is_dmr_available(
+    				cont.get_real_name(), cont.get_relative_name(), cont.get_container_type());
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(lock());
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    }//end is_dmr_available_test_4()
+
+    void is_dmr_available_test_5() {
+    	init_dmr_and_mds();
+
+    	// BESFileContainer(const string &sym_name, const string &real_name, const string &type);
+    	string relative_file = "/tmp/temp_01.dmr";
+    	string real_name = string(TEST_BUILD_DIR) + relative_file;
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name(relative_file);
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == real_name);
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/tmp/temp_01.dmr");
+
+    	BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	DBG(cerr << "besRH: " << (void*)besRH << endl);
+    	DBG(cerr << "d_handler: " << (void*)&d_handler << endl);
+    	CPPUNIT_ASSERT(besRH != 0);
+    	DBG(cerr << "d_handler.get_name(): " << d_handler.get_name() << endl);
+    	DBG(cerr << "besRH->get_name(): " << besRH->get_name() << endl);
+
+    	//string item_name = get_cache_file_name(get_hash(cont.get_relative_name() + "dmr_r"), false);
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dmr_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		sleep(3);
+
+    		int gd = open(real_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(gd != -1);
+
+    		GlobalMetadataStore::MDSReadLock lock = d_mds->is_dmr_available(
+    				cont.get_real_name(), cont.get_relative_name(), cont.get_container_type());
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(!lock());
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    	unlink(real_name.c_str());
+    }//end is_dmr_available_test_5()
+
+    // TODO This test depends on the path /relative/name not existing. Fix.
+    void is_dds_available_test_1() {
+    	init_dds_and_mds();
+
+    	BESFileContainer cont("cont", "/real/relative/name", "test_handler");
+    	cont.set_relative_name("/relative/name");
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == "/real/relative/name");
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/relative/name");
+
+    	GlobalMetadataStore::MDSReadLock lock = d_mds->is_dds_available(cont);
+    	CPPUNIT_ASSERT(!lock()); // The path /relative/name should not exist
+    }//end is_dds_available_test_1()
+
+    void is_dds_available_test_2() {
+    	init_dds_and_mds();
+    	// BESFileContainer(const string &sym_name, const string &real_name, const string &type);
+    	string real_name = string(TEST_SRC_DIR) + "/input-files/sequence_1.dds";
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name("/input-files/sequence_1.dds");
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == real_name);
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/input-files/sequence_1.dds");
+
+    	BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	DBG(cerr << "besRH: " << (void*)besRH << endl);
+    	DBG(cerr << "d_handler: " << (void*)&d_handler << endl);
+    	CPPUNIT_ASSERT(besRH != 0);
+    	DBG(cerr << "d_handler.get_name(): " << d_handler.get_name() << endl);
+    	DBG(cerr << "besRH->get_name(): " << besRH->get_name() << endl);
+
+    	//string item_name = get_cache_file_name(get_hash(cont.get_relative_name() + "dmr_r"), false);
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dds_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		GlobalMetadataStore::MDSReadLock lock = d_mds->is_dds_available(cont);
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(lock());
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    }//end is_dds_available_test_2()
+
+    void is_dds_available_test_3() {
+    	init_dds_and_mds();
+    	// BESFileContainer(const string &sym_name, const string &real_name, const string &type);
+    	string relative_file = "/tmp/temp_02.dds";
+    	string real_name = string(TEST_BUILD_DIR) + relative_file;
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name(relative_file);
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == real_name);
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/tmp/temp_02.dds");
+
+    	BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	DBG(cerr << "besRH: " << (void*)besRH << endl);
+    	DBG(cerr << "d_handler: " << (void*)&d_handler << endl);
+    	CPPUNIT_ASSERT(besRH != 0);
+    	DBG(cerr << "d_handler.get_name(): " << d_handler.get_name() << endl);
+    	DBG(cerr << "besRH->get_name(): " << besRH->get_name() << endl);
+
+    	//string item_name = get_cache_file_name(get_hash(cont.get_relative_name() + "dmr_r"), false);
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dds_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		sleep(3);
+
+    		int gd = open(real_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(gd != -1);
+
+    		GlobalMetadataStore::MDSReadLock lock = d_mds->is_dds_available(cont);
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(!lock());
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    	unlink(real_name.c_str());
+    }//end is_dds_available_test_3()
+
+    // TODO This test depends on the path /relative/name not existing. Fix.
+    void is_das_available_test_1() {
+    	init_dds_and_mds();
+
+    	BESFileContainer cont("cont", "/real/relative/name", "test_handler");
+    	cont.set_relative_name("/relative/name");
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == "/real/relative/name");
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/relative/name");
+
+    	GlobalMetadataStore::MDSReadLock lock = d_mds->is_das_available(cont);
+    	CPPUNIT_ASSERT(!lock()); // The path /relative/name should not exist
+    }//end is_das_available_test_1()
+
+    void is_das_available_test_2() {
+    	init_dds_and_mds();
+    	// BESFileContainer(const string &sym_name, const string &real_name, const string &type);
+    	string real_name = string(TEST_BUILD_DIR) + "/tmp/test_01.das";
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name("/tmp/test_01.das");
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == real_name);
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/tmp/test_01.das");
+
+    	BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	DBG(cerr << "besRH: " << (void*)besRH << endl);
+    	DBG(cerr << "d_handler: " << (void*)&d_handler << endl);
+    	CPPUNIT_ASSERT(besRH != 0);
+    	DBG(cerr << "d_handler.get_name(): " << d_handler.get_name() << endl);
+    	DBG(cerr << "besRH->get_name(): " << besRH->get_name() << endl);
+
+    	//string item_name = get_cache_file_name(get_hash(cont.get_relative_name() + "dmr_r"), false);
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "das_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int gd = open(real_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(gd != -1);
+
+    		sleep(3);
+
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		GlobalMetadataStore::MDSReadLock lock = d_mds->is_das_available(cont);
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(lock());
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    	unlink(real_name.c_str());
+    }//end is_das_available_test_2()
+
+    void is_das_available_test_3() {
+    	init_dds_and_mds();
+    	// BESFileContainer(const string &sym_name, const string &real_name, const string &type);
+    	string relative_file = "/tmp/temp_03.das";
+    	string real_name = string(TEST_BUILD_DIR) + relative_file;
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name(relative_file);
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == real_name);
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/tmp/temp_03.das");
+
+    	BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	DBG(cerr << "besRH: " << (void*)besRH << endl);
+    	DBG(cerr << "d_handler: " << (void*)&d_handler << endl);
+    	CPPUNIT_ASSERT(besRH != 0);
+    	DBG(cerr << "d_handler.get_name(): " << d_handler.get_name() << endl);
+    	DBG(cerr << "besRH->get_name(): " << besRH->get_name() << endl);
+
+    	//string item_name = get_cache_file_name(get_hash(cont.get_relative_name() + "dmr_r"), false);
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "das_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		sleep(3);
+
+    		int gd = open(real_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(gd != -1);
+
+    		GlobalMetadataStore::MDSReadLock lock = d_mds->is_das_available(cont);
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(!lock());
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    	unlink(real_name.c_str());
+    }//end is_das_available_test_3()
+
+    // TODO This test depends on the path /relative/name not existing. Fix.
+    void is_dmrpp_available_test_1() {
+    	init_dmr_and_mds();
+
+    	BESFileContainer cont("cont", "/real/relative/name", "test_handler");
+    	cont.set_relative_name("/relative/name");
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == "/real/relative/name");
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/relative/name");
+
+    	GlobalMetadataStore::MDSReadLock lock = d_mds->is_dmrpp_available(cont);
+    	CPPUNIT_ASSERT(!lock()); // The path /relative/name should not exist
+    }//end is_dmr_available_test_1()
+
+    void is_dmrpp_available_test_2() {
+    	init_dmr_and_mds();
+    	// BESFileContainer(const string &sym_name, const string &real_name, const string &type);
+    	string real_name = string(TEST_SRC_DIR) + "/input-files/chunked_fourD.h5.dmrpp";
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name("/input-files/chunked_fourD.h5.dmrpp");
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == real_name);
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/input-files/chunked_fourD.h5.dmrpp");
+
+    	BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	DBG(cerr << "besRH: " << (void*)besRH << endl);
+    	DBG(cerr << "d_handler: " << (void*)&d_handler << endl);
+    	CPPUNIT_ASSERT(besRH != 0);
+    	DBG(cerr << "d_handler.get_name(): " << d_handler.get_name() << endl);
+    	DBG(cerr << "besRH->get_name(): " << besRH->get_name() << endl);
+
+    	//string item_name = get_cache_file_name(get_hash(cont.get_relative_name() + "dmr_r"), false);
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dmrpp_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		GlobalMetadataStore::MDSReadLock lock = d_mds->is_dmrpp_available(cont);
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(lock());
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    }//end is_dmrpp_available_test_2()
+
+    void is_dmrpp_available_test_3() {
+    	init_dmr_and_mds();
+
+    	// BESFileContainer(const string &sym_name, const string &real_name, const string &type);
+    	string relative_file = "/tmp/temp_04.dmrpp";
+    	string real_name = string(TEST_BUILD_DIR) + relative_file;
+    	BESFileContainer cont("cont", real_name, "test_handler");
+    	cont.set_relative_name(relative_file);
+
+    	DBG(cerr << "cont.get_real_name: " << cont.get_real_name() << endl);
+    	DBG(cerr << "cont.get_relative_name: " << cont.get_relative_name() << endl);
+
+    	CPPUNIT_ASSERT(cont.get_real_name() == real_name);
+    	CPPUNIT_ASSERT(cont.get_relative_name() == "/tmp/temp_04.dmrpp");
+
+    	BESRequestHandler *besRH = BESRequestHandlerList::TheList()->find_handler("test_handler");
+    	DBG(cerr << "besRH: " << (void*)besRH << endl);
+    	DBG(cerr << "d_handler: " << (void*)&d_handler << endl);
+    	CPPUNIT_ASSERT(besRH != 0);
+    	DBG(cerr << "d_handler.get_name(): " << d_handler.get_name() << endl);
+    	DBG(cerr << "besRH->get_name(): " << besRH->get_name() << endl);
+
+    	//string item_name = get_cache_file_name(get_hash(cont.get_relative_name() + "dmr_r"), false);
+    	string hash_name = d_mds->get_hash(cont.get_relative_name() + "dmrpp_r");
+    	DBG(cerr << "hash_name: " << hash_name << endl);
+
+    	string item_name = d_mds->get_cache_file_name(hash_name, false /*mangle*/);
+    	DBG(cerr << "item_name: " << item_name << endl);
+
+    	try {
+    		int fd = open(item_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(fd != -1);
+
+    		sleep(3);
+
+    		int gd = open(real_name.c_str(), O_RDWR | O_CREAT, 00664 /*mode = rw rw r*/);
+    		CPPUNIT_ASSERT(gd != -1);
+
+    		GlobalMetadataStore::MDSReadLock lock = d_mds->is_dmrpp_available(cont);
+    		// since the cache file is newer than the 'real' file, we should have the lock
+    		CPPUNIT_ASSERT(!lock());
+    	}
+    	catch (BESError &e) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		ostringstream oss;
+    		oss << "Error: " << e.get_message() << " " << e.get_file() << ":" << e.get_line();
+    		CPPUNIT_FAIL(oss.str());
+    	}
+    	catch (...) {
+    		unlink(item_name.c_str());
+    		unlink(real_name.c_str());
+    		throw;
+    	}
+
+    	// TODO The clean_cache_dir() function hangs if this file is left in the cache
+    	unlink(item_name.c_str());
+    	unlink(real_name.c_str());
+    }//end is_dmrpp_available_test_3()
+
 
 #if 0
     void cache_a_dmrpp_response()
@@ -1017,6 +2067,38 @@ public:
     CPPUNIT_TEST(cache_a_dds_response);
     CPPUNIT_TEST(cache_a_das_response);
     CPPUNIT_TEST(cache_a_dmr_response);
+
+    CPPUNIT_TEST(get_cache_lmt_test);
+
+    CPPUNIT_TEST(is_available_helper_dmr_test_1);
+    CPPUNIT_TEST(is_available_helper_dmr_test_2);
+
+    CPPUNIT_TEST(is_available_helper_dds_test_1);
+    CPPUNIT_TEST(is_available_helper_dds_test_2);
+
+    CPPUNIT_TEST(is_available_helper_das_test_1);
+    CPPUNIT_TEST(is_available_helper_das_test_2);
+
+    CPPUNIT_TEST(is_available_helper_dmrpp_test_1);
+    CPPUNIT_TEST(is_available_helper_dmrpp_test_2);
+
+    CPPUNIT_TEST(is_dmr_available_test_1);
+    CPPUNIT_TEST(is_dmr_available_test_2);
+    CPPUNIT_TEST(is_dmr_available_test_3);
+    CPPUNIT_TEST(is_dmr_available_test_4);
+    CPPUNIT_TEST(is_dmr_available_test_5);
+
+    CPPUNIT_TEST(is_dds_available_test_1);
+    CPPUNIT_TEST(is_dds_available_test_2);
+    CPPUNIT_TEST(is_dds_available_test_3);
+
+    CPPUNIT_TEST(is_das_available_test_1);
+    CPPUNIT_TEST(is_das_available_test_2);
+    CPPUNIT_TEST(is_das_available_test_3);
+
+    CPPUNIT_TEST(is_dmrpp_available_test_1);
+    CPPUNIT_TEST(is_dmrpp_available_test_2);
+    CPPUNIT_TEST(is_dmrpp_available_test_3);
 
     CPPUNIT_TEST(add_response_test);
 

--- a/dap/unit-tests/bes.conf.in
+++ b/dap/unit-tests/bes.conf.in
@@ -3,3 +3,6 @@
 
 BES.LogName=./bes.log
 BES.LogVerbose=yes
+
+DAP.GlobalMetadataStore.path=@abs_top_builddir@/dap/unit-tests/mds
+DAP.GlobalMetadataStore.prefix=mds_

--- a/dispatch/BESRegex.cc
+++ b/dispatch/BESRegex.cc
@@ -93,6 +93,9 @@ BESRegex::BESRegex(const char* t, int)
 }
 
 /** Does the regular expression match the string? 
+ *  Warning : this function can be used to match strings of zero length
+ *  	if the regex pattern accepts empty strings.
+ *  Therefore this function returns -1 if the pattern does not match.
 
     @param s The string
     @param len The length of string to consider
@@ -109,7 +112,7 @@ BESRegex::match(const char* s, int len, int pos)
                          ss.substr(pos, len-pos).c_str(), len, pmatch, 0);
 	int matchnum;
     if (result == REG_NOMATCH)
-        matchnum = -1;
+        matchnum = -1; //returns -1 due to function being able to match strings of 0 length
 	else
 		matchnum = pmatch[0].rm_eo - pmatch[0].rm_so;
 		
@@ -126,7 +129,7 @@ BESRegex::match(const char* s, int len, int pos)
     value-result parameter.
     @param pos Start looking at this position in the string
     @return The start position of the first match. This is different from 
-    POSIX regular expressions, whcih return the start position of the 
+    POSIX regular expressions, which return the start position of the
     longest match. */
 int 
 BESRegex::search(const char* s, int len, int& matchlen, int pos)

--- a/dispatch/BESRequestHandler.cc
+++ b/dispatch/BESRequestHandler.cc
@@ -30,7 +30,12 @@
 //      pwest       Patrick West <pwest@ucar.edu>
 //      jgarcia     Jose Garcia <jgarcia@ucar.edu>
 
+#include <sys/stat.h>
+#include <string.h>
+
 #include "BESRequestHandler.h"
+#include "BESNotFoundError.h"
+
 
 /** @brief add a handler method to the request handler that knows how to fill
  * in a specific response object
@@ -113,6 +118,30 @@ string BESRequestHandler::get_method_names()
     }
     return ret;
 }
+
+/**
+ * @brief Get the Last modified time for \arg name
+ *
+ * Handlers that need a more sophisticated method should subclass.
+ *
+ * @param name
+ * @return The LMT
+ */
+time_t BESRequestHandler::get_lmt(const string &name){
+// 5/31/19 - SBL - Initial code
+// 6/03/19 - SBL - using BESUtil::pathConcat and throws BESNotFoundError
+    // Get the bes catalog root path from the conf info
+    //string root_dir = TheBESKeys::TheKeys()->read_string_key("BES.Catalog.catalog.RootDirectory", "");
+    // Get the name's LMT from the file system
+    //string filepath = BESUtil::pathConcat(root_dir, name, '/');
+    struct stat statbuf;
+    if (stat(name.c_str(), &statbuf) == -1){
+    	//perror(filepath);
+    	throw BESNotFoundError(strerror(errno), __FILE__, __LINE__);
+    }//end if
+
+    return statbuf.st_mtime;
+}//end get_lmt()
 
 /** @brief dumps information about this object
  *

--- a/dispatch/BESRequestHandler.h
+++ b/dispatch/BESRequestHandler.h
@@ -110,6 +110,7 @@ public:
     virtual p_request_handler_method find_method(const string &name);
 
     virtual string get_method_names();
+    virtual time_t get_lmt(const std::string &name);
 
     virtual void dump(ostream &strm) const;
 };

--- a/dispatch/BESRequestHandlerList.h
+++ b/dispatch/BESRequestHandlerList.h
@@ -1,4 +1,4 @@
-// BESRequestHandlerList.h
+	// BESRequestHandlerList.h
 
 // This file is part of bes, A C++ back-end server implementation framework
 // for the OPeNDAP Data Access Protocol.

--- a/dispatch/WhiteList.cc
+++ b/dispatch/WhiteList.cc
@@ -36,6 +36,7 @@
 #include <BESInternalError.h>
 #include <BESSyntaxUserError.h>
 #include <BESDebug.h>
+#include <BESNotFoundError.h>
 #include <BESForbiddenError.h>
 
 #include "WhiteList.h"
@@ -110,12 +111,52 @@ bool WhiteList::is_white_listed(const std::string &url)
 
         string catalog_root = bcat->get_root();
         BESDEBUG("bes", "WhiteList::Is_Whitelisted() - Catalog root: "<< catalog_root << endl);
-        int ret = file_path.compare(0, catalog_root.npos, catalog_root) == 0;
+
+
+        // Never a relative path shall be accepted.
+        // change??
+       // if( file_path[0] != '/'){
+       //     file_path.insert(0,"/");
+        //}
+
+        string relative_path;
+        if(file_path[0] == '/'){
+            if(file_path.length() < catalog_root.length()) {
+                whitelisted = false;
+            }
+            else {
+                int ret = file_path.compare(0, catalog_root.npos, catalog_root) == 0;
+                BESDEBUG("bes", "WhiteList::Is_Whitelisted() - file_path.compare(): " << ret << endl);
+                whitelisted = (ret==0);
+                relative_path = file_path.substr(catalog_root.length());
+            }
+        }
+        else {
+            BESDEBUG("bes", "WhiteList::Is_Whitelisted() - relative path detected");
+            relative_path = file_path;
+            whitelisted = true;
+        }
+
         // string::compare() returns 0 if the path strings match exactly.
         // And since we are just looking at the catalog.root as a prefix of the resource
         // name we only allow to be white-listed for an exact match.
-        whitelisted=(ret==0);
-        BESDEBUG("bes", "WhiteList::Is_Whitelisted() - Is_Whitelisted: "<< (whitelisted?"true ":"false ") << "(ret: " << ret << ")" << endl);
+        if(whitelisted){
+            // If we stop adding a '/' to file_path values that don't begin with one
+            // then we need to detect the use of the relative path here
+            bool follow_sym_links = bcat->get_catalog_utils()->follow_sym_links();
+            try {
+                BESUtil::check_path(relative_path, catalog_root, follow_sym_links);
+            }
+            catch (BESNotFoundError &e) {
+                whitelisted=false;
+            }
+            catch (BESForbiddenError &e) {
+                whitelisted=false;
+            }
+        }
+
+
+        BESDEBUG("bes", "WhiteList::Is_Whitelisted() - Is_Whitelisted: "<< (whitelisted?"true ":"false ") << endl);
     }
     else {
         // This checks HTTP and HTTPS URLs against the whitelist patterns.

--- a/dispatch/WhiteList.cc
+++ b/dispatch/WhiteList.cc
@@ -110,9 +110,12 @@ bool WhiteList::is_white_listed(const std::string &url)
 
         string catalog_root = bcat->get_root();
         BESDEBUG("bes", "WhiteList::Is_Whitelisted() - Catalog root: "<< catalog_root << endl);
-
-        whitelisted = file_path.compare(0, catalog_root.size(), catalog_root) == 0;
-        BESDEBUG("bes", "WhiteList::Is_Whitelisted() - Is_Whitelisted: "<< (whitelisted?"true":"false") << endl);
+        int ret = file_path.compare(0, catalog_root.npos, catalog_root) == 0;
+        // string::compare() returns 0 if the path strings match exactly.
+        // And since we are just looking at the catalog.root as a prefix of the resource
+        // name we only allow to be white-listed for an exact match.
+        whitelisted=(ret==0);
+        BESDEBUG("bes", "WhiteList::Is_Whitelisted() - Is_Whitelisted: "<< (whitelisted?"true ":"false ") << "(ret: " << ret << ")" << endl);
     }
     else {
         // This checks HTTP and HTTPS URLs against the whitelist patterns.

--- a/dispatch/unit-tests/WhiteListTest.cc
+++ b/dispatch/unit-tests/WhiteListTest.cc
@@ -142,7 +142,7 @@ public:
         CPPUNIT_ASSERT(
             can_access("http://cloudydap.opendap.org/opendap/Arch-2/ebs/samples/3A-MO.GPM.GMI.GRID2014R1.20140601-S000000-E235959.06.V03A.h5"));
 
-        CPPUNIT_ASSERT(!can_access("file://foo"));
+        CPPUNIT_ASSERT(!can_access("file:///foo"));
 
         CPPUNIT_ASSERT(can_access(BESUtil::assemblePath(catalog_root_url, "nc/fnoc1.nc")));
 

--- a/dispatch/unit-tests/WhiteListTest.cc
+++ b/dispatch/unit-tests/WhiteListTest.cc
@@ -113,7 +113,8 @@ public:
 
     CPPUNIT_TEST_SUITE( RemoteAccessTest );
 
-    CPPUNIT_TEST(do_test);
+    CPPUNIT_TEST(do_http_test);
+    CPPUNIT_TEST(do_file_test);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -125,28 +126,50 @@ public:
         return result;
     }
 
-    void do_test()
+    void do_http_test()
     {
-        string catalog_root_url = "file://" + catalog_root_dir;
-
         CPPUNIT_ASSERT(!can_access("http://google.com"));
-
         CPPUNIT_ASSERT(can_access("http://test.opendap.org/opendap/data/nc/fnoc1.nc"));
-
         CPPUNIT_ASSERT(can_access("https://s3.amazonaws.com/somewhereovertherainbow/data/nc/fnoc1.nc"));
         CPPUNIT_ASSERT(!can_access("http://s3.amazonaws.com/somewhereovertherainbow/data/nc/fnoc1.nc"));
-
         CPPUNIT_ASSERT(can_access("http://thredds.ucar.edu/thredds/dodsC/data/nc/fnoc1.nc"));
         CPPUNIT_ASSERT(!can_access("https://thredds.ucar.edu/thredds/dodsC/data/nc/fnoc1.nc"));
-
         CPPUNIT_ASSERT(
             can_access("http://cloudydap.opendap.org/opendap/Arch-2/ebs/samples/3A-MO.GPM.GMI.GRID2014R1.20140601-S000000-E235959.06.V03A.h5"));
 
+    }
+    void do_file_test()
+    {
+
+
+        /* Listing the data dir...
+
+            ls -1 CATALOG_ROOT
+
+            CATALOG_ROOT:
+                README
+                file1
+                file2
+                keys_test_m3.ini
+                child_dir:
+                    child_file.conf
+                    child_file1
+         */
+        string catalog_root_url = "file://" + catalog_root_dir;
+
+        // Rejected Does not exist in catalog_root
         CPPUNIT_ASSERT(!can_access("file:///foo"));
 
-        CPPUNIT_ASSERT(can_access(BESUtil::assemblePath(catalog_root_url, "nc/fnoc1.nc")));
+        // Accepted - Relative path successful access
+        CPPUNIT_ASSERT(can_access("file://child_dir/child_file1"));
 
+        // Accepted - Absolute path successful access
+        CPPUNIT_ASSERT(can_access(BESUtil::assemblePath(catalog_root_url, "child_dir/child_file1")));
+
+        // Rejected - does not exist in catalog_root
         CPPUNIT_ASSERT(!can_access("file://tmp/data/nc/fnoc1.nc"));
+
+        // Rejected - does not begin with catalog_root
         CPPUNIT_ASSERT(!can_access("file:///etc/password"));
     }
 };

--- a/functions/stare/stareMapping.cc
+++ b/functions/stare/stareMapping.cc
@@ -10,8 +10,7 @@
  *      																*
  ********************************************************************/
 
-#include "SpatialIndex.h"
-#include "SpatialInterface.h"
+#include "STARE.h"
 
 #include <D4Connect.h>
 #include <Connect.h>
@@ -42,22 +41,20 @@ struct coords {
 };
 
 /**
- * @brief Compute STARE indices and tie the values to x/y coords using lat/lon referenced by data url.
- * @param dataUrl
- * @param level
- * @param buildlevel
- * @param keyVals return value param containing the STARE info
+ * @brief Returns a an array of coords where each entry holds the x and y values
+ *  that correlate to the lat and lon values generated from the url
+ * @param url
+ * @return coords
  */
-void findLatLon(std::string dataUrl, const float64 level,
-	const float64 buildlevel, vector<int> &xArray, vector<int> &yArray, vector<float> &latArray, vector<float> &lonArray, vector<uint64> &stareArray) {
-	//Create an htmInterface that will be used to get the STARE index
-	htmInterface htm(level, buildlevel);
-	const SpatialIndex &index = htm.index();
-
+vector<coords> readUrl(string dataUrl, string latName, string lonName) {
 	auto_ptr < libdap::Connect > url(new libdap::Connect(dataUrl));
+
+	string latlonName = latName + "," + lonName;
 
 	std::vector<float> lat;
 	std::vector<float> lon;
+
+	vector<coords> indexArray;
 
 	try {
 		libdap::BaseTypeFactory factory;
@@ -66,13 +63,13 @@ void findLatLon(std::string dataUrl, const float64 level,
 		VERBOSE(cerr << "\n\n\tRequesting data from " << dataUrl << endl);
 
 		//Makes sure only the Latitude and Longitude variables are requested
-		url->request_data(dds, "Latitude,Longitude");
+		url->request_data(dds, latlonName);
 
 		//Create separate libdap arrays to store the lat and lon arrays individually
 		libdap::Array *urlLatArray = dynamic_cast<libdap::Array *>(dds.var(
-				"Latitude"));
+				latName));
 		libdap::Array *urlLonArray = dynamic_cast<libdap::Array *>(dds.var(
-				"Longitude"));
+				lonName));
 
 		// ----Error checking---- //
 		if (urlLatArray == 0 || urlLonArray == 0) {
@@ -110,33 +107,11 @@ void findLatLon(std::string dataUrl, const float64 level,
 		VERBOSE(cerr << "\tsize of lon array: " << lon.size() << endl);
 
 		coords indexVals = coords();
-		std::unordered_map<float, struct coords> indexMap;
-
-#if 0
-		//Taken out because CF doesn't support compound types,
-		//	so each variable will need to be stored in its own array
-		// -kln 5/17/19
-
-		//Array to store the key and values of the indexMap that will be used to write the hdf5 file
-		keyVals.resize(size_x * size_y);
-#endif
-
-		xArray.resize(lat.size());
-		yArray.resize(lat.size());
-		latArray.resize(lat.size());
-		lonArray.resize(lat.size());
-		stareArray.resize(lat.size());
 
 		//Declare the beginning of the vectors here rather than inside the loop to save compute time
 		//vector<float>::iterator i_begin = lat.begin();		FIXME: Probably not needed since we just use a single dimension array
 		vector<float>::iterator j_begin = lon.begin();
 
-		int arrayLoc = 0;
-
-		VERBOSE (cerr << "\nCalculating the STARE indices" << endl);
-
-		//Make a separate iterator to point at the lat vector and the lon vector inside the same loop.
-		// Then, loop through the lat and lon arrays at the same time
 		for (vector<float>::iterator i = lat.begin(), e = lat.end(), j =
 				lon.begin(); i != e; ++i, ++j) {
 			//Use an offset since we are using a 1D array and treating it like a 2D array
@@ -145,46 +120,64 @@ void findLatLon(std::string dataUrl, const float64 level,
 			indexVals.y = offset % (size_x - 1);//Get the current index for the lat
 			indexVals.lat = *i;
 			indexVals.lon = *j;
-			indexVals.stareIndex = index.idByLatLon(*i, *j);//Use the lat/lon values to calculate the Stare index
 
-			//Map the STARE index value to the x,y indices
-			indexMap[indexVals.stareIndex] = indexVals;
-
-			//Store the values calculated for indexVals and store them in their arrays to be used in the hdf5 file
-			xArray[arrayLoc] = indexVals.x;
-			yArray[arrayLoc] = indexVals.y;
-			latArray[arrayLoc] = *i;
-			lonArray[arrayLoc] = *j;
-			stareArray[arrayLoc] = indexVals.stareIndex;
-
-#if 0
-			//Taken out because CF doesn't support compound types,
-			//	so each variable will need to be stored in its own array
-			// -kln 5/17/19
-
-			//Store the same previous values inside the coords vector for use in the hdf5 file
-			keyVals[arrayLoc].x = indexVals.x;
-			keyVals[arrayLoc].y = indexVals.y;
-			keyVals[arrayLoc].lat = *i;
-			keyVals[arrayLoc].lon = *j;
-			keyVals[arrayLoc].stareIndex = indexVals.stareIndex;
-#endif
-
-			arrayLoc++;
+			indexArray.push_back(indexVals);
 		}
 
 	} catch (libdap::Error &e) {
 		cerr << "ERROR: " << e.get_error_message() << endl;
 	}
+
+	return indexArray;
 }
 
+/**
+ * @brief Use the coords struct to calculate the stare index based on the lat/lon values
+ * @param latlonVals
+ * @param level
+ * @param buildlevel
+ */
+vector<uint64> calculateStareIndex(const float64 level, const float64 buildlevel, vector<coords> latlonVals) {
+	//Create an htmInterface that will be used to get the STARE index
+	//htmInterface htm(level, buildlevel);
+	//const SpatialIndex &index = htm.index();
+	STARE index(level,buildlevel);
+
+	vector<uint64> stareVals;
+	uint64 stareIndex;
+
+	std::unordered_map<float, struct coords> indexMap;
+
+	for (vector<coords>::iterator i = latlonVals.begin(); i != latlonVals.end(); ++i) {
+		stareIndex = index.ValueFromLatLonDegrees(i->lat, i->lon, level);
+		stareVals.push_back(stareIndex);
+
+		//Map the stare values to its corresponding lat/lon and the iterators x/y
+		indexMap[stareIndex] = *i;
+	}
+
+	return stareVals;
+}
 
 /*************
  * HDF5 Stuff *
  *************/
-void writeHDF5(const string &filename, const vector<int> &xArray, const vector<int> &yArray, const vector<float> &latArray, const vector<float> &lonArray, const vector<uint64> &stareArray) {
+void writeHDF5(const string &filename, vector<coords> coordVals, vector<uint64> stareVals) {
 	hid_t file, datasetX, datasetY, datasetLat, datasetLon, datasetStare;
 	hid_t dataspace; /* handle */
+
+	//Need to store each value in its own array
+	vector<int> xArray;
+	vector<int> yArray;
+	vector<float> latArray;
+	vector<float> lonArray;
+
+	for (vector<coords>::iterator i = coordVals.begin(); i != coordVals.end(); ++i) {
+		xArray.push_back(i->x);
+		yArray.push_back(i->y);
+		latArray.push_back(i->lat);
+		lonArray.push_back(i->lon);
+	}
 
 	//Used to store the the size of the array.
 	// In other cases where the array is more than 1 dimension each dimension's length would be stored in this array.
@@ -268,7 +261,7 @@ void writeHDF5(const string &filename, const vector<int> &xArray, const vector<i
 	H5Dwrite(datasetY, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &yArray[0]);
 	H5Dwrite(datasetLat, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &latArray[0]);
 	H5Dwrite(datasetLon, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &lonArray[0]);
-	H5Dwrite(datasetStare, H5T_NATIVE_INT64, H5S_ALL, H5S_ALL, H5P_DEFAULT, &stareArray[0]);
+	H5Dwrite(datasetStare, H5T_NATIVE_INT64, H5S_ALL, H5S_ALL, H5P_DEFAULT, &stareVals[0]);
 
 	/*
 	 * Close/release resources.
@@ -293,7 +286,7 @@ int main(int argc, char *argv[]) {
 	while ((c = getopt(argc, argv, "hvo:")) != -1) {
 		switch (c) {
 		case 'h':
-			cerr << "\nbuild_sidecar [options] <filename> level buildlevel\n\n";
+			cerr << "\nbuild_sidecar [options] <filename> latitude-name longitude-name level buildlevel\n\n";
 			cerr << "-o output file: \tOutput the STARE data to the given output file\n\n";
 			cerr << "-v verbose\n" << endl;
 			exit(1);
@@ -308,7 +301,9 @@ int main(int argc, char *argv[]) {
 	}
 
 	//Argument values
-	string dataUrl = argv[argc-3];
+	string dataUrl = argv[argc-5];
+	string latName = argv[argc-4];
+	string lonName = argv[argc-3];
 	float level = atof(argv[argc-2]);
 	float build_level = atof(argv[argc-1]);
 
@@ -318,14 +313,10 @@ int main(int argc, char *argv[]) {
 	}*/
 
 	try {
-		//Need to store each value in its own array
-		vector<int> xVals;
-		vector<int> yVals;
-		vector<float> latVals;
-		vector<float> lonVals;
-		vector<uint64> stareVals;
 
-		findLatLon(dataUrl, level, build_level, xVals, yVals, latVals, lonVals, stareVals);
+		vector<coords> coordResults = readUrl(dataUrl, latName, lonName);
+
+		vector<uint64> stareResults = calculateStareIndex(level, build_level, coordResults);
 #if 0
 		//Taken out because CF doesn't support compound types,
 		//	so each variable will need to be stored in its own array
@@ -345,7 +336,7 @@ int main(int argc, char *argv[]) {
 			newName = granuleName.substr(0, findDot) + "_sidecar.h5";
 		}
 
-		writeHDF5(newName, xVals, yVals, latVals, lonVals, stareVals);
+		writeHDF5(newName, coordResults, stareResults);
 	}
 	catch(libdap::Error &e) {
 		cerr << "Error: " << e.get_error_message() << endl;

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -276,6 +276,81 @@ void DmrppArray::insert_constrained_contiguous(Dim_iter dimIter, unsigned long *
 }
 
 /**
+ * @brief Thread to insert data from one chunk
+ *
+ * @param arg_list
+ */
+void *one_chunk_unconstrained_thread(void *arg_list)
+{
+    one_chunk_unconstrained_args *args = reinterpret_cast<one_chunk_unconstrained_args*>(arg_list);
+
+    try {
+        process_one_chunk_unconstrained(args->chunk, args->array, args->array_shape, args->chunk_shape);
+    }
+    catch (BESError &error) {
+        write(args->fds[1], &args->tid, sizeof(args->tid));
+        delete args;
+        pthread_exit(new string(error.get_verbose_message()));
+    }
+
+    // tid is a char and thus us written atomically. Writing this tells the parent
+    // thread the child is complete and it should call pthread_join(tid, ...)
+    write(args->fds[1], &args->tid, sizeof(args->tid));
+
+    delete args;
+    pthread_exit(NULL);
+}
+
+/**
+ * @brief Manage parallel transfer for contiguous data
+ *
+ * Read data for one of the 'child chunks' made to read data for a variable
+ * with contiguous storage in parallel.
+ *
+ * @param arg_list
+ */
+void *one_child_chunk_thread(void *arg_list)
+{
+    one_child_chunk_args *args = reinterpret_cast<one_child_chunk_args*>(arg_list);
+
+    try {
+        args->child_chunk->read_chunk();
+
+        assert(args->master_chunk->get_rbuf());
+        assert(args->child_chunk->get_rbuf());
+        assert(args->child_chunk->get_bytes_read() == args->child_chunk->get_size());
+
+        // master offset \/
+        // master chunk:  mmmmmmmmmmmmmmmm
+        // child chunks:  1111222233334444 (there are four child chunks)
+        // child offsets: ^   ^   ^   ^
+        // For this example, child_1_offset - master_offset == 0 (that's always true)
+        // child_2_offset - master_offset == 4; child_2_offset - master_offset == 8
+        // and child_3_offset - master_offset == 12.
+        // Those are the starting locations with in the data buffer of the master chunk
+        // where that child chunk should be written.
+        // Note: all of the offset values start at the begining of the file.
+
+        unsigned int offset_within_master_chunk = args->child_chunk->get_offset() - args->master_chunk->get_offset();
+
+        memcpy(args->master_chunk->get_rbuf() + offset_within_master_chunk, args->child_chunk->get_rbuf(), args->child_chunk->get_bytes_read());
+    }
+    catch (BESError &error) {
+        write(args->fds[1], &args->tid, sizeof(args->tid));
+
+        delete args;
+        pthread_exit(new string(error.get_verbose_message()));
+    }
+
+    // tid is a char and thus us written atomically. Writing this tells the parent
+    // thread the child is complete and it should call pthread_join(tid, ...)
+    write(args->fds[1], &args->tid, sizeof(args->tid));
+
+    delete args;
+    pthread_exit(NULL);
+}
+
+/**
  * @brief Read an array that is stored using one 'chunk.'
  *
  * @return Always returns true, matching the libdap::Array::read() behavior.
@@ -290,17 +365,148 @@ void DmrppArray::read_contiguous()
 
     if (chunk_refs.size() != 1) throw BESInternalError(string("Expected only a single chunk for variable ") + name(), __FILE__, __LINE__);
 
-    Chunk &chunk = chunk_refs[0];
+    // This is the original chunk for this 'contiguous' variable.
+    Chunk &master_chunk = chunk_refs[0];
 
-    // TODO Break this call down so that data can be read in parallel. jhrg 8/21/18
-    chunk.read_chunk();
+    // If we want to read the chunk in parallel. Only read in parallel above some
+    // threshold. jhrg 9/21/19
+    if (DmrppRequestHandler::d_use_parallel_transfers) {
 
-    chunk.inflate_chunk(is_deflate_compression(), is_shuffle_compression(), get_chunk_size_in_elements(), var()->width());
+        // Allocated memory for the 'master chunk' so the threads can transfer data
+        // from the child chunks to it.
+        master_chunk.set_rbuf_to_size();
 
-    // 'chunk' now holds the data. Transfer it to the Array.
+		// This pipe is used by the child threads to indicate completion
+		int fds[2];
+		int status = pipe(fds);
+		if (status < 0)
+			throw BESInternalError(string("Could not open a pipe for thread communication: ").append(strerror(errno)), __FILE__, __LINE__);
+
+        // Create 4 equally sized chunks from the original chunk
+        // Initial test will be 4 chunks, may change. kln 9/19/19
+		// TODO Make this smarter.
+		const int num_chunks = 4;
+
+    	// Use the original chunk's size and offset to evenly split it into smaller chunks
+    	unsigned long long chunk_size = master_chunk.get_size() / num_chunks;
+    	unsigned long long chunk_offset = master_chunk.get_offset();
+
+    	// If the size of the master chunk is not evenly divisible by num_chunks, capture
+    	// the remainder here and increase the size of the last chunk by this number of bytes.
+    	unsigned int chunk_remainder = master_chunk.get_size() % num_chunks;
+
+    	string chunk_url = master_chunk.get_data_url();
+
+    	// Setup a queue to break up the original master_chunk and keep track of the pieces
+		queue<Chunk *> chunks_to_read;
+
+        for (int i = 0; i < num_chunks-1; i++) {
+            chunks_to_read.push(new Chunk(chunk_url, chunk_size, (chunk_size * i) + chunk_offset));
+        }
+        // See above for details about chunk_remainder. jhrg 9/21/19
+        chunks_to_read.push(new Chunk(chunk_url, chunk_size + chunk_remainder, (chunk_size * (num_chunks-1)) + chunk_offset));
+
+	    // Start the max number of processing pipelines
+		pthread_t threads[DmrppRequestHandler::d_max_parallel_transfers];
+		memset(&threads[0], 0, sizeof(pthread_t) * DmrppRequestHandler::d_max_parallel_transfers);
+
+		try {
+			unsigned int num_threads = 0;
+
+			// start initial set of threads
+			for (unsigned int i = 0; i < (unsigned int) DmrppRequestHandler::d_max_parallel_transfers && chunks_to_read.size() > 0; ++i) {
+				Chunk *current_chunk = chunks_to_read.front();
+				chunks_to_read.pop();
+
+                // thread number is 'i'
+                one_child_chunk_args *args = new one_child_chunk_args(fds, i, current_chunk, &master_chunk);
+                int status = pthread_create(&threads[i], NULL, dmrpp::one_child_chunk_thread, (void*) args);
+
+				if (status == 0) {
+					++num_threads;
+					BESDEBUG(dmrpp_3, "started thread: " << i << endl);
+				}
+				else {
+					ostringstream oss("Could not start process_one_chunk_unconstrained thread for master_chunk ", std::ios::ate);
+					oss << i << ": " << strerror(status);
+					BESDEBUG(dmrpp_3, oss.str());
+					throw BESInternalError(oss.str(), __FILE__, __LINE__);
+				}
+			}
+
+			// Now join the child threads, creating replacement threads if needed
+			while (num_threads > 0) {
+				unsigned char tid;   // bytes can be written atomically
+				// Block here until a child thread writes to the pipe, then read the byte
+				int bytes = ::read(fds[0], &tid, sizeof(tid));
+				if (bytes != sizeof(tid))
+					throw BESInternalError(string("Could not read the thread id: ").append(strerror(errno)), __FILE__, __LINE__);
+
+				if (!(tid < DmrppRequestHandler::d_max_parallel_transfers)) {
+					ostringstream oss("Invalid thread id read after thread exit: ", std::ios::ate);
+					oss << tid;
+					throw BESInternalError(oss.str(), __FILE__, __LINE__);
+				}
+
+				string *error;
+				int status = pthread_join(threads[tid], (void**)&error);
+				--num_threads;
+				BESDEBUG(dmrpp_3, "joined thread: " << (unsigned int)tid << ", there are: " << num_threads << endl);
+
+				if (status != 0) {
+					ostringstream oss("Could not join process_one_chunk_unconstrained thread for master_chunk ", std::ios::ate);
+					oss << tid << ": " << strerror(status);
+					throw BESInternalError(oss.str(), __FILE__, __LINE__);
+				}
+				else if (error != 0) {
+					BESInternalError e(*error, __FILE__, __LINE__);
+					delete error;
+					throw e;
+				}
+				else if (chunks_to_read.size() > 0) {
+					Chunk *current_chunk = chunks_to_read.front();
+					chunks_to_read.pop();
+
+                    // thread number is 'tid,' the number of the thread that just completed
+	                one_child_chunk_args *args = new one_child_chunk_args(fds, tid, current_chunk, &master_chunk);
+	                int status = pthread_create(&threads[tid], NULL, dmrpp::one_child_chunk_thread, (void*) args);
+
+					if (status != 0) {
+						ostringstream oss;
+						oss << "Could not start process_one_chunk_unconstrained thread for master_chunk " << tid << ": " << strerror(status);
+						throw BESInternalError(oss.str(), __FILE__, __LINE__);
+					}
+					++num_threads;
+					BESDEBUG(dmrpp_3, "started thread: " << (unsigned int)tid << ", there are: " << threads << endl);
+				}
+			}
+
+			// Once done with the threads, close the communication pipe.
+			close(fds[0]);
+			close(fds[1]);
+		}
+		catch (...) {
+			// cancel all the threads, otherwise we'll have threads out there using up resources
+			// defined in DmrppCommon.cc
+			join_threads(threads, DmrppRequestHandler::d_max_parallel_transfers);
+			// close the pipe used to communicate with the child threads
+			close(fds[0]);
+			close(fds[1]);
+			// re-throw the exception
+			throw;
+		}
+    }
+    else {
+        // Else read the master_chunk as is
+		master_chunk.read_chunk();
+    }
+
+    master_chunk.inflate_chunk(is_deflate_compression(), is_shuffle_compression(), get_chunk_size_in_elements(), var()->width());
+
+    // 'master_chunk' now holds the data. Transfer it to the Array.
 
     if (!is_projected()) {  // if there is no projection constraint
-        val2buf(chunk.get_rbuf());      // yes, it's not type-safe
+        val2buf(master_chunk.get_rbuf());      // yes, it's not type-safe
     }
     else {                  // apply the constraint
         vector<unsigned int> array_shape = get_shape(false);
@@ -310,7 +516,7 @@ void DmrppArray::read_contiguous()
         unsigned long target_index = 0;
         vector<unsigned int> subset;
 
-        insert_constrained_contiguous(dim_begin(), &target_index, subset, array_shape, chunk.get_rbuf());
+        insert_constrained_contiguous(dim_begin(), &target_index, subset, array_shape, master_chunk.get_rbuf());
     }
 
     set_read_p(true);
@@ -862,32 +1068,6 @@ void process_one_chunk_unconstrained(Chunk *chunk, DmrppArray *array, const vect
     array->insert_chunk_unconstrained(chunk, 0, 0, array_shape, 0, chunk_shape, chunk->get_position_in_array());
 }
 
-/**
- * @brief Thread to insert data from one chunk
- *
- * @param arg_list
- */
-void *one_chunk_unconstrained_thread(void *arg_list)
-{
-    one_chunk_unconstrained_args *args = reinterpret_cast<one_chunk_unconstrained_args*>(arg_list);
-
-    try {
-        process_one_chunk_unconstrained(args->chunk, args->array, args->array_shape, args->chunk_shape);
-    }
-    catch (BESError &error) {
-        write(args->fds[1], &args->tid, sizeof(args->tid));
-        delete args;
-        pthread_exit(new string(error.get_verbose_message()));
-    }
-
-    // tid is a char and thus us written atomically. Writing this tells the parent
-    // thread the child is complete and it should call pthread_join(tid, ...)
-    write(args->fds[1], &args->tid, sizeof(args->tid));
-
-    delete args;
-    pthread_exit(NULL);
-}
-
 void DmrppArray::read_chunks_unconstrained()
 {
     vector<Chunk> &chunk_refs = get_chunk_vec();
@@ -920,11 +1100,15 @@ void DmrppArray::read_chunks_unconstrained()
 
         // Start the max number of processing pipelines
         pthread_t threads[DmrppRequestHandler::d_max_parallel_transfers];
+        memset(&threads[0], 0, sizeof(pthread_t) * DmrppRequestHandler::d_max_parallel_transfers);
 
+#if 0
         // set the thread[] elements to null - this serves as a sentinel value
         for (unsigned int i = 0; i < (unsigned int)DmrppRequestHandler::d_max_parallel_transfers; ++i) {
             memset(&threads[i], 0, sizeof(pthread_t));
         }
+#endif
+
 
         try {
             unsigned int num_threads = 0;
@@ -1007,46 +1191,6 @@ void DmrppArray::read_chunks_unconstrained()
             // re-throw the exception
             throw;
         }
-
-#if 0
-        while (chunks_to_read.size() > 0) {
-
-            // Start the max number of processing pipelines
-            pthread_t threads[DmrppRequestHandler::d_max_parallel_transfers];
-            unsigned int threads = 0;
-            for (unsigned int i = 0; i < (unsigned int) DmrppRequestHandler::d_max_parallel_transfers && chunks_to_read.size() > 0; ++i) {
-                Chunk *chunk = chunks_to_read.front();
-                chunks_to_read.pop();
-
-                one_chunk_unconstrained_args *args = new one_chunk_unconstrained_args(fds, i, chunk, this, array_shape, chunk_shape);
-
-                int status = pthread_create(&threads[i], NULL, dmrpp::one_chunk_unconstrained_thread, (void*) args);
-                if (status == 0) {
-                    ++threads;
-                }
-                else {
-                    ostringstream oss("Could not start process_one_chunk_unconstrained thread for chunk ", std::ios::ate);
-                    oss << i << ": " << strerror(status);
-                    throw BESInternalError(oss.str(), __FILE__, __LINE__);
-                }
-            }
-            // Now join the child threads.
-            for (unsigned int i = 0; i < threads; ++i) {
-                string *error;
-                int status = pthread_join(threads[i], (void**) &error);
-                if (status != 0) {
-                    ostringstream oss("Could not join process_one_chunk_unconstrained thread for chunk ", std::ios::ate);
-                    oss << i << ": " << strerror(status);
-                    throw BESInternalError(oss.str(), __FILE__, __LINE__);
-                }
-                else if (error != 0) {
-                    BESInternalError e(*error, __FILE__, __LINE__);
-                    delete error;
-                    throw e;
-                }
-            }
-        }
-#endif
     }
     else {  // Serial transfers
         for (vector<Chunk>::iterator c = chunk_refs.begin(), e = chunk_refs.end(); c != e; ++c) {

--- a/modules/dmrpp_module/DmrppArray.h
+++ b/modules/dmrpp_module/DmrppArray.h
@@ -117,7 +117,7 @@ public:
 
 /// Chunk data insert args for use with pthreads
 struct one_chunk_unconstrained_args {
-    int *fds;             // pipe back to parent
+    int *fds;               // pipe back to parent
     unsigned char tid;      // thread id as a byte
     Chunk *chunk;
     DmrppArray *array;
@@ -126,6 +126,23 @@ struct one_chunk_unconstrained_args {
 
     one_chunk_unconstrained_args(int *pipe, unsigned char id, Chunk *c, DmrppArray *a, const vector<unsigned int> &a_s, const vector<unsigned int> &c_s)
         : fds(pipe), tid(id), chunk(c), array(a), array_shape(a_s), chunk_shape(c_s) {}
+};
+
+/// Chunk data insert args for use with pthreads. Used for reading contiguous data
+/// in parallel.
+struct one_child_chunk_args {
+    int *fds;               // pipe back to parent
+    unsigned char tid;      // thread id as a byte
+    Chunk *child_chunk;     // this chunk reads data; temporary allocation
+    Chunk *master_chunk;    // this chunk gets the data; shared memory, managed by DmrppArray
+
+    one_child_chunk_args(int *pipe, unsigned char id, Chunk *c_c, Chunk *m_c)
+        : fds(pipe), tid(id), child_chunk(c_c), master_chunk(m_c) {}
+
+    ~one_child_chunk_args() {
+        delete child_chunk;
+     }
+
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/build_dmrpp.cc
+++ b/modules/dmrpp_module/build_dmrpp.cc
@@ -67,12 +67,16 @@ typedef struct H5D_chunk_rec_t {
 #include <TheBESKeys.h>
 #include <BESUtil.h>
 #include <BESDebug.h>
+
+#include <BESError.h>
 #include <BESNotFoundError.h>
 #include <BESInternalError.h>
+#include <BESDataHandlerInterface.h>
 
 #include "DmrppTypeFactory.h"
 #include "DmrppD4Group.h"
 #include "DmrppMetadataStore.h"
+#include "BESDapNames.h"
 
 using namespace std;
 using namespace libdap;
@@ -555,7 +559,8 @@ int main(int argc, char*argv[])
             // is fragile. - ndp 6/6/18
             string h5_file_path = BESUtil::assemblePath(bes_data_root,h5_file_name);
 
-            bes::DmrppMetadataStore::MDSReadLock lock = mds->is_dmr_available(h5_file_name /*h5_file_path*/);
+            //bes::DmrppMetadataStore::MDSReadLock lock = mds->is_dmr_available(h5_file_name /*h5_file_path*/);
+            bes::DmrppMetadataStore::MDSReadLock lock = mds->is_dmr_available(h5_file_path, h5_file_name, "h5");
             if (lock()) {
                 // parse the DMR into a DMRpp (that uses the DmrppTypes)
                 auto_ptr<DMRpp> dmrpp(dynamic_cast<DMRpp*>(mds->get_dmr_object(h5_file_name /*h5_file_path*/)));

--- a/modules/dmrpp_module/tests/bes_mds_tests.conf.in
+++ b/modules/dmrpp_module/tests/bes_mds_tests.conf.in
@@ -12,9 +12,9 @@ BES.module.dap=@abs_top_builddir@/dap/.libs/libdap_module.so
 BES.module.cmd=@abs_top_builddir@/xmlcommand/.libs/libdap_xml_module.so
 BES.module.dmrpp=@abs_top_builddir@/modules/dmrpp_module/.libs/libdmrpp_module.so
 
-BES.Catalog.catalog.RootDirectory=@abs_top_srcdir@/modules/dmrpp_module
-BES.Catalog.catalog.TypeMatch=dmrpp:.*\.(dmrpp)$;
-BES.Catalog.catalog.FollowSymLinks=No
+BES.Catalog.catalog.RootDirectory = @abs_top_srcdir@/modules/dmrpp_module
+BES.Catalog.catalog.TypeMatch = dmrpp:.*\.(dmrpp)$;
+BES.Catalog.catalog.FollowSymLinks = No
 
 # TRICK: Without a type match for the underlying data files that are
 # to be accessed by the DMR++ the BES framework will kick out the request
@@ -25,7 +25,7 @@ BES.Catalog.catalog.FollowSymLinks=No
 # that some type be associated with them during the initial stages of
 # request processing. jhrg 6/1/18
 
-BES.Catalog.catalog.TypeMatch=h5:.*\.(h5)$;
+BES.Catalog.catalog.TypeMatch += dmrpp:.*\.(h5)$;
 
 BES.Catalog.catalog.Include=;
 BES.Catalog.catalog.Exclude=^\..*;

--- a/modules/freeform_handler/ffdas.cc
+++ b/modules/freeform_handler/ffdas.cc
@@ -201,6 +201,9 @@ static void header_to_attributes(AttrTable *at, DATA_BIN_PTR dbin)
             var = ((VARIABLE_PTR) (vlist)->data.u.var);
         }
     }
+    if (pinfo_list)
+        ff_destroy_process_info_list(pinfo_list);
+ 
 }
 
 /** Read the attributes and store their names and values in the attribute

--- a/modules/ugrid_functions/ugrid_restrict.h
+++ b/modules/ugrid_functions/ugrid_restrict.h
@@ -71,7 +71,7 @@ public:
             "by applying a filter expression to the values of the grid associated with the nodes.");
         setUsageString("ugnr(node_var [,node_var_2,...,node_var_n], 'relational query over domain')");
         setRole("http://services.opendap.org/dap4/server-side-function/unstructured_grids/ugrid_restrict");
-        setDocUrl("http://docs.opendap.org/index.php/UGrid_Functions");
+        setDocUrl("https://docs.opendap.org/index.php?title=OPULS:_UGrid_Subsetting#ugnr:_Subset_by_node_value.");
         setFunction(ugrid::ugnr);
         setVersion("1.0");
 }
@@ -93,7 +93,7 @@ public:
             "by applying a filter expression to the values of the grid associated with the edges.");
         setUsageString("uger(node_var [,node_var_2,...,node_var_n], 'relational query over domain')");
         setRole("http://services.opendap.org/dap4/server-side-function/unstructured_grids/ugrid_restrict");
-        setDocUrl("http://docs.opendap.org/index.php/UGrid_Functions");
+        setDocUrl("https://docs.opendap.org/index.php?title=OPULS:_UGrid_Subsetting#uger:_Subset_by_edge_value.");
         setFunction(ugrid::uger);
         setVersion("1.0");
 }
@@ -115,7 +115,7 @@ public:
             "by applying a filter expression to the values of the grid associated with the faces.");
         setUsageString("ugfr(node_var [,node_var_2,...,node_var_n], 'relational query over domain')");
         setRole("http://services.opendap.org/dap4/server-side-function/unstructured_grids/ugrid_restrict");
-        setDocUrl("http://docs.opendap.org/index.php/UGrid_Functions");
+        setDocUrl("https://docs.opendap.org/index.php?title=OPULS:_UGrid_Subsetting#ugfr:_Subset_by_face_value.");
         setFunction(ugrid::ugfr);
         setVersion("1.0");
 }

--- a/modules/www-interface/BESWWWResponseHandler.cc
+++ b/modules/www-interface/BESWWWResponseHandler.cc
@@ -84,7 +84,7 @@ void
     GlobalMetadataStore::MDSReadLock lock;
 
     dhi.first_container();
-    if (mds) lock = mds->is_dds_available(dhi.container->get_relative_name());
+    if (mds) lock = mds->is_dds_available(*(dhi.container));
 
     if (mds && lock()) {
         DDS *dds = mds->get_dds_object(dhi.container->get_relative_name());


### PR DESCRIPTION
**_I think this is ready now_**
I am opening this pull request prior to resolving the issue, primarily because I don't want to loose track of this. I think the old code, in `Whitelist.cc `, that handled the whitelisting of file URLs was simply wrong (because the semantics of the c++ `string::compare()` method are not even remotely equivalent to boolean). This initial check-in is somewhat better but does not correctly handle the case when the `catalog_root` is longer the the file path.

The way this should work is that all file URLs must begin with the `catalog_root` path or be rejected. So clearly, if the `file_url` is shorter than the `catalog_root` then it must be rejected.