### PR TITLE
HK-551, the attrs->append_attr() call changes the attrs in a for loop…

### DIFF
--- a/modules/fileout_netcdf/FONcAttributes.cc
+++ b/modules/fileout_netcdf/FONcAttributes.cc
@@ -373,7 +373,7 @@ void FONcAttributes::add_attributes_worker(int ncid, int varid, const string &va
                 string new_name_fillvalue = "Orig_FillValue";
                 BESDEBUG("fonc",
                          "FONcAttributes::add_attributes_worker - New attribute value is original value: " << val.c_str() << endl);
-                attrs.append_attr(new_name_fillvalue,"String", val);
+                //attrs.append_attr(new_name_fillvalue,"String", val);
                 stax = nc_put_att_text(ncid, varid, new_name_fillvalue.c_str(), val.length(), val.c_str());
             }
         }

--- a/modules/fileout_netcdf/FONcAttributes.cc
+++ b/modules/fileout_netcdf/FONcAttributes.cc
@@ -373,7 +373,11 @@ void FONcAttributes::add_attributes_worker(int ncid, int varid, const string &va
                 string new_name_fillvalue = "Orig_FillValue";
                 BESDEBUG("fonc",
                          "FONcAttributes::add_attributes_worker - New attribute value is original value: " << val.c_str() << endl);
-                //attrs.append_attr(new_name_fillvalue,"String", val);
+                // This line causes the segmentation fault since attrs is changed and the original iterator of attrs doesn't exist anymore.
+                // So it causes the segmentation fault when next attribute is fetched in the for loop of the add_attributes(). KY 2019-12-13
+#if 0
+                attrs.append_attr(new_name_fillvalue,"String", val);
+#endif
                 stax = nc_put_att_text(ncid, varid, new_name_fillvalue.c_str(), val.length(), val.c_str());
             }
         }


### PR DESCRIPTION
… of attrs iterator. This causes the segmentation fault of when checking the next iterator of the original attrs, which doesn't exist any more. Since the next line of this call writes the attribute to the netCDF file, appending this attribute to attrs is not necessary. So just comment out this line.

After fixing this, the program runs and exits normally.