### PR TITLE
Netrc location

### DIFF
--- a/modules/dmrpp_module/CredentialsManager.cc
+++ b/modules/dmrpp_module/CredentialsManager.cc
@@ -46,6 +46,8 @@ using namespace std;
 
 #define MODULE "dmrpp:creds"
 
+#define prolog std::string("CredentialsManager::").append(__func__).append("() - ")
+
 /**
  * Our singleton instance
  */
@@ -58,9 +60,8 @@ const string CredentialsManager::ENV_REGION_KEY="CMAC_REGION";
 //const string CredentialsManager::ENV_BUCKET_KEY="CMAC_BUCKET";
 const string CredentialsManager::ENV_URL_KEY="CMAC_URL";
 const string CredentialsManager::ENV_CREDS_KEY_VALUE="ENV_CREDS";
+const string CredentialsManager::NETRC_FILE_KEY="BES.netrc.credentials";
 
-
-#define NGAP_DIST_ENDPT_KEY "NGAP.distribution.endpoint.url"
 
 /**
  *  Get get the specified environment value. This function
@@ -117,7 +118,17 @@ CredentialsManager::~CredentialsManager() {
 /**
  * Really it's the default constructor for now.
  */
-CredentialsManager::CredentialsManager(): ngaps3CredentialsLoaded(false){}
+CredentialsManager::CredentialsManager(): ngaps3CredentialsLoaded(false){
+    bool found;
+    d_netrc_filename="";
+    TheBESKeys::TheKeys()->get_value(NETRC_FILE_KEY,d_netrc_filename,found);
+    if(found){
+        BESDEBUG(MODULE, prolog << "Using netrc file: " << d_netrc_filename << endl);
+    }
+    else {
+        BESDEBUG(MODULE, prolog << "Using ~/.netrc file." << endl);
+    }
+}
 
 /**
  *

--- a/modules/dmrpp_module/CredentialsManager.cc
+++ b/modules/dmrpp_module/CredentialsManager.cc
@@ -60,7 +60,7 @@ const string CredentialsManager::ENV_REGION_KEY="CMAC_REGION";
 //const string CredentialsManager::ENV_BUCKET_KEY="CMAC_BUCKET";
 const string CredentialsManager::ENV_URL_KEY="CMAC_URL";
 const string CredentialsManager::ENV_CREDS_KEY_VALUE="ENV_CREDS";
-const string CredentialsManager::NETRC_FILE_KEY="BES.netrc.credentials";
+const string CredentialsManager::NETRC_FILE_KEY="BES.netrc.file";
 
 
 /**

--- a/modules/dmrpp_module/CredentialsManager.h
+++ b/modules/dmrpp_module/CredentialsManager.h
@@ -42,6 +42,7 @@ public:
     //static const std::string ENV_BUCKET_KEY;
     static const std::string ENV_URL_KEY;
     static const std::string ENV_CREDS_KEY_VALUE;
+    static const std::string NETRC_FILE_KEY;
 
 private:
     CredentialsManager();
@@ -53,6 +54,8 @@ private:
 
     AccessCredentials *load_credentials_from_env( );
     void load_ngap_s3_credentials( );
+
+    std::string d_netrc_filename;
 
 public:
     static CredentialsManager *theMngr;
@@ -78,6 +81,7 @@ public:
         return ngaps3CredentialsLoaded;
     }
 
+    std::string get_netrc_filename(){ return d_netrc_filename; }
 };
 
 

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -46,7 +46,7 @@
 #include "BESDebug.h"
 #include "BESInternalError.h"
 #include "BESForbiddenError.h"
-#include <TheBESKeys.h>
+#include "TheBESKeys.h"
 #include "WhiteList.h"
 
 #include "DmrppRequestHandler.h"
@@ -835,6 +835,15 @@ CurlHandlePool::get_easy_handle(Chunk *chunk)
 
         // I added these next three to support Hyrax accessing data held behind URS auth. ndp - 8/20/18
         curl_easy_setopt(handle->d_handle, CURLOPT_NETRC, 1);
+
+        string netrc_file = CredentialsManager::theCM()->get_netrc_filename();
+        if(!netrc_file.empty()){
+            curl_easy_setopt(handle->d_handle, CURLOPT_NETRC_FILE, netrc_file.c_str());
+        }
+
+
+
+
 
         AccessCredentials *credentials = CredentialsManager::theCM()->get(handle->d_url);
         if ( credentials && credentials->isS3Cred()) {

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -833,17 +833,14 @@ CurlHandlePool::get_easy_handle(Chunk *chunk)
         // This requires curl 7.10.6 which is still in pre-release. 07/25/03 jhrg
         curl_easy_setopt(handle->d_handle, CURLOPT_HTTPAUTH, (long) CURLAUTH_ANY);
 
-        // I added these next three to support Hyrax accessing data held behind URS auth. ndp - 8/20/18
+        // Enable using the .netrc credentials file.
         curl_easy_setopt(handle->d_handle, CURLOPT_NETRC, 1);
 
+        // If the configuration specifies a particular .netrc credentials file, use it.
         string netrc_file = CredentialsManager::theCM()->get_netrc_filename();
         if(!netrc_file.empty()){
             curl_easy_setopt(handle->d_handle, CURLOPT_NETRC_FILE, netrc_file.c_str());
         }
-
-
-
-
 
         AccessCredentials *credentials = CredentialsManager::theCM()->get(handle->d_url);
         if ( credentials && credentials->isS3Cred()) {

--- a/modules/ngap_module/curl_utils.cc
+++ b/modules/ngap_module/curl_utils.cc
@@ -450,10 +450,10 @@ CURL *init(char *error_buffer) {
 
     // Follow 302 (redirect) responses
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
-    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5);
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 20);
 
     // Set the user agent to curls version response because, well, that's what command line curl does :)
-    curl_easy_setopt(curl, CURLOPT_USERAGENT, curl_version());
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "Hyrax" /*curl_version()*/ );
 
 #if 0
     // If the user turns off SSL validation...


### PR DESCRIPTION
Added a new bes.conf parameter that allows the .netrc file to be specified in the configuration, avoiding the default.