### PR TITLE
The xml:base context bug. A state problem with the DMR cache.

### DIFF
--- a/dap/BESDMRResponse.cc
+++ b/dap/BESDMRResponse.cc
@@ -23,10 +23,27 @@
 // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
 
 #include "BESDMRResponse.h"
+#include "BESDebug.h"
 
 using std::endl;
 using std::string;
 using std::ostream;
+
+#define MODULE "xmlbase"
+#define prolog std::string("BESDMRResponse::").append(__func__).append("() - ")
+
+BESDMRResponse::BESDMRResponse(DMR *dmr) : BESDapResponse(), _dmr(dmr) {
+    string xml_base = get_request_xml_base();
+    _dmr->set_request_xml_base(xml_base);
+    BESDEBUG(MODULE, prolog << "Using BESDapResponse::get_request_xml_base(): \"" << xml_base << "\""<< endl);
+}
+
+BESDMRResponse::~BESDMRResponse() {
+    delete _dmr ;
+}
+
+
+
 
 /** @brief set the container in the DAP response object
  *

--- a/dap/BESDMRResponse.cc
+++ b/dap/BESDMRResponse.cc
@@ -36,6 +36,9 @@ BESDMRResponse::BESDMRResponse(DMR *dmr) : BESDapResponse(), _dmr(dmr) {
     string xml_base = get_request_xml_base();
     _dmr->set_request_xml_base(xml_base);
     BESDEBUG(MODULE, prolog << "Using BESDapResponse::get_request_xml_base(): \"" << xml_base << "\""<< endl);
+    BESDEBUG(MODULE, prolog << "                    _dmr->request_xml_base(): \"" << _dmr->request_xml_base() << "\" (" << (void *) _dmr << ")" << endl);
+    BESDEBUG(MODULE, prolog << " _dmr: "<< (void *)  _dmr << endl);
+    BESDEBUG(MODULE, prolog << " this: "<< (void *)  this << endl);
 }
 
 BESDMRResponse::~BESDMRResponse() {

--- a/dap/BESDMRResponse.cc
+++ b/dap/BESDMRResponse.cc
@@ -29,16 +29,14 @@ using std::endl;
 using std::string;
 using std::ostream;
 
-#define MODULE "xmlbase"
+#define MODULE "dap"
 #define prolog std::string("BESDMRResponse::").append(__func__).append("() - ")
 
 BESDMRResponse::BESDMRResponse(DMR *dmr) : BESDapResponse(), _dmr(dmr) {
     string xml_base = get_request_xml_base();
     _dmr->set_request_xml_base(xml_base);
-    BESDEBUG(MODULE, prolog << "Using BESDapResponse::get_request_xml_base(): \"" << xml_base << "\""<< endl);
-    BESDEBUG(MODULE, prolog << "                    _dmr->request_xml_base(): \"" << _dmr->request_xml_base() << "\" (" << (void *) _dmr << ")" << endl);
-    BESDEBUG(MODULE, prolog << " _dmr: "<< (void *)  _dmr << endl);
-    BESDEBUG(MODULE, prolog << " this: "<< (void *)  this << endl);
+    BESDEBUG(MODULE, prolog << "_dmr->request_xml_base(): \"" << _dmr->request_xml_base()
+        << "\" (dmr: " << (void *) _dmr << ")" << endl);
 }
 
 BESDMRResponse::~BESDMRResponse() {

--- a/dap/BESDMRResponse.h
+++ b/dap/BESDMRResponse.h
@@ -41,8 +41,9 @@ private:
 	DMR * _dmr;
 	//ConstraintEvaluator _ce; //FIXME Use Dap4 CE stuff
 public:
-	BESDMRResponse(DMR *dmr) : BESDapResponse(), _dmr(dmr) { }
-	virtual ~BESDMRResponse() { delete _dmr ; }
+	BESDMRResponse(DMR *dmr);
+
+	virtual ~BESDMRResponse();
 
 	virtual void set_container(const std::string &cn);
 	virtual void clear_container();

--- a/dap/BESDMRResponseHandler.cc
+++ b/dap/BESDMRResponseHandler.cc
@@ -46,9 +46,8 @@
 using namespace bes;
 using namespace std;
 
-#define MODULE "xmlbase"
+#define MODULE "dap"
 #define prolog std::string("BESDMRResponseHandler::").append(__func__).append("() - ")
-
 
 BESDMRResponseHandler::BESDMRResponseHandler(const string &name) :
         BESResponseHandler(name)
@@ -103,9 +102,8 @@ void BESDMRResponseHandler::execute(BESDataHandlerInterface &dhi)
             dmr = mds->get_dmr_object(dhi.container->get_relative_name());
 
             BESDMRResponse *bdmr = new BESDMRResponse(dmr);
-            BESDEBUG(MODULE, prolog << "dmr->request_xml_base(): '"<< dmr->request_xml_base() << "'"<< endl);
-            BESDEBUG(MODULE, prolog << "bdmr->get_dmr()->request_xml_base(): '"<< bdmr->get_dmr()->request_xml_base() << "'"<< endl);
-            BESDEBUG(MODULE, prolog << " dmr: "<< (void *)  dmr << endl);
+            BESDEBUG(MODULE, prolog << "dmr->request_xml_base(): '"<< dmr->request_xml_base() <<
+                "' (dmr: "<< (void *)  dmr  << ")" << endl);
 
             // This method sets the constraint for the current container. It does nothing
             // if there is no 'current container.'
@@ -120,9 +118,8 @@ void BESDMRResponseHandler::execute(BESDataHandlerInterface &dhi)
 
             // if (xml_base_found && !xml_base.empty()) dmr->set_request_xml_base(xml_base);
             BESDMRResponse *bdmr = new BESDMRResponse(dmr);
-            BESDEBUG(MODULE, prolog << "dmr->request_xml_base(): '"<< dmr->request_xml_base() << "'"<< endl);
-            BESDEBUG(MODULE, prolog << "bdmr->get_dmr()->request_xml_base(): '"<< bdmr->get_dmr()->request_xml_base() << "'"<< endl);
-            BESDEBUG(MODULE, prolog << " dmr: "<< (void *)  dmr << endl);
+            BESDEBUG(MODULE, prolog << "dmr->request_xml_base(): '"<< dmr->request_xml_base()
+                << "' (dmr: "<< (void *)dmr << ")" << endl);
 
             d_response_object = bdmr;
 
@@ -130,7 +127,6 @@ void BESDMRResponseHandler::execute(BESDataHandlerInterface &dhi)
 
             // The RequestHandlers set the constraint and reset the container(s)
             BESRequestHandlerList::TheList()->execute_each(dhi);
-
 
             dhi.first_container();  // must reset container; execute_each() iterates over all of them
 

--- a/dap/BESDMRResponseHandler.cc
+++ b/dap/BESDMRResponseHandler.cc
@@ -46,6 +46,10 @@
 using namespace bes;
 using namespace std;
 
+#define MODULE "xmlbase"
+#define prolog std::string("BESDMRResponseHandler::").append(__func__).append("() - ")
+
+
 BESDMRResponseHandler::BESDMRResponseHandler(const string &name) :
         BESResponseHandler(name)
 {
@@ -76,9 +80,6 @@ void BESDMRResponseHandler::execute(BESDataHandlerInterface &dhi)
 {
     dhi.action_name = DMR_RESPONSE_STR;
 
-    bool xml_base_found = false;
-    string xml_base = BESContextManager::TheManager()->get_context("xml:base", xml_base_found);
-
     // Look in the MDS for dhi.container.get_real_name().
     // if found, use that response, else build it.
     // If the MDS is disabled, don't use it.
@@ -101,8 +102,6 @@ void BESDMRResponseHandler::execute(BESDataHandlerInterface &dhi)
             // If mds and lock(), the DDS is in the cache, get the _object_
             dmr = mds->get_dmr_object(dhi.container->get_relative_name());
 
-            if (xml_base_found && !xml_base.empty()) dmr->set_request_xml_base(xml_base);
-
             BESDMRResponse *bdmr = new BESDMRResponse(dmr);
 
             // This method sets the constraint for the current container. It does nothing
@@ -115,8 +114,7 @@ void BESDMRResponseHandler::execute(BESDataHandlerInterface &dhi)
         else {
             dmr = new DMR();
 
-            if (xml_base_found && !xml_base.empty()) dmr->set_request_xml_base(xml_base);
-
+            // if (xml_base_found && !xml_base.empty()) dmr->set_request_xml_base(xml_base);
             d_response_object = new BESDMRResponse(dmr);
 
             // The RequestHandlers set the constraint and reset the container(s)

--- a/dap/BESDMRResponseHandler.cc
+++ b/dap/BESDMRResponseHandler.cc
@@ -103,6 +103,9 @@ void BESDMRResponseHandler::execute(BESDataHandlerInterface &dhi)
             dmr = mds->get_dmr_object(dhi.container->get_relative_name());
 
             BESDMRResponse *bdmr = new BESDMRResponse(dmr);
+            BESDEBUG(MODULE, prolog << "dmr->request_xml_base(): '"<< dmr->request_xml_base() << "'"<< endl);
+            BESDEBUG(MODULE, prolog << "bdmr->get_dmr()->request_xml_base(): '"<< bdmr->get_dmr()->request_xml_base() << "'"<< endl);
+            BESDEBUG(MODULE, prolog << " dmr: "<< (void *)  dmr << endl);
 
             // This method sets the constraint for the current container. It does nothing
             // if there is no 'current container.'
@@ -110,15 +113,24 @@ void BESDMRResponseHandler::execute(BESDataHandlerInterface &dhi)
             bdmr->clear_container();
 
             d_response_object = bdmr;
+            BESDEBUG(MODULE, prolog << "d_response_object: "<< (void *) d_response_object << endl);
         }
         else {
             dmr = new DMR();
 
             // if (xml_base_found && !xml_base.empty()) dmr->set_request_xml_base(xml_base);
-            d_response_object = new BESDMRResponse(dmr);
+            BESDMRResponse *bdmr = new BESDMRResponse(dmr);
+            BESDEBUG(MODULE, prolog << "dmr->request_xml_base(): '"<< dmr->request_xml_base() << "'"<< endl);
+            BESDEBUG(MODULE, prolog << "bdmr->get_dmr()->request_xml_base(): '"<< bdmr->get_dmr()->request_xml_base() << "'"<< endl);
+            BESDEBUG(MODULE, prolog << " dmr: "<< (void *)  dmr << endl);
+
+            d_response_object = bdmr;
+
+            BESDEBUG(MODULE, prolog << "d_response_object: "<< (void *) d_response_object << endl);
 
             // The RequestHandlers set the constraint and reset the container(s)
             BESRequestHandlerList::TheList()->execute_each(dhi);
+
 
             dhi.first_container();  // must reset container; execute_each() iterates over all of them
 

--- a/dap/BESDap4ResponseHandler.cc
+++ b/dap/BESDap4ResponseHandler.cc
@@ -40,10 +40,6 @@
 using namespace std;
 using namespace bes;
 
-#define MODULE "xmlbase"
-#define prolog std::string("BESDap4ResponseHandler::").append(__func__).append("() - ")
-
-
 BESDap4ResponseHandler::BESDap4ResponseHandler(const string &name)
     : BESResponseHandler(name), d_use_dmrpp(false), d_dmrpp_name(DMRPP_DEFAULT_NAME)
 {

--- a/dap/BESDap4ResponseHandler.cc
+++ b/dap/BESDap4ResponseHandler.cc
@@ -40,6 +40,10 @@
 using namespace std;
 using namespace bes;
 
+#define MODULE "xmlbase"
+#define prolog std::string("BESDap4ResponseHandler::").append(__func__).append("() - ")
+
+
 BESDap4ResponseHandler::BESDap4ResponseHandler(const string &name)
     : BESResponseHandler(name), d_use_dmrpp(false), d_dmrpp_name(DMRPP_DEFAULT_NAME)
 {
@@ -90,10 +94,6 @@ void BESDap4ResponseHandler::execute(BESDataHandlerInterface &dhi)
 
 	if (found)
 	    dmr->set_response_limit(response_size_limit);
-
-    string xml_base = BESContextManager::TheManager()->get_context("xml:base", found);
-	if (found && !xml_base.empty())
-		dmr->set_request_xml_base(xml_base);
 
 	d_response_object = new BESDMRResponse(dmr.release());
 

--- a/dap/BESDapResponse.cc
+++ b/dap/BESDapResponse.cc
@@ -44,7 +44,9 @@ using std::ostream;
 #define MODULE "xmlbase"
 #define prolog std::string("BESDapResponse::").append(__func__).append("() - ")
 
-/** @brief Extract the dap protocol from the setConext information
+
+
+/** @brief Extract the dap protocol from the setContext information
 
  This method checks three contexts: dap_explicit_containers, dap_format and
  xdap_accept.
@@ -63,10 +65,13 @@ using std::ostream;
 void BESDapResponse::read_contexts()
 {
     bool found = false;
+    string context_key;
     BESDEBUG(MODULE,prolog << "BEGIN" << endl);
 
     // d_explicit_containers is false by default
-    string context = BESContextManager::TheManager()->get_context("dap_explicit_containers", found);
+    context_key = "dap_explicit_containers";
+    string context = BESContextManager::TheManager()->get_context(context_key, found);
+    BESDEBUG(MODULE,prolog << context_key << ": \"" << context  << "\" found: " << found << endl);
     if (found) {
         if (context == "yes")
             d_explicit_containers = true;
@@ -76,10 +81,10 @@ void BESDapResponse::read_contexts()
             throw BESError("dap_explicit_containers must be yes or no",
             BES_SYNTAX_USER_ERROR, __FILE__, __LINE__);
     }
-    BESDEBUG(MODULE,prolog << "dap_explicit_containers: \"" << context  << "\"" << endl);
-
-    if (!found) {
-        context = BESContextManager::TheManager()->get_context("dap_format", found);
+    else {
+        context_key = "dap_format";
+        context = BESContextManager::TheManager()->get_context(context_key, found);
+        BESDEBUG(MODULE,prolog << context_key << ": \"" << context  << "\" found: " << found << endl);
         if (found) {
             if (context == "dap2")
                 d_explicit_containers = false;
@@ -87,17 +92,17 @@ void BESDapResponse::read_contexts()
                 d_explicit_containers = true;
         }
     }
-    BESDEBUG(MODULE,prolog << "dap_format: \"" << context  << "\"" << endl);
+    BESDEBUG(MODULE,prolog << "d_explicit_containers: " <<  (d_explicit_containers?"true":"false") << endl);
 
     context = BESContextManager::TheManager()->get_context("xdap_accept", found);
     if (found) d_dap_client_protocol = context;
-    BESDEBUG(MODULE,prolog << "xdap_accept: \"" << context  << "\"" << endl);
+    BESDEBUG(MODULE,prolog << "xdap_accept: \"" << context  << "\" found: " << found << endl);
 
     context = BESContextManager::TheManager()->get_context("xml:base", found);
     if (found) d_request_xml_base = context;
-    BESDEBUG(MODULE,prolog << "xml:base: \"" << context  << "\"" << endl);
-    BESDEBUG(MODULE,prolog << "END" << endl);
+    BESDEBUG(MODULE,prolog << "xml:base: \"" << context  << "\" found: " << found << endl);
 
+    BESDEBUG(MODULE,prolog << "END" << endl);
 }
 
 /** @brief See get_explicit_containers()

--- a/dap/BESDapResponse.cc
+++ b/dap/BESDapResponse.cc
@@ -66,16 +66,17 @@ void BESDapResponse::read_contexts()
 {
     bool found = false;
     string context_key;
+    string context_value;
     BESDEBUG(MODULE,prolog << "BEGIN" << endl);
 
     // d_explicit_containers is false by default
     context_key = "dap_explicit_containers";
-    string context = BESContextManager::TheManager()->get_context(context_key, found);
-    BESDEBUG(MODULE,prolog << context_key << ": \"" << context  << "\" found: " << found << endl);
+    context_value = BESContextManager::TheManager()->get_context(context_key, found);
+    BESDEBUG(MODULE,prolog << context_key << ": \"" << context_value  << "\" found: " << found << endl);
     if (found) {
-        if (context == "yes")
+        if (context_value == "yes")
             d_explicit_containers = true;
-        else if (context == "no")
+        else if (context_value == "no")
             d_explicit_containers = false;
         else
             throw BESError("dap_explicit_containers must be yes or no",
@@ -83,10 +84,10 @@ void BESDapResponse::read_contexts()
     }
     else {
         context_key = "dap_format";
-        context = BESContextManager::TheManager()->get_context(context_key, found);
-        BESDEBUG(MODULE,prolog << context_key << ": \"" << context  << "\" found: " << found << endl);
+        context_value = BESContextManager::TheManager()->get_context(context_key, found);
+        BESDEBUG(MODULE,prolog << context_key << ": \"" << context_value  << "\" found: " << found << endl);
         if (found) {
-            if (context == "dap2")
+            if (context_value == "dap2")
                 d_explicit_containers = false;
             else
                 d_explicit_containers = true;
@@ -94,13 +95,15 @@ void BESDapResponse::read_contexts()
     }
     BESDEBUG(MODULE,prolog << "d_explicit_containers: " <<  (d_explicit_containers?"true":"false") << endl);
 
-    context = BESContextManager::TheManager()->get_context("xdap_accept", found);
-    if (found) d_dap_client_protocol = context;
-    BESDEBUG(MODULE,prolog << "xdap_accept: \"" << context  << "\" found: " << found << endl);
+    context_key = "xdap_accept";
+    context_value = BESContextManager::TheManager()->get_context(context_key, found);
+    BESDEBUG(MODULE,prolog << context_key << ": \"" << context_value  << "\" found: " << found << endl);
+    if (found) d_dap_client_protocol = context_value;
 
-    context = BESContextManager::TheManager()->get_context("xml:base", found);
-    if (found) d_request_xml_base = context;
-    BESDEBUG(MODULE,prolog << "xml:base: \"" << context  << "\" found: " << found << endl);
+    context_key = "xml:base";
+    context_value = BESContextManager::TheManager()->get_context(context_key, found);
+    BESDEBUG(MODULE,prolog << context_key << ": \"" << context_value  << "\" found: " << found << endl);
+    if (found) d_request_xml_base = context_value;
 
     BESDEBUG(MODULE,prolog << "END" << endl);
 }

--- a/dap/BESDapResponse.cc
+++ b/dap/BESDapResponse.cc
@@ -35,10 +35,14 @@
 #include "BESConstraintFuncs.h"
 #include "BESDataNames.h"
 #include "BESError.h"
+#include "BESDebug.h"
 
 using std::endl;
 using std::string;
 using std::ostream;
+
+#define MODULE "xmlbase"
+#define prolog std::string("BESDapResponse::").append(__func__).append("() - ")
 
 /** @brief Extract the dap protocol from the setConext information
 
@@ -59,6 +63,7 @@ using std::ostream;
 void BESDapResponse::read_contexts()
 {
     bool found = false;
+    BESDEBUG(MODULE,prolog << "BEGIN" << endl);
 
     // d_explicit_containers is false by default
     string context = BESContextManager::TheManager()->get_context("dap_explicit_containers", found);
@@ -71,6 +76,7 @@ void BESDapResponse::read_contexts()
             throw BESError("dap_explicit_containers must be yes or no",
             BES_SYNTAX_USER_ERROR, __FILE__, __LINE__);
     }
+    BESDEBUG(MODULE,prolog << "dap_explicit_containers: \"" << context  << "\"" << endl);
 
     if (!found) {
         context = BESContextManager::TheManager()->get_context("dap_format", found);
@@ -81,12 +87,16 @@ void BESDapResponse::read_contexts()
                 d_explicit_containers = true;
         }
     }
+    BESDEBUG(MODULE,prolog << "dap_format: \"" << context  << "\"" << endl);
 
     context = BESContextManager::TheManager()->get_context("xdap_accept", found);
     if (found) d_dap_client_protocol = context;
+    BESDEBUG(MODULE,prolog << "xdap_accept: \"" << context  << "\"" << endl);
 
     context = BESContextManager::TheManager()->get_context("xml:base", found);
     if (found) d_request_xml_base = context;
+    BESDEBUG(MODULE,prolog << "xml:base: \"" << context  << "\"" << endl);
+    BESDEBUG(MODULE,prolog << "END" << endl);
 
 }
 

--- a/dap/BESDapResponse.cc
+++ b/dap/BESDapResponse.cc
@@ -41,27 +41,24 @@ using std::endl;
 using std::string;
 using std::ostream;
 
-#define MODULE "xmlbase"
+#define MODULE "dap"
 #define prolog std::string("BESDapResponse::").append(__func__).append("() - ")
 
-
-
-/** @brief Extract the dap protocol from the setContext information
-
- This method checks three contexts: dap_explicit_containers, dap_format and
- xdap_accept.
-
- If given, the boolean value of dap_explicit_containers is used. If that's
- not given then look for dap_format and if that's not given default to
- true. The OLFS should always send this to make Hyrax work the way DAP
- clients expect.
-
- xdap_accept is the value of the DAP that clients can grok. It defaults to
- "2.0"
-
- @note This value will be passed on to the DDS so that it can correctly
- build versions of the DDX which are specified by DAP 3.x and 4.x
- */
+ /** @brief Extract the dap protocol from the setContext information
+  * This method checks four contexts: dap_explicit_containers, dap_format and
+  * xdap_accept, and xml:base
+  *
+  * If given, the boolean value of dap_explicit_containers is used. If that's
+  * not given then look for dap_format and if that's not given default to
+  * true. The OLFS should always send this to make Hyrax work the way DAP
+  * clients expect.
+  *
+  * xdap_accept is the value of the DAP that clients can grok. It defaults to
+  * "2.0"
+  *
+  * @note This value will be passed on to the DDS so that it can correctly
+  * build versions of the DDX which are specified by DAP 3.x and 4.x
+  */
 void BESDapResponse::read_contexts()
 {
     bool found = false;
@@ -72,7 +69,7 @@ void BESDapResponse::read_contexts()
     // d_explicit_containers is false by default
     context_key = "dap_explicit_containers";
     context_value = BESContextManager::TheManager()->get_context(context_key, found);
-    BESDEBUG(MODULE,prolog << context_key << ": \"" << context_value  << "\" found: " << found << endl);
+    //BESDEBUG(MODULE,prolog << context_key << ": \"" << context_value  << "\" found: " << found << endl);
     if (found) {
         if (context_value == "yes")
             d_explicit_containers = true;
@@ -85,7 +82,7 @@ void BESDapResponse::read_contexts()
     else {
         context_key = "dap_format";
         context_value = BESContextManager::TheManager()->get_context(context_key, found);
-        BESDEBUG(MODULE,prolog << context_key << ": \"" << context_value  << "\" found: " << found << endl);
+        //BESDEBUG(MODULE,prolog << context_key << ": \"" << context_value  << "\" found: " << found << endl);
         if (found) {
             if (context_value == "dap2")
                 d_explicit_containers = false;
@@ -97,13 +94,15 @@ void BESDapResponse::read_contexts()
 
     context_key = "xdap_accept";
     context_value = BESContextManager::TheManager()->get_context(context_key, found);
-    BESDEBUG(MODULE,prolog << context_key << ": \"" << context_value  << "\" found: " << found << endl);
+    //BESDEBUG(MODULE,prolog << context_key << ": \"" << context_value  << "\" found: " << found << endl);
     if (found) d_dap_client_protocol = context_value;
+    BESDEBUG(MODULE,prolog << "d_dap_client_protocol: " <<  d_dap_client_protocol << endl);
 
     context_key = "xml:base";
     context_value = BESContextManager::TheManager()->get_context(context_key, found);
-    BESDEBUG(MODULE,prolog << context_key << ": \"" << context_value  << "\" found: " << found << endl);
+    //BESDEBUG(MODULE,prolog << context_key << ": \"" << context_value  << "\" found: " << found << endl);
     if (found) d_request_xml_base = context_value;
+    BESDEBUG(MODULE,prolog << "d_request_xml_base: " <<  d_request_xml_base << endl);
 
     BESDEBUG(MODULE,prolog << "END" << endl);
 }

--- a/dap/BESDapResponseBuilder.cc
+++ b/dap/BESDapResponseBuilder.cc
@@ -1378,6 +1378,7 @@ void BESDapResponseBuilder::send_dmr(ostream &out, DMR &dmr, bool with_mime_head
 
 
     XMLWriter xml;
+    BESDEBUG("xmlbase", "BESDapResponseBuilder::send_dmr() - dmr.request_xml_base(): '"<< dmr.request_xml_base() << "' (dmr: " << (void *) &dmr << ")" << endl);
     dmr.print_dap4(xml, /*constrained &&*/!d_dap4ce.empty() /* true == constrained */);
     out << xml.get_doc() << flush;
 }

--- a/dap/BESDapResponseBuilder.cc
+++ b/dap/BESDapResponseBuilder.cc
@@ -82,6 +82,7 @@
 #include <mime_util.h>	// for last_modified_time() and rfc_822_date()
 #include <escaping.h>
 #include <util.h>
+
 #if USE_LOCAL_TIMEOUT_SCHEME
 #ifndef WIN32
 #include <SignalHandler.h>
@@ -118,6 +119,7 @@ using namespace libdap;
 const string CRLF = "\r\n";             // Change here, expr-test.cc
 const string BES_KEY_TIMEOUT_CANCEL = "BES.CancelTimeoutOnSend";
 
+#define MODULE "dap"
 #define prolog std::string("BESDapResponseBuilder::").append(__func__).append("() - ")
 
 /**
@@ -228,7 +230,7 @@ std::string BESDapResponseBuilder::get_store_result() const
 void BESDapResponseBuilder::set_store_result(std::string _sr)
 {
     d_store_result = _sr;
-    BESDEBUG("dap", "BESDapResponseBuilder::set_store_result() - store_result: " << _sr << endl);
+    BESDEBUG(MODULE, prolog << "store_result: " << _sr << endl);
 }
 
 std::string BESDapResponseBuilder::get_async_accepted() const
@@ -239,7 +241,7 @@ std::string BESDapResponseBuilder::get_async_accepted() const
 void BESDapResponseBuilder::set_async_accepted(std::string _aa)
 {
     d_async_accepted = _aa;
-    BESDEBUG("dap", "BESDapResponseBuilder::set_async_accepted() - async_accepted: " << _aa << endl);
+    BESDEBUG(MODULE, prolog << "set_async_accepted() - async_accepted: " << _aa << endl);
 }
 
 /** The ``dataset name'' is the filename or other string that the
@@ -419,7 +421,7 @@ static string::size_type find_closing_paren(const string &ce, string::size_type 
  */
 void BESDapResponseBuilder::split_ce(ConstraintEvaluator &eval, const string &expr)
 {
-    BESDEBUG("dap", "BESDapResponseBuilder::split_ce() - source expression: " << expr << endl);
+    BESDEBUG(MODULE, prolog << "source expression: " << expr << endl);
 
     string ce;
     if (!expr.empty())
@@ -462,9 +464,9 @@ void BESDapResponseBuilder::split_ce(ConstraintEvaluator &eval, const string &ex
     d_dap2ce = ce;
     d_btp_func_ce = btp_function_ce;
 
-    BESDEBUG("dap", "BESDapResponseBuilder::split_ce() - Modified constraint: " << d_dap2ce << endl);
-    BESDEBUG("dap", "BESDapResponseBuilder::split_ce() - BTP Function part: " << btp_function_ce << endl);
-    BESDEBUG("dap", "BESDapResponseBuilder::split_ce() - END" << endl);
+    BESDEBUG(MODULE, prolog << "Modified constraint: " << d_dap2ce << endl);
+    BESDEBUG(MODULE, prolog << "BTP Function part: " << btp_function_ce << endl);
+    BESDEBUG(MODULE, prolog << "END" << endl);
 }
 
 /**
@@ -738,37 +740,36 @@ bool BESDapResponseBuilder::store_dap2_result(ostream &out, DDS &dds, Constraint
         msg += "Unable to acquire StoredResultCache instance. ";
         msg += "This is most likely because the StoredResultCache is not (correctly) configured.";
 
-        BESDEBUG("dap", "[WARNING] " << msg << endl);
+        BESDEBUG(MODULE, prolog << "[WARNING] " << msg << endl);
 
         d4au.writeD4AsyncResponseRejected(xmlWrtr, UNAVAILABLE, msg, stylesheet_ref);
         out << xmlWrtr.get_doc();
         out << flush;
 
-        BESDEBUG("dap", "BESDapResponseBuilder::store_dap2_result() - Sent AsyncRequestRejected" << endl);
+        BESDEBUG(MODULE,prolog << "Sent AsyncRequestRejected" << endl);
     }
     else if (get_async_accepted().length() != 0) {
 
         /**
          * Client accepts async responses so, woot! lets store this thing and tell them where to find it.
          */
-        BESDEBUG("dap", "BESDapResponseBuilder::store_dap2_result() - serviceUrl="<< serviceUrl << endl);
+        BESDEBUG(MODULE, prolog << "serviceUrl="<< serviceUrl << endl);
 
         BESStoredDapResultCache *resultCache = BESStoredDapResultCache::get_instance();
         string storedResultId = "";
         storedResultId = resultCache->store_dap2_result(dds, get_ce(), this, &eval);
 
-        BESDEBUG("dap",
-            "BESDapResponseBuilder::store_dap2_result() - storedResultId='"<< storedResultId << "'" << endl);
+        BESDEBUG(MODULE, prolog << "storedResultId='"<< storedResultId << "'" << endl);
 
         string targetURL = BESUtil::assemblePath(serviceUrl, storedResultId);
-        BESDEBUG("dap", "BESDapResponseBuilder::store_dap2_result() - targetURL='"<< targetURL << "'" << endl);
+        BESDEBUG(MODULE, prolog << "targetURL='"<< targetURL << "'" << endl);
 
         XMLWriter xmlWrtr;
         d4au.writeD4AsyncAccepted(xmlWrtr, 0, 0, targetURL, stylesheet_ref);
         out << xmlWrtr.get_doc();
         out << flush;
 
-        BESDEBUG("dap", "BESDapResponseBuilder::store_dap2_result() - sent DAP4 AsyncAccepted response" << endl);
+        BESDEBUG(MODULE, prolog << "Sent DAP4 AsyncAccepted response" << endl);
     }
     else {
         /**
@@ -779,7 +780,7 @@ bool BESDapResponseBuilder::store_dap2_result(ostream &out, DDS &dds, Constraint
         out << xmlWrtr.get_doc();
         out << flush;
 
-        BESDEBUG("dap", "BESDapResponseBuilder::store_dap2_result() - sent DAP4 AsyncRequired  response" << endl);
+        BESDEBUG(MODULE, prolog << "Sent DAP4 AsyncRequired  response" << endl);
     }
 
     return true;
@@ -795,7 +796,7 @@ void BESDapResponseBuilder::serialize_dap2_data_dds(ostream &out, DDS **dds, Con
     BESStopWatch sw;
     if (BESISDEBUG(TIMING_LOG)) sw.start("BESDapResponseBuilder::serialize_dap2_data_dds", "");
 
-    BESDEBUG("dap", "BESDapResponseBuilder::serialize_dap2_data_dds() - BEGIN" << endl);
+    BESDEBUG(MODULE, prolog << "BEGIN" << endl);
 
     (*dds)->print_constrained(out);
     out << "Data:\n";
@@ -817,7 +818,7 @@ void BESDapResponseBuilder::serialize_dap2_data_dds(ostream &out, DDS **dds, Con
         }
     }
 
-    BESDEBUG("dap", "BESDapResponseBuilder::serialize_dap2_data_dds() - END" << endl);
+    BESDEBUG(MODULE, prolog << "END" << endl);
 }
 
 #ifdef DAP2_STORED_RESULTS
@@ -832,7 +833,7 @@ void BESDapResponseBuilder::serialize_dap2_data_dds(ostream &out, DDS **dds, Con
 void BESDapResponseBuilder::serialize_dap2_data_ddx(ostream &out, DDS **dds, ConstraintEvaluator &eval,
     const string &boundary, const string &start, bool ce_eval)
 {
-    BESDEBUG("dap", __PRETTY_FUNCTION__ << " BEGIN" << endl);
+    BESDEBUG(MODULE, prolog << "BEGIN" << endl);
 
     // Write the MPM headers for the DDX (text/xml) part of the response
     libdap::set_mime_ddx_boundary(out, boundary, start, dods_ddx, x_plain);
@@ -869,7 +870,7 @@ void BESDapResponseBuilder::serialize_dap2_data_ddx(ostream &out, DDS **dds, Con
         }
     }
 
-    BESDEBUG("dap", __PRETTY_FUNCTION__ << " END" << endl);
+    BESDEBUG(MODULE, prolog << "END" << endl);
 }
 #endif
 
@@ -912,7 +913,7 @@ void BESDapResponseBuilder::remove_timeout() const
 libdap::DDS *
 BESDapResponseBuilder::process_dap2_dds(BESResponseObject *obj, BESDataHandlerInterface &dhi)
 {
-    BESDEBUG("dap", "BESDapResponseBuilder::process_dap2_dds() - BEGIN"<< endl);
+    BESDEBUG(MODULE, prolog << "BEGIN"<< endl);
 
     dhi.first_container();
 
@@ -957,6 +958,7 @@ BESDapResponseBuilder::process_dap2_dds(BESResponseObject *obj, BESDataHandlerIn
     }
 
     eval.parse_constraint(d_dap2ce, *dds); // Throws Error if the ce doesn't parse.
+    BESDEBUG(MODULE, prolog << "END"<< endl);
 
     return dds;
 }
@@ -981,7 +983,7 @@ BESDapResponseBuilder::process_dap2_dds(BESResponseObject *obj, BESDataHandlerIn
 libdap::DDS *
 BESDapResponseBuilder::intern_dap2_data(BESResponseObject *obj, BESDataHandlerInterface &dhi)
 {
-    BESDEBUG("dap", "BESDapResponseBuilder::intern_dap2_data() - BEGIN"<< endl);
+    BESDEBUG(MODULE, prolog << "BEGIN"<< endl);
 
     dhi.first_container();
 
@@ -1012,8 +1014,7 @@ BESDapResponseBuilder::intern_dap2_data(BESResponseObject *obj, BESDataHandlerIn
     // Use that DDS and parse the non-function ce
     // Serialize using the second ce and the second dds
     if (!get_btp_func_ce().empty()) {
-        BESDEBUG("dap",
-            "BESDapResponseBuilder::intern_dap2_data() - Found function(s) in CE: " << get_btp_func_ce() << endl);
+        BESDEBUG(MODULE,prolog << "Found function(s) in CE: " << get_btp_func_ce() << endl);
 
         BESDapFunctionResponseCache *responseCache = BESDapFunctionResponseCache::get_instance();
 
@@ -1065,7 +1066,7 @@ BESDapResponseBuilder::intern_dap2_data(BESResponseObject *obj, BESDataHandlerIn
         }
     }
 
-    BESDEBUG("dap", "BESDapResponseBuilder::intern_dap2_data() - END"<< endl);
+    BESDEBUG(MODULE, prolog << "END"<< endl);
 
     return dds;
 }
@@ -1086,7 +1087,7 @@ BESDapResponseBuilder::intern_dap2_data(BESResponseObject *obj, BESDataHandlerIn
 void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, ConstraintEvaluator &eval,
     bool with_mime_headers)
 {
-    BESDEBUG("dap", "BESDapResponseBuilder::send_dap2_data() - BEGIN"<< endl);
+    BESDEBUG(MODULE, prolog << "BEGIN"<< endl);
 
 #if USE_LOCAL_TIMEOUT_SCHEME
     // Set up the alarm.
@@ -1101,8 +1102,7 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
     // Use that DDS and parse the non-function ce
     // Serialize using the second ce and the second dds
     if (!get_btp_func_ce().empty()) {
-        BESDEBUG("dap",
-            "BESDapResponseBuilder::send_dap2_data() - Found function(s) in CE: " << get_btp_func_ce() << endl);
+        BESDEBUG(MODULE,prolog << "Found function(s) in CE: " << get_btp_func_ce() << endl);
 
         BESDapFunctionResponseCache *response_cache = BESDapFunctionResponseCache::get_instance();
 
@@ -1144,7 +1144,7 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
 
     }
     else {
-        BESDEBUG("dap", "BESDapResponseBuilder::send_dap2_data() - Simple constraint" << endl);
+        BESDEBUG(MODULE, prolog << "Simple constraint" << endl);
 
         eval.parse_constraint(get_ce(), **dds); // Throws Error if the ce doesn't parse.
 
@@ -1167,14 +1167,14 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
 
     data_stream << flush;
 
-    BESDEBUG("dap", "BESDapResponseBuilder::send_dap2_data() - END"<< endl);
+    BESDEBUG(MODULE, prolog << "END"<< endl);
 
 }
 
 void BESDapResponseBuilder::send_dap2_data(BESDataHandlerInterface &dhi, DDS **dds, ConstraintEvaluator &eval,
     bool with_mime_headers)
 {
-    BESDEBUG("dap", "BESDapResponseBuilder::send_dap2_data() - BEGIN"<< endl);
+    BESDEBUG(MODULE, prolog << "BEGIN"<< endl);
 
     ostream & data_stream = dhi.get_output_stream();
 #if USE_LOCAL_TIMEOUT_SCHEME
@@ -1190,8 +1190,7 @@ void BESDapResponseBuilder::send_dap2_data(BESDataHandlerInterface &dhi, DDS **d
     // Use that DDS and parse the non-function ce
     // Serialize using the second ce and the second dds
     if (!get_btp_func_ce().empty()) {
-        BESDEBUG("dap",
-            "BESDapResponseBuilder::send_dap2_data() - Found function(s) in CE: " << get_btp_func_ce() << endl);
+        BESDEBUG(MODULE, prolog << "Found function(s) in CE: " << get_btp_func_ce() << endl);
 
         // Server-side functions need to include the attributes in data access.
         // So obtain the attributes if necessary. KY 2019-10-30
@@ -1246,7 +1245,7 @@ void BESDapResponseBuilder::send_dap2_data(BESDataHandlerInterface &dhi, DDS **d
 
     }
     else {
-        BESDEBUG("dap", "BESDapResponseBuilder::send_dap2_data() - Simple constraint" << endl);
+        BESDEBUG(MODULE, prolog << "Simple constraint" << endl);
 
         eval.parse_constraint(get_ce(), **dds); // Throws Error if the ce doesn't parse.
 
@@ -1269,7 +1268,7 @@ void BESDapResponseBuilder::send_dap2_data(BESDataHandlerInterface &dhi, DDS **d
 
     data_stream << flush;
 
-    BESDEBUG("dap", "BESDapResponseBuilder::send_dap2_data() - END"<< endl);
+    BESDEBUG(MODULE, prolog << "END"<< endl);
 
 }
 /** Send the DDX response. The DDX never contains data, instead it holds a
@@ -1361,7 +1360,7 @@ void BESDapResponseBuilder::send_dmr(ostream &out, DMR &dmr, bool with_mime_head
     // throw Error
     if (!d_dap4ce.empty()) {
 
-        BESDEBUG("dap", prolog << "Parsing DAP4 constraint: '"<< d_dap4ce << "'"<< endl);
+        BESDEBUG(MODULE, prolog << "Parsing DAP4 constraint: '"<< d_dap4ce << "'"<< endl);
 
         D4ConstraintEvaluator parser(&dmr);
         bool parse_ok = parser.parse(d_dap4ce);
@@ -1378,10 +1377,9 @@ void BESDapResponseBuilder::send_dmr(ostream &out, DMR &dmr, bool with_mime_head
 
     conditional_timeout_cancel();
 
-    BESDEBUG("xmlbase", prolog << "DMR::request_xml_base(): \"" << dmr.request_xml_base() << "\""<< endl);
+    BESDEBUG(MODULE, prolog << "dmr.request_xml_base(): '"<< dmr.request_xml_base() << "' (dmr: " << (void *) &dmr << ")" << endl);
 
     XMLWriter xml;
-    BESDEBUG("xmlbase", "BESDapResponseBuilder::send_dmr() - dmr.request_xml_base(): '"<< dmr.request_xml_base() << "' (dmr: " << (void *) &dmr << ")" << endl);
     dmr.print_dap4(xml, /*constrained &&*/!d_dap4ce.empty() /* true == constrained */);
     out << xml.get_doc() << flush;
 }
@@ -1447,11 +1445,11 @@ void BESDapResponseBuilder::send_dap4_data(ostream &out, DMR &dmr, bool with_mim
  */
 void BESDapResponseBuilder::serialize_dap4_data(std::ostream &out, libdap::DMR &dmr, bool with_mime_headers)
 {
-    BESDEBUG("dap", "BESDapResponseBuilder::serialize_dap4_data() - BEGIN" << endl);
+    BESDEBUG(MODULE, prolog << "BEGIN" << endl);
 
     if (with_mime_headers) set_mime_binary(out, dap4_data, x_plain, last_modified_time(d_dataset), dmr.dap_version());
 
-    BESDEBUG("xmlbase", prolog << "DMR::request_xml_base(): \"" << dmr.request_xml_base() << "\""<< endl);
+    BESDEBUG(MODULE, prolog << "dmr.request_xml_base(): \"" << dmr.request_xml_base() << "\""<< endl);
 
     // Write the DMR
     XMLWriter xml;
@@ -1475,7 +1473,7 @@ void BESDapResponseBuilder::serialize_dap4_data(std::ostream &out, libdap::DMR &
 #endif
     cos << flush;
 
-    BESDEBUG("dap", "BESDapResponseBuilder::serialize_dap4_data() - END" << endl);
+    BESDEBUG(MODULE, prolog << "END" << endl);
 }
 
 /**
@@ -1520,11 +1518,11 @@ bool BESDapResponseBuilder::store_dap4_result(ostream &out, libdap::DMR &dmr)
             msg += "Unable to acquire StoredResultCache instance. ";
             msg += "This is most likely because the StoredResultCache is not (correctly) configured.";
 
-            BESDEBUG("dap", "[WARNING] " << msg << endl);
+            BESDEBUG(MODULE, prolog << "[WARNING] " << msg << endl);
             d4au.writeD4AsyncResponseRejected(xmlWrtr, UNAVAILABLE, msg, stylesheet_ref);
             out << xmlWrtr.get_doc();
             out << flush;
-            BESDEBUG("dap", "BESDapResponseBuilder::store_dap4_result() - Sent AsyncRequestRejected" << endl);
+            BESDEBUG(MODULE, prolog << "Sent AsyncRequestRejected" << endl);
 
             return true;
         }
@@ -1534,21 +1532,20 @@ bool BESDapResponseBuilder::store_dap4_result(ostream &out, libdap::DMR &dmr)
             /**
              * Client accepts async responses so, woot! lets store this thing and tell them where to find it.
              */
-            BESDEBUG("dap", "BESDapResponseBuilder::store_dap4_result() - serviceUrl="<< serviceUrl << endl);
+            BESDEBUG(MODULE, prolog << "serviceUrl="<< serviceUrl << endl);
 
             string storedResultId = "";
             storedResultId = resultCache->store_dap4_result(dmr, get_ce(), this);
 
-            BESDEBUG("dap",
-                "BESDapResponseBuilder::store_dap4_result() - storedResultId='"<< storedResultId << "'" << endl);
+            BESDEBUG(MODULE,prolog << "storedResultId='"<< storedResultId << "'" << endl);
 
             string targetURL = BESUtil::assemblePath(serviceUrl, storedResultId);
-            BESDEBUG("dap", "BESDapResponseBuilder::store_dap4_result() - targetURL='"<< targetURL << "'" << endl);
+            BESDEBUG(MODULE, prolog << "targetURL='"<< targetURL << "'" << endl);
 
             d4au.writeD4AsyncAccepted(xmlWrtr, 0, 0, targetURL, stylesheet_ref);
             out << xmlWrtr.get_doc();
             out << flush;
-            BESDEBUG("dap", "BESDapResponseBuilder::store_dap4_result() - sent AsyncAccepted" << endl);
+            BESDEBUG(MODULE, prolog << "Sent AsyncAccepted" << endl);
 
         }
         else {
@@ -1559,7 +1556,7 @@ bool BESDapResponseBuilder::store_dap4_result(ostream &out, libdap::DMR &dmr)
             d4au.writeD4AsyncRequired(xmlWrtr, 0, 0, stylesheet_ref);
             out << xmlWrtr.get_doc();
             out << flush;
-            BESDEBUG("dap", "BESDapResponseBuilder::store_dap4_result() - sent AsyncAccepted" << endl);
+            BESDEBUG(MODULE, prolog << "Sent AsyncAccepted" << endl);
         }
 
         return true;

--- a/dap/BESDapTransmit.cc
+++ b/dap/BESDapTransmit.cc
@@ -59,6 +59,9 @@
 using namespace libdap;
 using namespace std;
 
+#define MODULE "xmlbase"
+#define prolog std::string("DapTransmit::").append(__func__).append("() - ")
+
 ///////////////////////////////////////////////////////////////////////////////
 // Local Helpers
 
@@ -257,6 +260,10 @@ private:
 
         DMR *dmr = bdmr->get_dmr();
 
+        BESDEBUG(MODULE, prolog << "SendDMR bdmr: "<< (void *)  bdmr << endl);
+        BESDEBUG(MODULE, prolog << "SendDMR  dmr: "<< (void *)  dmr << endl);
+        BESDEBUG(MODULE, prolog << "SendDMR dmr->request_xml_base(): '"<< dmr->request_xml_base() << endl);
+
         dhi.first_container();
 
         BESDapResponseBuilder rb;
@@ -288,6 +295,10 @@ private:
         if (!bdmr) throw BESInternalError("cast error", __FILE__, __LINE__);
 
         DMR *dmr = bdmr->get_dmr();
+
+        BESDEBUG(MODULE, prolog << "SendDap4Data bdmr: "<< (void *)  bdmr << endl);
+        BESDEBUG(MODULE, prolog << "SendDap4Data  dmr: "<< (void *)  dmr << endl);
+        BESDEBUG(MODULE, prolog << "SendDap4Data dmr->request_xml_base(): '"<< dmr->request_xml_base() << endl);
 
         dhi.first_container();
 

--- a/dap/BESDapTransmit.cc
+++ b/dap/BESDapTransmit.cc
@@ -59,7 +59,7 @@
 using namespace libdap;
 using namespace std;
 
-#define MODULE "xmlbase"
+#define MODULE "dap"
 #define prolog std::string("DapTransmit::").append(__func__).append("() - ")
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -175,7 +175,7 @@ private:
         BESDapResponseBuilder rb;
         rb.set_dataset_name(dhi.container->get_real_name());
         rb.set_ce(dhi.data[POST_CONSTRAINT]);
-        BESDEBUG("dap", "dhi.data[POST_CONSTRAINT]: " << dhi.data[POST_CONSTRAINT] << endl);
+        BESDEBUG(MODULE, prolog << "dhi.data[POST_CONSTRAINT]: " << dhi.data[POST_CONSTRAINT] << endl);
         rb.send_dds(dhi.get_output_stream(), &dds, ce, true, print_mime);
         bdds->set_dds(dds);
     }
@@ -208,7 +208,7 @@ private:
         rb.set_async_accepted(dhi.data[ASYNC]);
         rb.set_store_result(dhi.data[STORE_RESULT]);
 
-        BESDEBUG("dap", "dhi.data[POST_CONSTRAINT]: " << dhi.data[POST_CONSTRAINT] << endl);
+        BESDEBUG(MODULE, prolog << "dhi.data[POST_CONSTRAINT]: " << dhi.data[POST_CONSTRAINT] << endl);
         //rb.send_dap2_data(dhi.get_output_stream(), &dds, ce, print_mime);
         rb.send_dap2_data(dhi, &dds, ce, print_mime);
         bdds->set_dds(dds);
@@ -253,16 +253,14 @@ private:
 
     virtual void send_internal(BESResponseObject * obj, BESDataHandlerInterface & dhi)
     {
-        BESDEBUG("dap", "Entering SendDMR::send_internal ..." << endl);
+        BESDEBUG(MODULE, prolog << "SendDMR::send_internal() - BEGIN" << endl);
 
         BESDMRResponse *bdmr = dynamic_cast<BESDMRResponse *>(obj);
         if (!bdmr) throw BESInternalError("cast error", __FILE__, __LINE__);
 
         DMR *dmr = bdmr->get_dmr();
 
-        BESDEBUG(MODULE, prolog << "SendDMR bdmr: "<< (void *)  bdmr << endl);
-        BESDEBUG(MODULE, prolog << "SendDMR  dmr: "<< (void *)  dmr << endl);
-        BESDEBUG(MODULE, prolog << "SendDMR dmr->request_xml_base(): '"<< dmr->request_xml_base() << endl);
+        BESDEBUG(MODULE, prolog << "SendDMR::send_internal() - dmr->request_xml_base(): '"<< dmr->request_xml_base() << endl);
 
         dhi.first_container();
 
@@ -276,6 +274,7 @@ private:
         rb.set_store_result(dhi.data[STORE_RESULT]);
 
         rb.send_dmr(dhi.get_output_stream(), *dmr, get_print_mime());
+        BESDEBUG(MODULE, prolog << "SendDMR::send_internal() - END" << endl);
     }
 };
 
@@ -288,6 +287,7 @@ private:
     }
     virtual void send_internal(BESResponseObject * obj, BESDataHandlerInterface & dhi)
     {
+        BESDEBUG(MODULE, prolog << "SendDap4Data::send_internal() - BEGIN" << endl);
         // In DAP2 we made a special object for data - a child of DDS. That turned to make
         // some code harder to write, so this time I'll just use the DMR to hold data. jhrg
         // 10/31/13
@@ -296,9 +296,7 @@ private:
 
         DMR *dmr = bdmr->get_dmr();
 
-        BESDEBUG(MODULE, prolog << "SendDap4Data bdmr: "<< (void *)  bdmr << endl);
-        BESDEBUG(MODULE, prolog << "SendDap4Data  dmr: "<< (void *)  dmr << endl);
-        BESDEBUG(MODULE, prolog << "SendDap4Data dmr->request_xml_base(): '"<< dmr->request_xml_base() << endl);
+        BESDEBUG(MODULE, prolog << "SendDap4Data::send_internal() -  dmr->request_xml_base(): '"<< dmr->request_xml_base() << endl);
 
         dhi.first_container();
 
@@ -312,6 +310,7 @@ private:
         rb.set_store_result(dhi.data[STORE_RESULT]);
 
         rb.send_dap4_data(dhi.get_output_stream(), *dmr, get_print_mime());
+        BESDEBUG(MODULE, prolog << "SendDap4Data::send_internal() - END" << endl);
     }
 };
 

