### PR TITLE
gdal handler: Westernmost_Northing --> Westernmost_Easting

### DIFF
--- a/modules/gdal_handler/gdal_utils.cc
+++ b/modules/gdal_handler/gdal_utils.cc
@@ -135,7 +135,11 @@ static void build_global_attributes(const GDALDatasetH& hDS, AttrTable* attr_tab
         attr_table->append_attr("Northernmost_Northing", "Float64", CPLSPrintf("%.16g", dfMaxY));
         attr_table->append_attr("Southernmost_Northing", "Float64", CPLSPrintf("%.16g", dfMinY));
         attr_table->append_attr("Easternmost_Easting", "Float64", CPLSPrintf("%.16g", dfMaxX));
+#if 0
+        // Gareth Williams pointed out this typo. jhrg 9/26/19
         attr_table->append_attr("Westernmost_Northing", "Float64", CPLSPrintf("%.16g", dfMinX));
+#endif
+        attr_table->append_attr("Westernmost_Easting", "Float64", CPLSPrintf("%.16g", dfMinX));
 
         snprintf(szGeoTransform, 200, "%.16g %.16g %.16g %.16g %.16g %.16g", adfGeoTransform[0], adfGeoTransform[1],
             adfGeoTransform[2], adfGeoTransform[3], adfGeoTransform[4], adfGeoTransform[5]);

--- a/modules/gdal_handler/tests/gdal/Atlantic.wind.grb.dap.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/Atlantic.wind.grb.dap.bescmd.baseline
@@ -5392,7 +5392,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <Value>-39.375</Value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <Value>-100.625</Value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">

--- a/modules/gdal_handler/tests/gdal/Atlantic.wind.grb.das.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/Atlantic.wind.grb.das.bescmd.baseline
@@ -3,7 +3,7 @@ Attributes {
         Float64 Northernmost_Northing 48.5;
         Float64 Southernmost_Northing 9.5;
         Float64 Easternmost_Easting -39.375;
-        Float64 Westernmost_Northing -100.625;
+        Float64 Westernmost_Easting -100.625;
         String GeoTransform "-100.625 1.25 0 48.5 0 -1";
         String spatial_ref "GEOGCS[\"Coordinate System imported from GRIB file\",DATUM[\"unknown\",SPHEROID[\"Sphere\",6371200,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]]";
     }

--- a/modules/gdal_handler/tests/gdal/Atlantic.wind.grb.dmr.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/Atlantic.wind.grb.dmr.bescmd.baseline
@@ -5020,7 +5020,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <Value>-39.375</Value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <Value>-100.625</Value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">

--- a/modules/gdal_handler/tests/gdal/DIGEST_Example_2.jp2.das.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/DIGEST_Example_2.jp2.das.bescmd.baseline
@@ -3,7 +3,7 @@ Attributes {
         Float64 Northernmost_Northing -20.30846;
         Float64 Southernmost_Northing -20.326892;
         Float64 Easternmost_Easting 118.59356;
-        Float64 Westernmost_Northing 118.575128;
+        Float64 Westernmost_Easting 118.575128;
         String GeoTransform "118.575128 1.800000000000239e-05 0 -20.30846 0 -1.800000000000239e-05";
         Metadata {
             String TIFFTAG_RESOLUTIONUNIT "3 (pixels/cm)";

--- a/modules/gdal_handler/tests/gdal/DIGEST_Example_2.jp2.dmr.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/DIGEST_Example_2.jp2.dmr.bescmd.baseline
@@ -63,7 +63,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <Value>118.59356</Value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <Value>118.575128</Value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">

--- a/modules/gdal_handler/tests/gdal/SP27GTIF.TIF.dap.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/SP27GTIF.TIF.dap.bescmd.baseline
@@ -42,7 +42,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <Value>704407.2</Value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <Value>681480</Value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">

--- a/modules/gdal_handler/tests/gdal/SP27GTIF.TIF.das.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/SP27GTIF.TIF.das.bescmd.baseline
@@ -3,7 +3,7 @@ Attributes {
         Float64 Northernmost_Northing 1913050;
         Float64 Southernmost_Northing 1882578.8;
         Float64 Easternmost_Easting 704407.2;
-        Float64 Westernmost_Northing 681480;
+        Float64 Westernmost_Easting 681480;
         String GeoTransform "681480 32.8 0 1913050 0 -32.8";
         Metadata {
             String AREA_OR_POINT "Area";

--- a/modules/gdal_handler/tests/gdal/SP27GTIF.TIF.dmr.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/SP27GTIF.TIF.dmr.bescmd.baseline
@@ -33,7 +33,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <Value>704407.2</Value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <Value>681480</Value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">

--- a/modules/gdal_handler/tests/gdal/cea.tif.0.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/cea.tif.0.bescmd.baseline
@@ -3,7 +3,7 @@ Attributes {
         Float64 Northernmost_Northing 4255884.543802192;
         Float64 Southernmost_Northing 4224973.143255847;
         Float64 Easternmost_Easting 2358.211624949061;
-        Float64 Westernmost_Northing -28493.16678441252;
+        Float64 Westernmost_Easting -28493.16678441252;
         String GeoTransform "-28493.16678441252 60.02213698319374 0 4255884.543802192 0 -60.02213698319374";
         Metadata {
             String AREA_OR_POINT "Area";

--- a/modules/gdal_handler/tests/gdal/cea.tif.2.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/cea.tif.2.bescmd.baseline
@@ -10,7 +10,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <value>2358.211624949061</value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <value>-28493.16678441252</value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">

--- a/modules/gdal_handler/tests/gdal/cea.tif.dap.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/cea.tif.dap.bescmd.baseline
@@ -42,7 +42,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <Value>2358.211624949061</Value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <Value>-28493.16678441252</Value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">

--- a/modules/gdal_handler/tests/gdal/cea.tif.dmr.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/cea.tif.dmr.bescmd.baseline
@@ -33,7 +33,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <Value>2358.211624949061</Value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <Value>-28493.16678441252</Value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">

--- a/modules/gdal_handler/tests/gdal/cea.tif.r0.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/cea.tif.r0.bescmd.baseline
@@ -3,7 +3,7 @@ Attributes {
         Float64 Northernmost_Northing 4255884.543802192;
         Float64 Southernmost_Northing 4224973.143255847;
         Float64 Easternmost_Easting 2358.211624949061;
-        Float64 Westernmost_Northing -28493.16678441252;
+        Float64 Westernmost_Easting -28493.16678441252;
         String GeoTransform "-28493.16678441252 60.02213698319374 0 4255884.543802192 0 -60.02213698319374";
         Metadata {
             String AREA_OR_POINT "Area";
@@ -21,7 +21,7 @@ Attributes {
         Float64 Northernmost_Northing 4255884.543802192;
         Float64 Southernmost_Northing 4224973.143255847;
         Float64 Easternmost_Easting 2358.211624949061;
-        Float64 Westernmost_Northing -28493.16678441252;
+        Float64 Westernmost_Easting -28493.16678441252;
         String GeoTransform "-28493.16678441252 60.02213698319374 0 4255884.543802192 0 -60.02213698319374";
         Metadata {
             String AREA_OR_POINT "Area";
@@ -39,7 +39,7 @@ Attributes {
         Float64 Northernmost_Northing 4255884.543802192;
         Float64 Southernmost_Northing 4224973.143255847;
         Float64 Easternmost_Easting 2358.211624949061;
-        Float64 Westernmost_Northing -28493.16678441252;
+        Float64 Westernmost_Easting -28493.16678441252;
         String GeoTransform "-28493.16678441252 60.02213698319374 0 4255884.543802192 0 -60.02213698319374";
         Metadata {
             String AREA_OR_POINT "Area";

--- a/modules/gdal_handler/tests/gdal/cea.tif.r2.bescmd.baseline
+++ b/modules/gdal_handler/tests/gdal/cea.tif.r2.bescmd.baseline
@@ -10,7 +10,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <value>2358.211624949061</value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <value>-28493.16678441252</value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">
@@ -72,7 +72,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <value>2358.211624949061</value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <value>-28493.16678441252</value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">
@@ -134,7 +134,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <value>2358.211624949061</value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <value>-28493.16678441252</value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">

--- a/modules/ncml_module/tests/baselines/gdal/joinNew_geotiff.ncml.das
+++ b/modules/ncml_module/tests/baselines/gdal/joinNew_geotiff.ncml.das
@@ -3,7 +3,7 @@ Attributes {
         Float64 Northernmost_Northing 4255884.543802192;
         Float64 Southernmost_Northing 4224973.143255847;
         Float64 Easternmost_Easting 2358.211624949061;
-        Float64 Westernmost_Northing -28493.16678441252;
+        Float64 Westernmost_Easting -28493.16678441252;
         String GeoTransform "-28493.16678441252 60.02213698319374 0 4255884.543802192 0 -60.02213698319374";
         Metadata {
             String AREA_OR_POINT "Area";

--- a/modules/ncml_module/tests/baselines/gdal/joinNew_geotiff.ncml.ddx
+++ b/modules/ncml_module/tests/baselines/gdal/joinNew_geotiff.ncml.ddx
@@ -10,7 +10,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <value>2358.211624949061</value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <value>-28493.16678441252</value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">

--- a/modules/ncml_module/tests/baselines/gdal/joinNew_geotiff.ncml.ddx.dap2
+++ b/modules/ncml_module/tests/baselines/gdal/joinNew_geotiff.ncml.ddx.dap2
@@ -10,7 +10,7 @@
         <Attribute name="Easternmost_Easting" type="Float64">
             <value>2358.211624949061</value>
         </Attribute>
-        <Attribute name="Westernmost_Northing" type="Float64">
+        <Attribute name="Westernmost_Easting" type="Float64">
             <value>-28493.16678441252</value>
         </Attribute>
         <Attribute name="GeoTransform" type="String">


### PR DESCRIPTION
The gdal handler used the wrong name for the the attribute
Westernmost_Easting. Thanks to Gareth Williams for noticing
this.