### PR TITLE
Doi version

### DIFF
--- a/dispatch/BESVersionInfo.cc
+++ b/dispatch/BESVersionInfo.cc
@@ -78,7 +78,8 @@ void BESVersionInfo::add_version(const string &type, const string &name, const s
 {
     map<string, string> attrs;
     attrs["name"] = name;
-    add_tag(type, vers, &attrs);
+    attrs["version"] = vers;
+    add_tag(type, "", &attrs);
 }
 
 /** @brief dumps information about this object


### PR DESCRIPTION
While we agreed to drop trying to bake the DOI information into the code (chicken&egg issues) I did make a small change to the version response in order to make the content more understandable by moving the version numbers from element text content into an attribute named  _version_.