--- a/dap/GlobalMetadataStore.h
+++ b/dap/GlobalMetadataStore.h
@@ -262,7 +262,7 @@ public:
     virtual void write_dds_response(const std::string &name, std::ostream &os);
     virtual void write_das_response(const std::string &name, std::ostream &os);
 
-    // Add a third parameter to enable changing the value of xmlbase in this response.
+    // @TODO Add a third parameter to enable changing the value of xmlbase in this response.
     // jhrg 2.28.18
     virtual void write_dmr_response(const std::string &name, std::ostream &os);
     virtual void write_dmrpp_response(const std::string &name, std::ostream &os);

--- a/dispatch/BESContextManager.cc
+++ b/dispatch/BESContextManager.cc
@@ -38,12 +38,15 @@
 
 #include "BESContextManager.h"
 #include "BESInfo.h"
+#include "BESDebug.h"
 
 using std::endl;
 using std::string;
 using std::ostream;
 
 BESContextManager *BESContextManager::_instance = 0;
+
+#define MODULE "context"
 
 /** @brief set context in the BES
  *
@@ -52,6 +55,7 @@ BESContextManager *BESContextManager::_instance = 0;
  */
 void BESContextManager::set_context(const string &name, const string &value)
 {
+    BESDEBUG(MODULE, "BESContextManager::set_context(name=\"" << name << "\", value=\"" << value << "\")" << endl);
     _context_list[name] = value;
 }
 
