### PR TITLE
Revert stdout logging

### DIFF
--- a/dispatch/BESLog.h
+++ b/dispatch/BESLog.h
@@ -105,8 +105,7 @@ private:
     static BESLog * d_instance;
 
     int d_flushed;
-    std::ostream * d_file_buffer;
-    //std::ostream * d_file_buffer;
+    std::ofstream * d_file_buffer;
     std::string d_file_name;
 
     // Flag to indicate the object is not routing data to its associated stream
@@ -116,8 +115,6 @@ private:
     bool d_verbose;
 
     bool d_use_local_time; ///< Use UTC by default
-
-    bool stdout;
 
 protected:
     BESLog();

--- a/modules/cmr_module/cmr.conf.in
+++ b/modules/cmr_module/cmr.conf.in
@@ -11,8 +11,9 @@ BES.Include=dap.conf
 # modules to load, includes data modules and command modules            #
 #-----------------------------------------------------------------------#
 
-# BES.modules+=cmr
 BES.module.cmr=@bes_modules_dir@/libcmr_module.so
+# Uncomment this next line to enable CMR module
+# BES.modules+=cmr
 
 # CMR module specific parameters"
 # CMR.Reference: URL to the FoJson Reference Page at docs.opendap.org"


### PR DESCRIPTION
This PR rolls back the changes to the BESLog that enabled logging to stdout. Why? Because the BES uses stdout to transmit responses to the OLFS. Writing the log to stdout from within the BES pollutes the structured communications between the BES and OLFS and breaks the server.

We resolved this for ngap deployments by running `tail -f /var/log/bes/bes.log` at the end of the `entry point.sh` script for the NGAP docker container.