### PR TITLE
HK-618, add a BES key to turn off the global attributes output. This …

### DIFF
--- a/modules/fileout_netcdf/FONcArray.cc
+++ b/modules/fileout_netcdf/FONcArray.cc
@@ -593,6 +593,9 @@ void FONcArray::write_for_nc4_types(int ncid) {
     int stax = NC_NOERR;
 
     // create array to hold data hyperslab
+    // DAP2 only supports unsigned BYTE. So here
+    // we don't inlcude NC_BYTE(the signed BYTE, the same
+    // as 64-bit integer. KY 2020-03-20 
     switch (d_array_type) {
     case NC_UBYTE: {
         unsigned char *data = new unsigned char[d_nelements];

--- a/modules/fileout_netcdf/FONcArray.cc
+++ b/modules/fileout_netcdf/FONcArray.cc
@@ -594,8 +594,8 @@ void FONcArray::write_for_nc4_types(int ncid) {
 
     // create array to hold data hyperslab
     // DAP2 only supports unsigned BYTE. So here
-    // we don't inlcude NC_BYTE(the signed BYTE, the same
-    // as 64-bit integer. KY 2020-03-20 
+    // we don't inlcude NC_BYTE (the signed BYTE, the same
+    // as 64-bit integer). KY 2020-03-20 
     switch (d_array_type) {
     case NC_UBYTE: {
         unsigned char *data = new unsigned char[d_nelements];

--- a/modules/fileout_netcdf/FONcRequestHandler.cc
+++ b/modules/fileout_netcdf/FONcRequestHandler.cc
@@ -64,11 +64,15 @@
 #define FONC_CLASSIC_MODEL true
 #define FONC_CLASSIC_MODEL_KEY "FONc.ClassicModel"
 
+#define FONC_NO_GLOBAL_ATTRS false
+#define FONC_NO_GLOBAL_ATTRS_KEY "FONc.NoGlobalAttrs"
+
 std::string FONcRequestHandler::temp_dir;
 bool FONcRequestHandler::byte_to_short;
 bool FONcRequestHandler::use_compression;
 int FONcRequestHandler::chunk_size;
 bool FONcRequestHandler::classic_model;
+bool FONcRequestHandler::no_global_attrs;
 
 using namespace std;
 
@@ -153,11 +157,14 @@ FONcRequestHandler::FONcRequestHandler( const string &name )
 
     read_key_value(FONC_CLASSIC_MODEL_KEY, FONcRequestHandler::classic_model, FONC_CLASSIC_MODEL);
 
+    read_key_value(FONC_NO_GLOBAL_ATTRS_KEY, FONcRequestHandler::no_global_attrs, FONC_NO_GLOBAL_ATTRS);
+
     BESDEBUG("fonc", "FONcRequestHandler::temp_dir: " << FONcRequestHandler::temp_dir << endl);
     BESDEBUG("fonc", "FONcRequestHandler::byte_to_short: " << FONcRequestHandler::byte_to_short << endl);
     BESDEBUG("fonc", "FONcRequestHandler::use_compression: " << FONcRequestHandler::use_compression << endl);
     BESDEBUG("fonc", "FONcRequestHandler::chunk_size: " << FONcRequestHandler::chunk_size << endl);
     BESDEBUG("fonc", "FONcRequestHandler::classic_model: " << FONcRequestHandler::classic_model << endl);
+    BESDEBUG("fonc", "FONcRequestHandler::turn_off_global_attrs: " << FONcRequestHandler::no_global_attrs << endl);
 }
 
 /** @brief Any cleanup that needs to take place

--- a/modules/fileout_netcdf/FONcRequestHandler.h
+++ b/modules/fileout_netcdf/FONcRequestHandler.h
@@ -54,6 +54,7 @@ public:
     static bool use_compression;
     static int chunk_size;
     static bool classic_model;
+    static bool no_global_attrs;
 
     static bool build_help(BESDataHandlerInterface &dhi);
     static bool build_version(BESDataHandlerInterface &dhi);

--- a/modules/fileout_netcdf/FONcTransform.cc
+++ b/modules/fileout_netcdf/FONcTransform.cc
@@ -195,13 +195,15 @@ void FONcTransform::transform()
             fbt->define(_ncid);
         }
 
-        // Add any global attributes to the netcdf file
-        AttrTable &globals = _dds->get_attr_table();
-        BESDEBUG("fonc", "FONcTransform::transform() - Adding Global Attributes" << endl << globals << endl);
-        bool is_netCDF_enhanced = false;
-        if(FONcTransform::_returnAs == RETURNAS_NETCDF4 && FONcRequestHandler::classic_model==false)
-            is_netCDF_enhanced = true;
-        FONcAttributes::add_attributes(_ncid, NC_GLOBAL, globals, "", "",is_netCDF_enhanced);
+        if(FONcRequestHandler::no_global_attrs == false) {
+            // Add any global attributes to the netcdf file
+            AttrTable &globals = _dds->get_attr_table();
+            BESDEBUG("fonc", "FONcTransform::transform() - Adding Global Attributes" << endl << globals << endl);
+            bool is_netCDF_enhanced = false;
+            if(FONcTransform::_returnAs == RETURNAS_NETCDF4 && FONcRequestHandler::classic_model==false)
+                is_netCDF_enhanced = true;
+            FONcAttributes::add_attributes(_ncid, NC_GLOBAL, globals, "", "",is_netCDF_enhanced);
+        }
 
         // We are done defining the variables, dimensions, and
         // attributes of the netcdf file. End the define mode.

--- a/modules/fileout_netcdf/fonc.conf.in
+++ b/modules/fileout_netcdf/fonc.conf.in
@@ -30,3 +30,7 @@ FONc.Reference=http://docs.opendap.org/index.php/BES_-_Modules_-_FileOut_Netcdf
 FONc.UseCompression=true
 FONc.ChunkSize=4096
 FONc.ClassicModel=true
+#Uncomment the following line if not wanting to have the output of global attributes.
+#FONc.NoGlobalAttrs=true
+
+

--- a/modules/fileout_netcdf/fonc.conf.in
+++ b/modules/fileout_netcdf/fonc.conf.in
@@ -30,7 +30,8 @@ FONc.Reference=http://docs.opendap.org/index.php/BES_-_Modules_-_FileOut_Netcdf
 FONc.UseCompression=true
 FONc.ChunkSize=4096
 FONc.ClassicModel=true
-#Uncomment the following line if not wanting to have the output of global attributes.
+
+# Uncomment the following line to suppress the output of global attributes.
 #FONc.NoGlobalAttrs=true
 
 

--- a/modules/fileout_netcdf/tests/bes.conf.in
+++ b/modules/fileout_netcdf/tests/bes.conf.in
@@ -66,6 +66,9 @@ FONc.Tempdir=@abs_top_builddir@/modules/fileout_netcdf/tests/
 FONc.UseCompression=true
 FONc.ChunkSize=4096
 FONc.ClassicModel=true
+#Uncomment the following line if not wanting to have the output of global attributes.
+#FONc.NoGlobalAttrs=true
+
 
 # For HDF4
 

--- a/modules/fileout_netcdf/tests/bes.conf.in
+++ b/modules/fileout_netcdf/tests/bes.conf.in
@@ -66,7 +66,7 @@ FONc.Tempdir=@abs_top_builddir@/modules/fileout_netcdf/tests/
 FONc.UseCompression=true
 FONc.ChunkSize=4096
 FONc.ClassicModel=true
-#Uncomment the following line if not wanting to have the output of global attributes.
+# Uncomment the following line to suppress the output of global attributes.
 #FONc.NoGlobalAttrs=true
 
 

--- a/modules/fileout_netcdf/tests/bes.nc4.conf.in
+++ b/modules/fileout_netcdf/tests/bes.nc4.conf.in
@@ -66,6 +66,8 @@ FONc.Tempdir=@abs_top_builddir@/modules/fileout_netcdf/tests/
 FONc.UseCompression=true
 FONc.ChunkSize=4096
 FONc.ClassicModel=false
+#Uncomment the following line if not wanting to have the output of global attributes.
+#FONc.NoGlobalAttrs=true
 
 # For HDF5
 # Note enabling the CF option changes the behavior of testFillValue test.

--- a/modules/fileout_netcdf/tests/bes.nc4.conf.in
+++ b/modules/fileout_netcdf/tests/bes.nc4.conf.in
@@ -66,7 +66,7 @@ FONc.Tempdir=@abs_top_builddir@/modules/fileout_netcdf/tests/
 FONc.UseCompression=true
 FONc.ChunkSize=4096
 FONc.ClassicModel=false
-#Uncomment the following line if not wanting to have the output of global attributes.
+# Uncomment the following line to suppress the output of global attributes.
 #FONc.NoGlobalAttrs=true
 
 # For HDF5


### PR DESCRIPTION
…key is turned off by default.

So all tests should pass as usual.