@@ -62,6 +66,7 @@ void BESContextManager::set_context(const string &name, const string &value)
  */
 void BESContextManager::unset_context(const string &name)
 {
+    BESDEBUG(MODULE, "BESContextManager::unset_context(name=\"" << name << "\")" << endl);
     _context_list.erase(name);
 }
 
@@ -84,6 +89,7 @@ string BESContextManager::get_context(const string &name, bool &found)
         ret = (*i).second;
         found = true;
     }
+    BESDEBUG(MODULE, "BESContextManager::get_context(name=\"" << name << "\", found=\"" << found << "\"): \"" << ret << "\"" << endl);
     return ret;
 }
 
@@ -108,6 +114,7 @@ int BESContextManager::get_context_int(const string &name, bool &found)
         throw BESInternalError(string("Error reading an integer value for the context '") + name + "': " + strerror(errno),
             __FILE__, __LINE__);
     }
+    BESDEBUG(MODULE, "BESContextManager::get_context_int(name=\"" << name << "\", found=\"" << found << "\"): \"" << val << "\"" << endl);
 
     return val;
 }

--- a/dispatch/BESContextManager.cc
+++ b/dispatch/BESContextManager.cc
@@ -81,15 +81,24 @@ void BESContextManager::unset_context(const string &name)
  */
 string BESContextManager::get_context(const string &name, bool &found)
 {
+#if 1
     string ret = "";
     found = false;
     BESContextManager::Context_iter i;
+    string s = _context_list[name];
     i = _context_list.find(name);
     if (i != _context_list.end()) {
         ret = (*i).second;
         found = true;
     }
     BESDEBUG(MODULE, "BESContextManager::get_context(name=\"" << name << "\", found=\"" << found << "\"): \"" << ret << "\"" << endl);
+#else
+
+    string ret = _context_list[name];
+    BESDEBUG(MODULE, "BESContextManager::get_context(name=\"" << name << "): \"" << ret << "\"" << endl);
+
+#endif
+
     return ret;
 }
 

