### PR TITLE
Modified configure.ac so the ngap module is built by default.

### DIFF
--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -66,6 +66,9 @@ cd bes
 git submodule update --init --recursive
 
 # build (autoreconf; configure, make)
+
+echo "autoconf: `autoconf --version`"
+
 autoreconf -fiv
 
 ./configure --disable-dependency-tracking --prefix=$prefix --with-dependencies=$prefix/deps

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -68,6 +68,7 @@ git submodule update --init --recursive
 # build (autoreconf; configure, make)
 
 echo "autoconf: `autoconf --version`"
+echo "automake: `automake --version`"
 
 autoreconf -fiv
 

--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ dnl Build NGAP support by default or if the user provides --with-ngap. Do not bu
 dnl module if the user supplies --without-ngap or --with-ngap=no. jhrg 3/31/20
 
 AC_ARG_WITH([ngap], [AS_HELP_STRING([--without-ngap], [disable support for the NGAP module])],
-    [AM_CONDITIONAL([WITH_NGAP], [AS_IF([test "x$with_ngap" == xyes], [true], [false])])],
+    [AM_CONDITIONAL([WITH_NGAP], [test "x$with_ngap" == xyes])],
     [AM_CONDITIONAL([WITH_NGAP], [true])])
 
 AM_COND_IF([WITH_NGAP],

--- a/configure.ac
+++ b/configure.ac
@@ -52,22 +52,31 @@ AC_ARG_ENABLE([asan], [AS_HELP_STRING([--enable-asan], [Use the address sanitize
      cxx_debug_flags="$cxx_debug_flags -fsanitize=address -fno-omit-frame-pointer -fno-common"], 
     [AM_CONDITIONAL([USE_ASAN], [false])])
 
-AC_ARG_WITH([cmr], [AS_HELP_STRING([--with-cmr], [Build and include the CMR Module (built by default in developer mode)])], 
+AC_ARG_WITH([cmr], [AS_HELP_STRING([--with-cmr], [Build the CMR Module (built by default in developer mode)])],
     [AM_CONDITIONAL([WITH_CMR], [true])],
-    [AM_CONDITIONAL([WITH_CMR], [AM_COND_IF([BES_DEVELOPER], [true], [flase])])])
+    [AM_CONDITIONAL([WITH_CMR], [AM_COND_IF([BES_DEVELOPER], [true], [false])])])
 
-AC_ARG_WITH([ngap], [AS_HELP_STRING([--with-ngap], [Build and include the NGAP Module (built by default in developer mode)])], 
-    [AM_CONDITIONAL([WITH_NGAP], [true])],
-    [AM_CONDITIONAL([WITH_NGAP], [AM_COND_IF([BES_DEVELOPER], [true], [false])])])
+AM_COND_IF([WITH_CMR],
+    [AC_MSG_NOTICE([Building support for the CMR Module])],
+    [AC_MSG_NOTICE([Disabled support for the CMR Module])])
+
+dnl Build NGAP support by default or if the user provides --with-ngap. Do not build the
+dnl module if the user supplies --without-ngap or --with-ngap=no. jhrg 3/31/20
+
+AC_ARG_WITH([ngap], [AS_HELP_STRING([--without-ngap], [disable support for the NGAP module])],
+    [AM_CONDITIONAL([WITH_NGAP], [AS_IF([test "x$with_ngap" == xyes], [true], [false])])],
+    [AM_CONDITIONAL([WITH_NGAP], [true])])
+
+AM_COND_IF([WITH_NGAP],
+    [AC_MSG_NOTICE([Building support for the NGAP Module])],
+    [AC_MSG_NOTICE([Disabled support for the NGAP Module])])
 
 AS_IF([test "$CC" = "gcc"], [AM_CONDITIONAL([COMPILER_IS_GCC],[true])],
     [AM_CONDITIONAL([COMPILER_IS_GCC],[false])])
 
 dnl Only set CXXFLAGS if the caller didn't supply a value
-dnl AS_IF([test -z "${CXXFLAGS+set}"], [CXXFLAGS="$cxx_debug_flags"])
-AS_IF([test -z "${CXXFLAGS+set}"], [CXXFLAGS=])
 
-dnl : ${CXXFLAGS=""}
+AS_IF([test -z "${CXXFLAGS+set}"], [CXXFLAGS=])
 
 dnl library visioning: Update these when the interface changes.
 dnl
@@ -148,8 +157,8 @@ dnl Makefile will call bison -y which does not know how to make the parsers
 dnl we require. jhrg 6/15/05
 AC_CHECK_PROG(YACC,[bison],[bison])
 
-dnl Use libtool instead?
-dnl AC_PROG_RANLIB
+dnl Use libtool instead
+
 AM_PROG_LIBTOOL
 
 AC_SEARCH_LIBS([uuid_generate], [uuid],
@@ -197,7 +206,7 @@ AC_CHECK_FUNCS(strdup strftime strtol strcasecmp strcspn strerror strncasecmp)
 AC_CHECK_FUNCS(strpbrk strchr strrchr strspn strtoul)
 AC_CHECK_FUNCS(timegm mktime atexit floor isascii memmove memset pow sqrt)
 
-# Make sure we have the cctype library
+dnl Make sure we have the cctype library
 AC_SEARCH_LIBS([isdigit], [cctype])
 
 AC_SYS_LARGEFILE


### PR DESCRIPTION
Use --without-ngap or --with-ngap=no to disable the module.