### PR TITLE
Fixing the various library references in  get_dmrpp

### DIFF
--- a/modules/dmrpp_module/data/Makefile.am
+++ b/modules/dmrpp_module/data/Makefile.am
@@ -4,6 +4,8 @@ AUTOMAKE_OPTIONS = foreign
 AM_CPPFLAGS = $(DAP_CFLAGS) $(BES_CPPFLAGS) -I$(top_srcdir)/dap -I$(top_srcdir)/dispatch
 AM_CXXFLAGS = 
 
+lib_besdir=$(libdir)/bes
+
 # noinst_PROGRAMS = endian_convert multiball keepalive2
 
 # endian_convert_SOURCES = endian_convert.cc
@@ -35,7 +37,8 @@ get_dmrpp: $(srcdir)/get_dmrpp.in $(top_srcdir)/configure.ac
 	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
 	cat $(srcdir)/get_dmrpp.in | sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" \
-		-e "s%[@]modulesdir[@]%${modulesdir}%" > get_dmrpp
+		-e "s%[@]bes_modules_dir[@]%${lib_besdir}%" > get_dmrpp
+
 
 EXTRA_PROGRAMS = 
 

--- a/modules/dmrpp_module/data/get_dmrpp.in
+++ b/modules/dmrpp_module/data/get_dmrpp.in
@@ -28,17 +28,11 @@ BES.LogVerbose=no
 
 BES.modules=dap,cmd,h5,dmrpp
 
-# Despite the comment at the top, use the development modules for now. jhrg 5/11/18
-
 BES.module.dap=@bes_modules_dir@/libdap_module.so
 BES.module.cmd=@bes_modules_dir@/libdap_xml_module.so
 BES.module.h5=@bes_modules_dir@/libhdf5_module.so
 BES.module.dmrpp=@bes_modules_dir@/libdmrpp_module.so
 
-#BES.module.dap=@abs_top_builddir@/dap/.libs/libdap_module.so
-#BES.module.cmd=@abs_top_builddir@/xmlcommand/.libs/libdap_xml_module.so
-#BES.module.h5=@abs_top_builddir@/modules/hdf5_handler/.libs/libhdf5_module.so
-#BES.module.dmrpp=@abs_top_builddir@/modules/dmrpp_module/.libs/libdmrpp_module.so
 
 # The value "@hdf5_root_directory@" is replaced at run time.
 BES.Catalog.catalog.RootDirectory=@hdf5_root_directory@

--- a/modules/dmrpp_module/data/get_dmrpp.in
+++ b/modules/dmrpp_module/data/get_dmrpp.in
@@ -30,14 +30,15 @@ BES.modules=dap,cmd,h5,dmrpp
 
 # Despite the comment at the top, use the development modules for now. jhrg 5/11/18
 
-# BES.module.dap=@modulesdir@/libdap_module.so
-# BES.module.cmd=@modulesdir@/libdap_xml_module.so
-# BES.module.h5=@modulesdir@/libhdf5_module.so
+BES.module.dap=@bes_modules_dir@/libdap_module.so
+BES.module.cmd=@bes_modules_dir@/libdap_xml_module.so
+BES.module.h5=@bes_modules_dir@/libhdf5_module.so
+BES.module.dmrpp=@bes_modules_dir@/libdmrpp_module.so
 
-BES.module.dap=@abs_top_builddir@/dap/.libs/libdap_module.so
-BES.module.cmd=@abs_top_builddir@/xmlcommand/.libs/libdap_xml_module.so
-BES.module.h5=@abs_top_builddir@/modules/hdf5_handler/.libs/libhdf5_module.so
-BES.module.dmrpp=@abs_top_builddir@//modules/dmrpp_module/.libs/libdmrpp_module.so
+#BES.module.dap=@abs_top_builddir@/dap/.libs/libdap_module.so
+#BES.module.cmd=@abs_top_builddir@/xmlcommand/.libs/libdap_xml_module.so
+#BES.module.h5=@abs_top_builddir@/modules/hdf5_handler/.libs/libhdf5_module.so
+#BES.module.dmrpp=@abs_top_builddir@/modules/dmrpp_module/.libs/libdmrpp_module.so
 
 # The value "@hdf5_root_directory@" is replaced at run time.
 BES.Catalog.catalog.RootDirectory=@hdf5_root_directory@


### PR DESCRIPTION
In this PR we are fixing the get_dmrpp program so that the default bes.conf (which stored as a HERE document in the get_dmrpp shell script) contains meaning full library references when the script is built during RPM builds. 