--- a/dispatch/BESContextManager.cc
+++ b/dispatch/BESContextManager.cc
@@ -47,6 +47,7 @@ using std::ostream;
 BESContextManager *BESContextManager::_instance = 0;
 
 #define MODULE "context"
+#define prolog std::string("BESContextManager::").append(__func__).append("() - ")
 
 /** @brief set context in the BES
  *
@@ -55,7 +56,7 @@ BESContextManager *BESContextManager::_instance = 0;
  */
 void BESContextManager::set_context(const string &name, const string &value)
 {
-    BESDEBUG(MODULE, "BESContextManager::set_context(name=\"" << name << "\", value=\"" << value << "\")" << endl);
+    BESDEBUG(MODULE, prolog << "name=\"" << name << "\", value=\"" << value << "\"" << endl);
     _context_list[name] = value;
 }
 
@@ -66,7 +67,7 @@ void BESContextManager::set_context(const string &name, const string &value)
  */
 void BESContextManager::unset_context(const string &name)
 {
-    BESDEBUG(MODULE, "BESContextManager::unset_context(name=\"" << name << "\")" << endl);
+    BESDEBUG(MODULE, prolog << "name=\"" << name << "\"" << endl);
     _context_list.erase(name);
 }
 
@@ -85,17 +86,16 @@ string BESContextManager::get_context(const string &name, bool &found)
     string ret = "";
     found = false;
     BESContextManager::Context_iter i;
