### PR TITLE
Added an exception to Chunk::chunk_write_data() to prevent buffer overflow.

### DIFF
--- a/modules/dmrpp_module/Chunk.cc
+++ b/modules/dmrpp_module/Chunk.cc
@@ -124,7 +124,6 @@ size_t chunk_write_data(void *buffer, size_t size, size_t nmemb, void *data)
     unsigned long long bytes_read = c_ptr->get_bytes_read();
 
     // If this fails, the code will write beyond the buffer.
-    assert(bytes_read + nbytes <= c_ptr->get_rbuf_size());
     if(bytes_read + nbytes > c_ptr->get_rbuf_size()){
         stringstream msg;
         msg << prolog << "ERROR! The number of bytes_read: " << bytes_read << " plus the number of bytes to read: " <<


### PR DESCRIPTION

There is an assert() with the same fundamental test, but that is removed from the code when  --enable-developer is not used. Because we know that dmr++ production has problems  with variables created by hdf5 CF routines (as in the data is synthesized and is not part of the original granule) the buffer overflow problems may be common for a while and the error needs to be handled in a way that produces some time of error response. Thus this PR