### PR TITLE
Combined log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -221,6 +221,8 @@ before_deploy:
 
 # The deploy section copies the snapshot build product our S3 bucket and to www.opendap.org
 deploy:
+
+  # Push all build results to our S3 bucket
   - provider: s3
     access_key_id: $AWS_ACCESS_KEY_ID
     secret_access_key: $AWS_SECRET_ACCESS_KEY

--- a/xmlcommand/BESXMLInterface.cc
+++ b/xmlcommand/BESXMLInterface.cc
@@ -41,6 +41,7 @@ using namespace std;
 #include "BESXMLCommand.h"
 #include "BESXMLUtils.h"
 #include "BESDataNames.h"
+#include "BESContextManager.h"
 
 #include "BESResponseHandler.h"
 #include "BESReturnManager.h"
@@ -232,26 +233,31 @@ void BESXMLInterface::execute_data_request_plan()
 #ifdef LOG_ONLY_GET_COMMANDS
         // Special logging action for the 'get' command. In non-verbose logging mode,
         // only log the get command.
+        string separator="|&|"; //",";
         if (d_dhi_ptr->action.find("get.") != string::npos) {
 
             string new_log_info = d_dhi_ptr->action;
             if (!d_dhi_ptr->data[RETURN_CMD].empty())
-                new_log_info.append(",").append(d_dhi_ptr->data[RETURN_CMD]);
+                new_log_info.append(separator).append(d_dhi_ptr->data[RETURN_CMD]);
 
             // Assume this is DAP and thus there is at most one container. Log a warning if that's
             // not true. jhrg 11/14/17
             BESContainer *c = *(d_dhi_ptr->containers.begin());
             if (c) {
-                if (!c->get_real_name().empty()) new_log_info.append(",").append(c->get_real_name());
+                if (!c->get_real_name().empty()) new_log_info.append(separator).append(c->get_real_name());
 
                 if (!c->get_constraint().empty()) {
-                    new_log_info.append(",").append(c->get_constraint());
+                    new_log_info.append(separator).append(c->get_constraint());
                 }
                 else {
-                    if (!c->get_dap4_constraint().empty()) new_log_info.append(",").append(c->get_dap4_constraint());
-                    if (!c->get_dap4_function().empty()) new_log_info.append(",").append(c->get_dap4_function());
+                    if (!c->get_dap4_constraint().empty()) new_log_info.append(separator).append(c->get_dap4_constraint());
+                    if (!c->get_dap4_function().empty()) new_log_info.append(separator).append(c->get_dap4_function());
                 }
             }
+            bool found = false;
+            string olfs_log_line = BESContextManager::TheManager()->get_context("olfsLog", found);
+            if(found)
+                LOG(olfs_log_line << endl);
 
             LOG(new_log_info << endl);
 

--- a/xmlcommand/BESXMLInterface.cc
+++ b/xmlcommand/BESXMLInterface.cc
@@ -233,31 +233,40 @@ void BESXMLInterface::execute_data_request_plan()
 #ifdef LOG_ONLY_GET_COMMANDS
         // Special logging action for the 'get' command. In non-verbose logging mode,
         // only log the get command.
-        string separator="|&|"; //",";
         if (d_dhi_ptr->action.find("get.") != string::npos) {
 
-            string new_log_info = d_dhi_ptr->action;
+            string log_delim="|&|"; //",";
+
+            string new_log_info = "";
+
+            // If the OLFS sent it's log info, integrate that into the log output
+            bool found = false;
+            string olfs_log_line = BESContextManager::TheManager()->get_context("olfsLog", found);
+            if(found){
+                new_log_info.append("OLFS").append(log_delim).append(olfs_log_line).append(log_delim);
+                new_log_info.append("BES").append(log_delim);
+            }
+
+            new_log_info.append(d_dhi_ptr->action);
+
+
             if (!d_dhi_ptr->data[RETURN_CMD].empty())
-                new_log_info.append(separator).append(d_dhi_ptr->data[RETURN_CMD]);
+                new_log_info.append(log_delim).append(d_dhi_ptr->data[RETURN_CMD]);
 
             // Assume this is DAP and thus there is at most one container. Log a warning if that's
             // not true. jhrg 11/14/17
             BESContainer *c = *(d_dhi_ptr->containers.begin());
             if (c) {
-                if (!c->get_real_name().empty()) new_log_info.append(separator).append(c->get_real_name());
+                if (!c->get_real_name().empty()) new_log_info.append(log_delim).append(c->get_real_name());
 
                 if (!c->get_constraint().empty()) {
-                    new_log_info.append(separator).append(c->get_constraint());
+                    new_log_info.append(log_delim).append(c->get_constraint());
                 }
                 else {
-                    if (!c->get_dap4_constraint().empty()) new_log_info.append(separator).append(c->get_dap4_constraint());
-                    if (!c->get_dap4_function().empty()) new_log_info.append(separator).append(c->get_dap4_function());
+                    if (!c->get_dap4_constraint().empty()) new_log_info.append(log_delim).append(c->get_dap4_constraint());
+                    if (!c->get_dap4_function().empty()) new_log_info.append(log_delim).append(c->get_dap4_function());
                 }
             }
-            bool found = false;
-            string olfs_log_line = BESContextManager::TheManager()->get_context("olfsLog", found);
-            if(found)
-                LOG(olfs_log_line << endl);
 
             LOG(new_log_info << endl);
 


### PR DESCRIPTION
This PR creates the option of creating a combined BES/OLFS log (in the BES log file). The newly added BES code checks for the presence of the OLFS log content (in the request document) and when found it builds a combined log line with both the BES and OLFS log information. The OLFS and it's configuration determine if the information is sent to the BES, and if it is not sent the BES produces the same log entries as prior to this addition.