-    string s = _context_list[name];
     i = _context_list.find(name);
     if (i != _context_list.end()) {
         ret = (*i).second;
         found = true;
     }
-    BESDEBUG(MODULE, "BESContextManager::get_context(name=\"" << name << "\", found=\"" << found << "\"): \"" << ret << "\"" << endl);
+    BESDEBUG(MODULE, prolog << "name=\"" << name << "\", found=\"" << found << "\" value:\"" << ret << "\"" << endl);
 #else
 
     string ret = _context_list[name];
-    BESDEBUG(MODULE, "BESContextManager::get_context(name=\"" << name << "): \"" << ret << "\"" << endl);
+    BESDEBUG(MODULE, prolog << "name=\"" << name << "\"  value: \"" << ret << "\"" << endl);
 
 #endif
 
@@ -123,7 +123,7 @@ int BESContextManager::get_context_int(const string &name, bool &found)
         throw BESInternalError(string("Error reading an integer value for the context '") + name + "': " + strerror(errno),
             __FILE__, __LINE__);
     }
-    BESDEBUG(MODULE, "BESContextManager::get_context_int(name=\"" << name << "\", found=\"" << found << "\"): \"" << val << "\"" << endl);
+    BESDEBUG(MODULE, prolog << "name=\"" << name << "\", found=\"" << found << "\" value: \"" << val << "\"" << endl);
 
     return val;
 }
