### PR TITLE
Repeat after me: "getopt() returns an int"

### DIFF
--- a/cmdln/unit-tests/translateT.cc
+++ b/cmdln/unit-tests/translateT.cc
@@ -357,7 +357,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION( translateT );
 int main(int argc, char *argv[])
 {
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
 
     while ((option_char = getopt()) != -1)
         switch (option_char) {

--- a/dap/unit-tests/StoredDap2ResultTest.cc
+++ b/dap/unit-tests/StoredDap2ResultTest.cc
@@ -497,7 +497,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(StoredDap2ResultTest);
 int main(int argc, char*argv[])
 {
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dap/unit-tests/StoredDap4ResultTest.cc
+++ b/dap/unit-tests/StoredDap4ResultTest.cc
@@ -318,7 +318,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dap/unit-tests/unused/SequenceAggregationServerTest.cc
+++ b/dap/unit-tests/unused/SequenceAggregationServerTest.cc
@@ -351,7 +351,7 @@ int main(int argc, char*argv[]) {
     runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
 
     GetOpt getopt(argc, argv, "d");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/old/unit_tests_old/gzT.cc
+++ b/dispatch/old/unit_tests_old/gzT.cc
@@ -168,7 +168,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION( gzT ) ;
 int main(int argc, char*argv[]) {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/old/unit_tests_old/zT.cc
+++ b/dispatch/old/unit_tests_old/zT.cc
@@ -168,7 +168,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION( zT ) ;
 int main(int argc, char*argv[]) {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/BESCatalogListTest.cc
+++ b/dispatch/unit-tests/BESCatalogListTest.cc
@@ -123,7 +123,7 @@ int main(int argc, char*argv[])
 
     int start = 0;
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd': {

--- a/dispatch/unit-tests/CatalogItemTest.cc
+++ b/dispatch/unit-tests/CatalogItemTest.cc
@@ -170,7 +170,7 @@ int main(int argc, char*argv[])
 
     int start = 0;
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd': {

--- a/dispatch/unit-tests/CatalogNodeTest.cc
+++ b/dispatch/unit-tests/CatalogNodeTest.cc
@@ -157,7 +157,7 @@ int main(int argc, char*argv[])
 
     int start = 0;
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd': {

--- a/dispatch/unit-tests/ServerAdministratorTest.cc
+++ b/dispatch/unit-tests/ServerAdministratorTest.cc
@@ -207,7 +207,7 @@ int main(int argc, char*argv[])
 
     int start = 0;
     GetOpt getopt(argc, argv, "bdh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd': {

--- a/dispatch/unit-tests/WhiteListTest.cc
+++ b/dispatch/unit-tests/WhiteListTest.cc
@@ -179,7 +179,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(RemoteAccessTest);
 int main(int argc, char*argv[])
 {
     GetOpt getopt(argc, argv, "dhb");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/agglistT.cc
+++ b/dispatch/unit-tests/agglistT.cc
@@ -179,7 +179,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/catT.cc
+++ b/dispatch/unit-tests/catT.cc
@@ -930,7 +930,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dDhb");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/checkT.cc
+++ b/dispatch/unit-tests/checkT.cc
@@ -303,7 +303,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/complete_catalog_lister.cc
+++ b/dispatch/unit-tests/complete_catalog_lister.cc
@@ -412,7 +412,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/constraintT.cc
+++ b/dispatch/unit-tests/constraintT.cc
@@ -165,7 +165,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/debugT.cc
+++ b/dispatch/unit-tests/debugT.cc
@@ -214,7 +214,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/defT.cc
+++ b/dispatch/unit-tests/defT.cc
@@ -189,7 +189,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/fsT.cc
+++ b/dispatch/unit-tests/fsT.cc
@@ -186,7 +186,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/infoT.cc
+++ b/dispatch/unit-tests/infoT.cc
@@ -197,7 +197,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/old/bz2T.cc
+++ b/dispatch/unit-tests/old/bz2T.cc
@@ -179,7 +179,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/pfileT.cc
+++ b/dispatch/unit-tests/pfileT.cc
@@ -185,7 +185,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/plistT.cc
+++ b/dispatch/unit-tests/plistT.cc
@@ -186,7 +186,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/regexT.cc
+++ b/dispatch/unit-tests/regexT.cc
@@ -186,7 +186,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/replistT.cc
+++ b/dispatch/unit-tests/replistT.cc
@@ -154,7 +154,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/reqhandlerT.cc
+++ b/dispatch/unit-tests/reqhandlerT.cc
@@ -209,7 +209,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/reqlistT.cc
+++ b/dispatch/unit-tests/reqlistT.cc
@@ -159,7 +159,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/resplistT.cc
+++ b/dispatch/unit-tests/resplistT.cc
@@ -225,7 +225,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/scrubT.cc
+++ b/dispatch/unit-tests/scrubT.cc
@@ -172,7 +172,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/servicesT.cc
+++ b/dispatch/unit-tests/servicesT.cc
@@ -531,7 +531,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/urlT.cc
+++ b/dispatch/unit-tests/urlT.cc
@@ -159,7 +159,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/dispatch/unit-tests/utilT.cc
+++ b/dispatch/unit-tests/utilT.cc
@@ -272,7 +272,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/functions/unit-tests/CEFunctionsTest.cc
+++ b/functions/unit-tests/CEFunctionsTest.cc
@@ -809,7 +809,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/functions/unit-tests/Dap4_CEFunctionsTest.cc
+++ b/functions/unit-tests/Dap4_CEFunctionsTest.cc
@@ -741,7 +741,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/functions/unit-tests/Dap4_TabularFunctionTest.cc
+++ b/functions/unit-tests/Dap4_TabularFunctionTest.cc
@@ -260,7 +260,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dDh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/functions/unit-tests/GridGeoConstraintTest.cc
+++ b/functions/unit-tests/GridGeoConstraintTest.cc
@@ -1252,7 +1252,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dDh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/functions/unit-tests/OdometerTest.cc
+++ b/functions/unit-tests/OdometerTest.cc
@@ -298,7 +298,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dDh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/functions/unit-tests/RoiFunctionTest.cc
+++ b/functions/unit-tests/RoiFunctionTest.cc
@@ -343,7 +343,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dDh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/functions/unit-tests/TabularFunctionTest.cc
+++ b/functions/unit-tests/TabularFunctionTest.cc
@@ -853,7 +853,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dDh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/functions/unused_ArrayGeoConstraint_code/ArrayGeoConstraintTest.cc
+++ b/functions/unused_ArrayGeoConstraint_code/ArrayGeoConstraintTest.cc
@@ -230,7 +230,7 @@ int main(int argc, char*argv[]) {
     runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
 
     GetOpt getopt(argc, argv, "d");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/modules/asciival/unit-tests/AsciiArrayTest.cc
+++ b/modules/asciival/unit-tests/AsciiArrayTest.cc
@@ -258,7 +258,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/modules/asciival/unit-tests/AsciiOutputTest.cc
+++ b/modules/asciival/unit-tests/AsciiOutputTest.cc
@@ -112,7 +112,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/ppt/unit-tests/connT.cc
+++ b/ppt/unit-tests/connT.cc
@@ -168,7 +168,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/ppt/unit-tests/extT.cc
+++ b/ppt/unit-tests/extT.cc
@@ -214,7 +214,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/ppt/unit-tests/sbT.cc
+++ b/ppt/unit-tests/sbT.cc
@@ -138,7 +138,7 @@ int main(int argc, char*argv[])
 {
 
     GetOpt getopt(argc, argv, "dh");
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':

--- a/xmlcommand/unit-tests/buildT.cc
+++ b/xmlcommand/unit-tests/buildT.cc
@@ -142,7 +142,7 @@ int main(int argc, char*argv[])
     string env_var = (string) "BES_CONF=" + TEST_SRC_DIR + "/bes.conf";
     putenv((char *) env_var.c_str());
 
-    char option_char;
+    int option_char;
     while ((option_char = getopt()) != EOF)
         switch (option_char) {
         case 'd':


### PR DESCRIPTION
This can trigger infinite loops on non-x86 arches.  There is something strange going on as well where the main CXXFLAGS is not being applied to many of these - so we are missing our (Fedora's) global -Wall which would have triggered more warnings about it.