@@ -156,7 +156,7 @@ void BESContextManager::list_context(BESInfo &info)
  */
 void BESContextManager::dump(ostream &strm) const
 {
-    strm << BESIndent::LMarg << "BESContextManager::dump - (" << (void *) this << ")" << endl;
+    strm << BESIndent::LMarg << prolog << "(this: " << (void *) this << ")" << endl;
     BESIndent::Indent();
     if (_context_list.size()) {
         strm << BESIndent::LMarg << "current context:" << endl;

--- a/modules/netcdf_handler/NCRequestHandler.cc
+++ b/modules/netcdf_handler/NCRequestHandler.cc
@@ -536,6 +536,7 @@ bool NCRequestHandler::nc_build_dmr(BESDataHandlerInterface &dhi)
             // copy the cached DMR into the BES response object
             BESDEBUG(NC_NAME, "DMR Cached hit for : " << dataset_name << endl);
             *dmr = *cached_dmr_ptr; // Copy the referenced object
+            dmr->set_request_xml_base(bdmr.get_request_xml_base());
         }
         else {
 #if 0


### PR DESCRIPTION
When DMR objects are cached they contain the xml:base of the request that brought the DMR instance into being. Unfortunately, the value of xml:base for a particular dataset may change per request, as different clients may access the server through different domain names. This PR adds the insertion of the current request's xml:base context value into the DMR after a DMR copy is retrieved from cache.