### PR TITLE
Distcheck 1.16 fix

### DIFF
--- a/cmdln/tests/Makefile.am
+++ b/cmdln/tests/Makefile.am
@@ -31,7 +31,7 @@ distclean-local:
 
 AUTOTEST = $(AUTOM4TE) --language=autotest
 
-$(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4
+$(TESTSUITE): $(TESTSUITE).at
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
 # The `:;' works around a Bash 3.2 bug when the output is not writable.

--- a/cmdln/tests/Makefile.am
+++ b/cmdln/tests/Makefile.am
@@ -1,7 +1,7 @@
 
 AUTOMAKE_OPTIONS = foreign 
 
-CLEANFILES = bes.conf bes.annotation.conf
+CLEANFILES =
 
 # NB: Make sure to distribute both the source and generated files
 # for the test
@@ -9,6 +9,9 @@ EXTRA_DIST = $(TESTSUITE) $(TESTSUITE).at $(srcdir)/package.m4 \
 atlocal.in ff hdf4 hdf5 nc show ssfunc mds_initial_state
 
 DISTCLEANFILES = atconfig
+
+mds_cachedir = $(datadir)/mds
+mds_cache_DATA = $(srcdir)/mds_initial_state/*
 
 ############## Autotest follows #####################
 
@@ -20,8 +23,11 @@ clean-local:
 	test ! -f '$(TESTSUITE)' || $(SHELL) '$(TESTSUITE)' --clean
 	-rm -f $(TESTSUITE) $(srcdir)/package.m4
 
-check-local: $(TESTSUITE)
-	$(SHELL) $(TESTSUITE)
+check-local: $(TESTSUITE) install-data
+	@if bescmdln -x "show version;"; \
+		then $(SHELL) '$(TESTSUITE)' $(TESTSUITEFLAGS); \
+		else echo "no bes found, not running cmdln-based tests"; \
+	fi
 
 AUTOTEST = $(AUTOM4TE) --language=autotest
 
@@ -30,7 +36,7 @@ $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4
 %: %.at 
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/cmdln/tests/Makefile.am.old
+++ b/cmdln/tests/Makefile.am.old
@@ -1,14 +1,15 @@
 
-AUTOMAKE_OPTIONS = foreign 
+AUTOMAKE_OPTIONS = foreign
 
-CLEANFILES = bes.conf bes.annotation.conf
+CLEANFILES = *.log *.sum $(srcdir)/package.m4
 
-# NB: Make sure to distribute both the source and generated files
-# for the test
-EXTRA_DIST = $(TESTSUITE) $(TESTSUITE).at $(srcdir)/package.m4 \
-atlocal.in ff hdf4 hdf5 nc show ssfunc mds_initial_state
+EXTRA_DIST = $(TESTSUITE).at $(TESTSUITE) atlocal.in ff hdf4 hdf5 nc show ssfunc \
+mds_initial_state
 
-DISTCLEANFILES = atconfig
+DISTCLEANFILES = $(TESTSUITE)
+
+mds_cachedir = $(datadir)/mds
+mds_cache_DATA = $(srcdir)/mds_initial_state/*
 
 ############## Autotest follows #####################
 
@@ -16,21 +17,26 @@ AUTOM4TE = autom4te
 
 TESTSUITE = $(srcdir)/testsuite
 
+check-local: atconfig atlocal $(TESTSUITE) install-data
+	@if bescmdln -x "show version;"; \
+		then $(SHELL) '$(TESTSUITE)' $(TESTSUITEFLAGS); \
+		else echo "no bes found, not running cmdln-based tests"; \
+	fi
+
 clean-local:
 	test ! -f '$(TESTSUITE)' || $(SHELL) '$(TESTSUITE)' --clean
-	-rm -f $(TESTSUITE) $(srcdir)/package.m4
 
-check-local: $(TESTSUITE)
-	$(SHELL) $(TESTSUITE)
+distclean-local:
+	-rm atconfig
 
 AUTOTEST = $(AUTOM4TE) --language=autotest
 
 $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4
 
-%: %.at 
+%: %.at
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/dap/tests/Makefile.am
+++ b/dap/tests/Makefile.am
@@ -34,7 +34,7 @@ DISTCLEANFILES = atconfig
 # configure's value for the parameter when running the distcheck target.
 
 %.conf: %.conf.in
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > $@
 

--- a/dap/tests/Makefile.am
+++ b/dap/tests/Makefile.am
@@ -71,7 +71,7 @@ $(TESTSUITE2): $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4
 %: %.at 
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/dap/unit-tests/Makefile.am
+++ b/dap/unit-tests/Makefile.am
@@ -60,8 +60,8 @@ DISTCLEANFILES = *.strm *.file *.Po tmp.txt  tmp_* bes.log mds_ledger.txt
 BES_CONF_IN = bes.conf.in
 
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 
@@ -69,7 +69,7 @@ test_config.h: $(srcdir)/test_config.h.in Makefile
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(srcdir)/$(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 	    -e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/dapreader/tests/Makefile.am
+++ b/dapreader/tests/Makefile.am
@@ -17,7 +17,7 @@ DISTCLEANFILES = atconfig
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 %.conf : %.conf.in
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > $@
 

--- a/dapreader/tests/Makefile.am
+++ b/dapreader/tests/Makefile.am
@@ -55,7 +55,7 @@ clean-local:
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 $(TESTSUITE): $(srcdir)/package.m4 $(top_srcdir)/modules/handler_tests_macros.m4
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/dispatch/tests/Makefile.am
+++ b/dispatch/tests/Makefile.am
@@ -33,8 +33,8 @@ noinst_HEADERS = test_config.h
 BUILT_SOURCES = test_config.h
 
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 

--- a/dispatch/tests/Makefile.am
+++ b/dispatch/tests/Makefile.am
@@ -66,7 +66,7 @@ $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@.tmp $@.at
 	mv $@.tmp $@
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/dispatch/unit-tests/Makefile.am
+++ b/dispatch/unit-tests/Makefile.am
@@ -84,17 +84,17 @@ CLEANFILES = *.log *.sum real* test_config.h bes.conf
 #
 # Changed test_config.h.in tp $(srcdir)/test_config.h.in. jhrg 1/21/18
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 		-e "s%[@]abs_top_srcdir[@]%$${mod_abs_top_srcdir}%" \
 		-e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 
 bes.conf: $(srcdir)/bes.conf.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 		-e "s%[@]abs_top_srcdir[@]%$${mod_abs_top_srcdir}%" \
 		-e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > bes.conf

--- a/functions/geo-functions/unit-tests/Makefile.am
+++ b/functions/geo-functions/unit-tests/Makefile.am
@@ -43,7 +43,7 @@ DISTCLEANFILES = test_config.h *.strm *.file *.Po tmp.txt
 # TODO Check if this sed command to filter out the ../ from the value of 
 # ${abs_srcdir} is really needed for the distcheck target. jhrg 5/16/13
 test_config.h: test_config.h.in Makefile
-	@my_topdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@my_topdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${my_topdir}%" $< > test_config.h
 
 

--- a/functions/tests/Makefile.am
+++ b/functions/tests/Makefile.am
@@ -29,7 +29,7 @@ DISTCLEANFILES = atconfig generate_data_baselines.sh generate_metadata_baselines
 # @abs_top_srcdir@ does not contain '../'. This happens when using
 # configure's value for the parameter when running the distcheck target.
 %.conf : %.conf.in
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > $@
 

--- a/functions/tests/Makefile.am
+++ b/functions/tests/Makefile.am
@@ -74,7 +74,7 @@ AUTOTEST = $(AUTOM4TE) --language=autotest
 % : %.at 
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/functions/unit-tests/Makefile.am
+++ b/functions/unit-tests/Makefile.am
@@ -44,7 +44,7 @@ DISTCLEANFILES = test_config.h *.strm *.file *.Po tmp.txt
 # TODO Check if this sed command to filter out the ../ from the value of 
 # ${abs_srcdir} is really needed for the distcheck target. jhrg 5/16/13
 test_config.h: test_config.h.in Makefile
-	@my_topdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@my_topdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${my_topdir}%" $< > test_config.h
 
 

--- a/hello_world/tests/Makefile.am
+++ b/hello_world/tests/Makefile.am
@@ -47,7 +47,7 @@ $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4
 % : %.at
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/hello_world/tests/Makefile.am
+++ b/hello_world/tests/Makefile.am
@@ -23,7 +23,7 @@ DISTCLEANFILES = atconfig
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: bes.conf.in $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 	    -e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/asciival/tests/Makefile.am
+++ b/modules/asciival/tests/Makefile.am
@@ -56,7 +56,7 @@ $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4 $(srcdir)/handler_tests_macro
 # % : %.at
 #	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/asciival/tests/Makefile.am
+++ b/modules/asciival/tests/Makefile.am
@@ -26,7 +26,7 @@ BES_CONF_IN = bes.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/asciival/unit-tests/Makefile.am
+++ b/modules/asciival/unit-tests/Makefile.am
@@ -36,8 +36,8 @@ DISTCLEANFILES =
 BUILT_SOURCES = test_config.h
 
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 

--- a/modules/cmr_module/Makefile.am
+++ b/modules/cmr_module/Makefile.am
@@ -41,7 +41,7 @@ CLEANFILES = *~ cmr.conf
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = cmr.conf
 
-cmr.conf: cmr.conf.in $(top_srcdir)/config.status
+cmr.conf: cmr.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > cmr.conf
 
 C4_DIR=./cccc

--- a/modules/cmr_module/tests/Makefile.am
+++ b/modules/cmr_module/tests/Makefile.am
@@ -16,7 +16,7 @@ BES_CONF_IN = bes.conf.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/cmr_module/tests/Makefile.am
+++ b/modules/cmr_module/tests/Makefile.am
@@ -48,7 +48,7 @@ $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4 $(top_srcdir)/modules/handler
 %: %.at
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/cmr_module/unit-tests/Makefile.am
+++ b/modules/cmr_module/unit-tests/Makefile.am
@@ -39,8 +39,8 @@ noinst_HEADERS = test_config.h
 # are no '../' seqeunces in the paths. The BES will reject paths with 'dot dot'
 # in them in certain circumstances. jhrg 1/21/18
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 
@@ -56,7 +56,7 @@ bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
 	@echo "# abs_top_builddir: $(abs_top_builddir)" 
 	@echo "# abs_builddir: $(abs_builddir)" 
 	@echo "# builddir: $(builddir)" 
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/csv_handler/Makefile.am
+++ b/modules/csv_handler/Makefile.am
@@ -46,7 +46,7 @@ sample_data_DATA = data/temperature.csv
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = csv.conf
 
-csv.conf: csv.conf.in $(top_srcdir)/config.status
+csv.conf: csv.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > csv.conf
 
 C4_DIR=./cccc

--- a/modules/csv_handler/tests/Makefile.am
+++ b/modules/csv_handler/tests/Makefile.am
@@ -55,7 +55,7 @@ AUTOTEST = $(AUTOM4TE) --language=autotest
 $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/csv_handler/tests/Makefile.am
+++ b/modules/csv_handler/tests/Makefile.am
@@ -26,7 +26,7 @@ BES_CONF_IN = bes.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 	-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/debug_functions/tests/Makefile.am
+++ b/modules/debug_functions/tests/Makefile.am
@@ -55,7 +55,7 @@ AUTOTEST = $(AUTOM4TE) --language=autotest
 $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/debug_functions/tests/Makefile.am
+++ b/modules/debug_functions/tests/Makefile.am
@@ -30,7 +30,7 @@ BES_CONF_IN = bes.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/debug_functions/unit-tests/Makefile.am
+++ b/modules/debug_functions/unit-tests/Makefile.am
@@ -32,7 +32,7 @@ noinst_HEADERS = test_config.h
 
 DIRS_EXTRA = 
 
-EXTRA_DIST = 
+EXTRA_DIST = test_config.h.in
 
 CLEANFILES = testout .dodsrc  *.gcda *.gcno test_config.h *.strm *.file tmp.txt
 
@@ -40,9 +40,17 @@ DISTCLEANFILES =
 
 BUILT_SOURCES = test_config.h
 
+# `python -c "import os; print os.path.abspath('${abs_srcdir}')"`
+
+# test_config.h: $(srcdir)/test_config.h.in Makefile
+#	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+#	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
+#	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
+#	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
+
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 

--- a/modules/dmrpp_module/Makefile.am
+++ b/modules/dmrpp_module/Makefile.am
@@ -36,7 +36,7 @@ BUILT_SOURCES = bes_default_conf.h
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes_default_conf.h: $(srcdir)/bes_default_conf_template.h.in $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	cat $(srcdir)/bes_default_conf_template.h.in | sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" \
 		-e "s%[@]modulesdir[@]%${modulesdir}%" > bes_default_conf.h

--- a/modules/dmrpp_module/data/Makefile.am
+++ b/modules/dmrpp_module/data/Makefile.am
@@ -14,7 +14,7 @@ dist_bin_SCRIPTS = get_dmrpp ingest_filesystem ingest_s3bucket
 #
 # Not used. jhrg  4/1/20
 %.conf : %.conf.in
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" \
 		-e "s%[@]modulesdir[@]%${modulesdir}%" $< > $@

--- a/modules/dmrpp_module/tests/Makefile.am
+++ b/modules/dmrpp_module/tests/Makefile.am
@@ -102,7 +102,7 @@ $(TESTSUITE_MDS): $(TESTSUITE_MDS).at $(srcdir)/package.m4 $(top_srcdir)/modules
 
 $(TESTSUITE_S3): $(TESTSUITE_S3).at $(srcdir)/package.m4 $(top_srcdir)/modules/handler_tests_macros.m4
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/dmrpp_module/tests/Makefile.am
+++ b/modules/dmrpp_module/tests/Makefile.am
@@ -19,7 +19,7 @@ DISTCLEANFILES = atconfig mds_for_tests_ledger.txt
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 %.conf : %.conf.in
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > $@
 
@@ -33,7 +33,7 @@ $(builddir)/mds_for_tests:
 	cp -r $(top_srcdir)/modules/dmrpp_module/data/mds_for_tests $(builddir)/mds_for_tests
 	chmod -R a+w $(builddir)/mds_for_tests
 	(cd $(builddir)/mds_for_tests && \
-	 clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	 clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	 for d in *.in; \
 		do sed -e "s%[@]abs_top_srcdir[@]%$${clean_abs_top_srcdir}%" $$d > `basename $$d .in`; \
 	 done)

--- a/modules/dmrpp_module/unit-tests/Makefile.am
+++ b/modules/dmrpp_module/unit-tests/Makefile.am
@@ -56,9 +56,9 @@ BES_CONF_IN = bes.conf.in
 BES_NGAP_CREDS_CONF_IN = bes_ngap_s3_creds.conf.in
 
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_top_srcdir[@]%$${mod_abs_top_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
@@ -67,12 +67,12 @@ test_config.h: $(srcdir)/test_config.h.in Makefile
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(srcdir)/$(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 	    -e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 
 bes_ngap_s3_creds.conf: $(srcdir)/$(BES_NGAP_CREDS_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 	    -e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes_ngap_s3_creds.conf
 

--- a/modules/dmrpp_module/unused/tests/Makefile.am
+++ b/modules/dmrpp_module/unused/tests/Makefile.am
@@ -28,7 +28,7 @@ BES_CONF_IN = bes.conf.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/dmrpp_module/unused/tests/Makefile.am
+++ b/modules/dmrpp_module/unused/tests/Makefile.am
@@ -50,7 +50,7 @@ $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@.tmp $@.at
 	mv $@.tmp $@
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/fileout_covjson/Makefile.am
+++ b/modules/fileout_covjson/Makefile.am
@@ -39,7 +39,7 @@ CLEANFILES = *~ focovjson.conf
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = focovjson.conf
 
-focovjson.conf: focovjson.conf.in $(top_srcdir)/config.status
+focovjson.conf: focovjson.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > focovjson.conf
 
 C4_DIR=./cccc

--- a/modules/fileout_covjson/tests/Makefile.am
+++ b/modules/fileout_covjson/tests/Makefile.am
@@ -27,7 +27,7 @@ BES_CONF_IN = bes.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/fileout_covjson/tests/Makefile.am
+++ b/modules/fileout_covjson/tests/Makefile.am
@@ -52,7 +52,7 @@ $(TESTSUITE): $(srcdir)/fileout_covjsonTest.at $(srcdir)/package.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@.tmp $@.at
 	mv $@.tmp $@
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/fileout_covjson/unit-tests/Makefile.am
+++ b/modules/fileout_covjson/unit-tests/Makefile.am
@@ -37,8 +37,8 @@ noinst_HEADERS = test_config.h
 # are no '../' seqeunces in the paths. The BES will reject paths with 'dot dot'
 # in them in certain circumstances. jhrg 1/21/18
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 

--- a/modules/fileout_gdal/Makefile.am
+++ b/modules/fileout_gdal/Makefile.am
@@ -40,7 +40,7 @@ CLEANFILES = *~ fong.conf
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = fong.conf
 
-fong.conf: fong.conf.in $(top_srcdir)/config.status
+fong.conf: fong.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > fong.conf
 
 C4_DIR=./cccc

--- a/modules/fileout_gdal/tests/Makefile.am
+++ b/modules/fileout_gdal/tests/Makefile.am
@@ -5,7 +5,8 @@ TESTSUITE_TIF = $(srcdir)/testsuite_tif
 TESTSUITE_JP2 = $(srcdir)/testsuite_jp2
 
 EXTRA_DIST = $(TESTSUITE_TIF).at $(TESTSUITE_TIF) $(srcdir)/package.m4 \
-atlocal.in handler_tests_macros.m4 $(BES_CONF_IN) gdal
+$(TESTSUITE_JP2).at $(TESTSUITE_JP2)  atlocal.in \
+handler_tests_macros.m4 $(BES_CONF_IN) gdal
 
 # if OPENJPEG_FOUND
 # EXTRA_DIST += $(TESTSUITE_JP2).at $(TESTSUITE_JP2)
@@ -19,7 +20,7 @@ DISTCLEANFILES = atconfig
 
 check-local: atconfig atlocal $(TESTSUITE_TIF) $(TESTSUITE_JP2)
 	$(SHELL) '$(TESTSUITE_TIF)' $(TESTSUITE_TIFFLAGS)
-	test ! -f '$(TESTSUITE_JP2)' || $(SHELL) '$(TESTSUITE_JP2)' $(TESTSUITE_TIFFLAGS)
+	test ! -f '$(TESTSUITE_JP2)' || $(SHELL) '$(TESTSUITE_JP2)' $(TESTSUITE_JP2FLAGS)
 
 clean-local:
 	test ! -f '$(TESTSUITE_TIF)' || $(SHELL) '$(TESTSUITE_TIF)' --clean
@@ -32,7 +33,7 @@ BES_CONF_IN = bes.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 
@@ -41,13 +42,15 @@ bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
 AUTOM4TE = $(SHELL) $(top_srcdir)/conf/missing --run autom4te
 AUTOTEST = $(AUTOM4TE) --language=autotest
 
-$(TESTSUITE_TIF): $(TESTSUITE_TIF).at bes.conf $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4 
-	$(AUTOTEST) -I '$(srcdir)' -o ${srcdir}/$@.tmp $@.at
-	mv ${srcdir}/$@.tmp ${srcdir}/$@
+$(TESTSUITE_TIF): $(TESTSUITE_TIF).at bes.conf $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4
+	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
+
+# mv ${srcdir}/$@.tmp ${srcdir}/$@
 
 $(TESTSUITE_JP2): $(TESTSUITE_JP2).at bes.conf $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4
-	$(AUTOTEST) -I '$(srcdir)' -o ${srcdir}/$@.tmp $@.at
-	mv ${srcdir}/$@.tmp ${srcdir}/$@
+	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
+
+#mv ${srcdir}/$@.tmp ${srcdir}/$@
 
 # The `:;' works around a Bash 3.2 bug when the output is not writeable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac

--- a/modules/fileout_gdal/tests/Makefile.am
+++ b/modules/fileout_gdal/tests/Makefile.am
@@ -36,7 +36,7 @@ clean-local:
 	test ! -f '$(TESTSUITE_JP2)' || $(SHELL) '$(TESTSUITE_JP2)' --clean
 	-rm -f $(TESTSUITE_TIF) $(TESTSUITE_JP2) $(srcdir)/package.m4
 
-installcheck-local: $(TESTSUITE_TIF) $(TESTSUITE_JP2) atconfig atlocal cache
+installcheck-local: $(TESTSUITE_TIF) $(TESTSUITE_JP2) atconfig atlocal
 	$(SHELL) '$(TESTSUITE_TIF)' AUTOTEST_PATH='$(bindir)' $(TESTSUITE_TIFFFLAGS)
 	$(SHELL) '$(TESTSUITE_JP2)' AUTOTEST_PATH='$(bindir)' $(TESTSUITE_JP2FLAGS)
 

--- a/modules/fileout_gdal/tests/Makefile.am
+++ b/modules/fileout_gdal/tests/Makefile.am
@@ -6,7 +6,7 @@ noinst_DATA = bes.conf
 CLEANFILES = bes.conf
 
 EXTRA_DIST = $(TESTSUITE_TIF).at $(TESTSUITE_TIF) atlocal.in \
-$(TESTSUITE_JP2).at $(TESTSUITE_JP2) $(BES_CONF_IN) package.m4
+$(TESTSUITE_JP2).at $(TESTSUITE_JP2) $(BES_CONF_IN) package.m4 gdal
 
 DISTCLEANFILES = atconfig
 

--- a/modules/fileout_gdal/tests/Makefile.am
+++ b/modules/fileout_gdal/tests/Makefile.am
@@ -48,7 +48,7 @@ $(TESTSUITE_JP2): $(TESTSUITE_JP2).at $(srcdir)/package.m4 $(srcdir)/handler_tes
 %: %.at
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/fileout_gdal/tests/Makefile.am
+++ b/modules/fileout_gdal/tests/Makefile.am
@@ -6,7 +6,8 @@ noinst_DATA = bes.conf
 CLEANFILES = bes.conf
 
 EXTRA_DIST = $(TESTSUITE_TIF).at $(TESTSUITE_TIF) atlocal.in \
-$(TESTSUITE_JP2).at $(TESTSUITE_JP2) $(BES_CONF_IN) package.m4 gdal
+$(TESTSUITE_JP2).at $(TESTSUITE_JP2) $(BES_CONF_IN) package.m4 gdal \
+handler_tests_macros.m4
 
 DISTCLEANFILES = atconfig
 

--- a/modules/fileout_gdal/tests/Makefile.am.old
+++ b/modules/fileout_gdal/tests/Makefile.am.old
@@ -1,14 +1,31 @@
-
 AUTOMAKE_OPTIONS = foreign
+
+TESTSUITE_TIF = $(srcdir)/testsuite_tif
+
+TESTSUITE_JP2 = $(srcdir)/testsuite_jp2
+
+EXTRA_DIST = $(TESTSUITE_TIF).at $(TESTSUITE_TIF) $(srcdir)/package.m4 \
+$(TESTSUITE_JP2).at $(TESTSUITE_JP2)  atlocal.in \
+handler_tests_macros.m4 $(BES_CONF_IN) gdal
+
+# if OPENJPEG_FOUND
+# EXTRA_DIST += $(TESTSUITE_JP2).at $(TESTSUITE_JP2)
+# endif
 
 noinst_DATA = bes.conf
 
 CLEANFILES = bes.conf
 
-EXTRA_DIST = $(TESTSUITE_TIF).at $(TESTSUITE_TIF) atlocal.in \
-$(TESTSUITE_JP2).at $(TESTSUITE_JP2) $(BES_CONF_IN) package.m4
-
 DISTCLEANFILES = atconfig
+
+check-local: atconfig atlocal $(TESTSUITE_TIF) $(TESTSUITE_JP2)
+	$(SHELL) '$(TESTSUITE_TIF)' $(TESTSUITE_TIFFLAGS)
+	test ! -f '$(TESTSUITE_JP2)' || $(SHELL) '$(TESTSUITE_JP2)' $(TESTSUITE_JP2FLAGS)
+
+clean-local:
+	test ! -f '$(TESTSUITE_TIF)' || $(SHELL) '$(TESTSUITE_TIF)' --clean
+	test ! -f '$(TESTSUITE_JP2)' || $(SHELL) '$(TESTSUITE_JP2)' --clean
+	-rm -f $(TESTSUITE_TIF) $(TESTSUITE_JP2) $(srcdir)/package.m4 
 
 BES_CONF_IN = bes.conf.modules.in
 
@@ -20,33 +37,20 @@ bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 
-############## Autotest follows #####################
 
-AUTOM4TE = autom4te
-
-TESTSUITE_TIF = $(srcdir)/testsuite_tif
-TESTSUITE_JP2 = $(srcdir)/testsuite_jp2
-
-check-local: atconfig atlocal bes.conf $(TESTSUITE_TIF) $(TESTSUITE_JP2)
-	$(SHELL) '$(TESTSUITE_TIF)' $(TESTSUITE_TIFFLAGS)
-	test ! -f '$(TESTSUITE_JP2)' || $(SHELL) '$(TESTSUITE_JP2)' $(TESTSUITE_JP2FLAGS)
-
-clean-local:
-	test ! -f '$(TESTSUITE_TIF)' || $(SHELL) '$(TESTSUITE_TIF)' --clean
-	test ! -f '$(TESTSUITE_JP2)' || $(SHELL) '$(TESTSUITE_JP2)' --clean
-	-rm -f $(TESTSUITE_TIF) $(TESTSUITE_JP2) $(srcdir)/package.m4
-
-installcheck-local: $(TESTSUITE_TIF) $(TESTSUITE_JP2) atconfig atlocal cache
-	$(SHELL) '$(TESTSUITE_TIF)' AUTOTEST_PATH='$(bindir)' $(TESTSUITE_TIFFFLAGS)
-	$(SHELL) '$(TESTSUITE_JP2)' AUTOTEST_PATH='$(bindir)' $(TESTSUITE_JP2FLAGS)
-
+# Use the missing script for better error checking on autom4te run.
+AUTOM4TE = $(SHELL) $(top_srcdir)/conf/missing --run autom4te
 AUTOTEST = $(AUTOM4TE) --language=autotest
 
 $(TESTSUITE_TIF): $(TESTSUITE_TIF).at $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4
-$(TESTSUITE_JP2): $(TESTSUITE_JP2).at $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4
-
-%: %.at
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
+
+# mv ${srcdir}/$@.tmp ${srcdir}/$@
+
+$(TESTSUITE_JP2): $(TESTSUITE_JP2).at $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4
+	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
+
+#mv ${srcdir}/$@.tmp ${srcdir}/$@
 
 # The `:;' works around a Bash 3.2 bug when the output is not writeable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac

--- a/modules/fileout_json/Makefile.am
+++ b/modules/fileout_json/Makefile.am
@@ -39,7 +39,7 @@ CLEANFILES = *~ fojson.conf
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = fojson.conf
 
-fojson.conf: fojson.conf.in $(top_srcdir)/config.status
+fojson.conf: fojson.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > fojson.conf
 
 C4_DIR=./cccc

--- a/modules/fileout_json/tests/Makefile.am
+++ b/modules/fileout_json/tests/Makefile.am
@@ -27,7 +27,7 @@ BES_CONF_IN = bes.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/fileout_json/tests/Makefile.am
+++ b/modules/fileout_json/tests/Makefile.am
@@ -52,7 +52,7 @@ $(TESTSUITE): $(srcdir)/fileout_jsonTest.at $(srcdir)/package.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@.tmp $@.at
 	mv $@.tmp $@
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/fileout_json/unit-tests/Makefile.am
+++ b/modules/fileout_json/unit-tests/Makefile.am
@@ -37,8 +37,8 @@ noinst_HEADERS = test_config.h
 # are no '../' seqeunces in the paths. The BES will reject paths with 'dot dot'
 # in them in certain circumstances. jhrg 1/21/18
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 

--- a/modules/fileout_netcdf/Makefile.am
+++ b/modules/fileout_netcdf/Makefile.am
@@ -51,7 +51,7 @@ CLEANFILES = *~ fonc.conf
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = fonc.conf
 
-fonc.conf: fonc.conf.in $(top_srcdir)/config.status
+fonc.conf: fonc.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > fonc.conf
 
 C4_DIR=./cccc

--- a/modules/fileout_netcdf/old/unit-tests/Makefile.am
+++ b/modules/fileout_netcdf/old/unit-tests/Makefile.am
@@ -116,7 +116,7 @@ AUTOTEST = $(AUTOM4TE) --language=autotest
 $(TESTSUITE): $(TESTSUITE).at
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/fileout_netcdf/tests/Makefile.am
+++ b/modules/fileout_netcdf/tests/Makefile.am
@@ -77,7 +77,7 @@ $(srcdir)/local_handler_tests_macros.m4
 %: %.at
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/fileout_netcdf/tests/Makefile.am
+++ b/modules/fileout_netcdf/tests/Makefile.am
@@ -16,7 +16,8 @@ noinst_DATA = bes.conf bes.nc4.conf
 CLEANFILES = bes.conf bes.nc4.conf
 
 EXTRA_DIST = bescmd $(TESTSUITE).at $(TESTSUITE)  \
-atlocal.in bes.conf.in bes.nc4.conf.in package.m4
+atlocal.in bes.conf.in bes.nc4.conf.in package.m4 \
+local_handler_tests_macros.m4
 
 # I moved the tests back to one file and dropped the 'pass the alternate
 # conf file in using --conf=...' because that was not working with ncdump
@@ -30,7 +31,7 @@ DISTCLEANFILES = atconfig
 # @abs_top_srcdir@ does not contain '../'. This happens when using
 # configure's value for the parameter when running the distcheck target.
 %.conf : %.conf.in
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > $@
 
@@ -68,7 +69,8 @@ clean-local:
 
 AUTOTEST = $(AUTOM4TE) --language=autotest
 
-$(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4 $(top_srcdir)/modules/handler_tests_macros.m4 $(srcdir)/local_handler_tests_macros.m4
+$(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4 $(top_srcdir)/modules/handler_tests_macros.m4 \
+$(srcdir)/local_handler_tests_macros.m4
 
 # $(TESTSUITE_NC4): $(TESTSUITE_NC4).at $(srcdir)/package.m4 $(top_srcdir)/modules/handler_tests_macros.m4
 

--- a/modules/fits_handler/Makefile.am
+++ b/modules/fits_handler/Makefile.am
@@ -47,7 +47,7 @@ sample_data_DATA = data/20060308.172859.mk4.cpb.fts data/20060308.172859.mk4.rpb
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = fits.conf
 
-fits.conf: fits.conf.in $(top_srcdir)/config.status
+fits.conf: fits.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > fits.conf
 
 

--- a/modules/fits_handler/tests/Makefile.am
+++ b/modules/fits_handler/tests/Makefile.am
@@ -28,7 +28,7 @@ BES_CONF_IN = bes.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/fits_handler/tests/Makefile.am
+++ b/modules/fits_handler/tests/Makefile.am
@@ -50,7 +50,7 @@ $(TESTSUITE): $(srcdir)/fits_handlerTest.at $(srcdir)/package.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@.tmp $@.at
 	mv $@.tmp $@
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/freeform_handler/Makefile.am
+++ b/modules/freeform_handler/Makefile.am
@@ -72,7 +72,7 @@ sample_data_DATA = data/1998-6-avhrr.dat data/avhrr.dat data/gsodock.dat data/gs
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = ff.conf
 
-ff.conf: ff.conf.in $(top_srcdir)/config.status
+ff.conf: ff.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > ff.conf
 
 C4_DIR=./cccc

--- a/modules/freeform_handler/tests/Makefile.am
+++ b/modules/freeform_handler/tests/Makefile.am
@@ -16,7 +16,7 @@ BES_CONF_IN = bes.conf.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/freeform_handler/tests/Makefile.am
+++ b/modules/freeform_handler/tests/Makefile.am
@@ -45,7 +45,7 @@ AUTOTEST = $(AUTOM4TE) --language=autotest
 $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/gateway_module/Makefile.am
+++ b/modules/gateway_module/Makefile.am
@@ -50,7 +50,7 @@ CLEANFILES = *~ gateway.conf
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = gateway.conf
 
-gateway.conf: gateway.conf.in $(top_srcdir)/config.status
+gateway.conf: gateway.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > gateway.conf
 
 C4_DIR=./cccc

--- a/modules/gateway_module/tests/Makefile.am
+++ b/modules/gateway_module/tests/Makefile.am
@@ -28,7 +28,7 @@ BES_CONF_IN = bes.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/gateway_module/tests/Makefile.am
+++ b/modules/gateway_module/tests/Makefile.am
@@ -51,7 +51,7 @@ $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4 $(srcdir)/handler_tests_macro
 	$(AUTOTEST) -I '$(srcdir)' -o $@.tmp $@.at
 	mv $@.tmp $@
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/gdal_handler/Makefile.am
+++ b/modules/gdal_handler/Makefile.am
@@ -71,5 +71,5 @@ sample_data_DATA = data/README \
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = gdal.conf
 
-gdal.conf: gdal.conf.in $(top_srcdir)/config.status
+gdal.conf: gdal.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > gdal.conf

--- a/modules/gdal_handler/tests/Makefile.am
+++ b/modules/gdal_handler/tests/Makefile.am
@@ -38,7 +38,7 @@ $(TESTSUITE): $(srcdir)/package.m4 $(TESTSUITE).at $(srcdir)/handler_tests_macro
 
 # mv ${srcdir}/$@.tmp ${srcdir}/$@
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/gdal_handler/tests/Makefile.am
+++ b/modules/gdal_handler/tests/Makefile.am
@@ -25,7 +25,7 @@ BES_CONF_IN = bes.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 
@@ -34,8 +34,9 @@ AUTOM4TE = $(SHELL) $(top_srcdir)/conf/missing --run autom4te
 AUTOTEST = $(AUTOM4TE) --language=autotest
 
 $(TESTSUITE): $(srcdir)/package.m4 $(TESTSUITE).at $(srcdir)/handler_tests_macros.m4
-	$(AUTOTEST) -I '$(srcdir)' -o ${srcdir}/$@.tmp $@.at
-	mv ${srcdir}/$@.tmp ${srcdir}/$@
+	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
+
+# mv ${srcdir}/$@.tmp ${srcdir}/$@
 
 # The `:;' works around a Bash 3.2 bug when the output is not writeable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac

--- a/modules/httpd_catalog_module/Makefile.am
+++ b/modules/httpd_catalog_module/Makefile.am
@@ -46,7 +46,7 @@ CLEANFILES = *~ httpd_catalog.conf
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = httpd_catalog.conf
 
-httpd_catalog.conf: httpd_catalog.conf.in $(top_srcdir)/config.status
+httpd_catalog.conf: httpd_catalog.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > $@
 
 C4_DIR=./cccc

--- a/modules/httpd_catalog_module/tests/Makefile.am
+++ b/modules/httpd_catalog_module/tests/Makefile.am
@@ -17,7 +17,7 @@ DISTCLEANFILES = atconfig
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/httpd_catalog_module/tests/Makefile.am
+++ b/modules/httpd_catalog_module/tests/Makefile.am
@@ -47,7 +47,7 @@ AUTOTEST = $(AUTOM4TE) --language=autotest
 $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4 $(top_srcdir)/modules/handler_tests_macros.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/httpd_catalog_module/unit-tests/Makefile.am
+++ b/modules/httpd_catalog_module/unit-tests/Makefile.am
@@ -40,9 +40,9 @@ noinst_HEADERS = test_config.h
 # in them in certain circumstances. jhrg 1/21/18
 
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_top_srcdir[@]%$${mod_abs_top_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
@@ -60,7 +60,7 @@ bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
 	@echo "# abs_top_builddir: $(abs_top_builddir)" 
 	@echo "# abs_builddir: $(abs_builddir)" 
 	@echo "# builddir: $(builddir)" 
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/ncml_module/Makefile.am
+++ b/modules/ncml_module/Makefile.am
@@ -178,7 +178,7 @@ sample_data_dmrpp_DATA = 	data/ncml/dmrpp/chunked_twoD.h5
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = ncml.conf
 
-ncml.conf: ncml.conf.in $(top_srcdir)/config.status
+ncml.conf: ncml.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > ncml.conf
 
 .PHONY: docs

--- a/modules/ncml_module/tests/Makefile.am
+++ b/modules/ncml_module/tests/Makefile.am
@@ -75,7 +75,7 @@ AUTOTEST = $(AUTOM4TE) --language=autotest
 # canonical_abs_top_srcdir =  `${READLINK_F} ${abs_top_srcdir}`
 
 # Generate the m4 defines from top level configure.ac
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/ncml_module/tests/Makefile.am
+++ b/modules/ncml_module/tests/Makefile.am
@@ -28,17 +28,17 @@ BES_UNKNOWN_TYPE_AGGREGATION_ERROR_CONF_IN = bes_unknown_type_aggregation_error.
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 %.conf: %.conf.in $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > $@
 
 # bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-#	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+#	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 #	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 #		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 
 # bes_no_nc_global.conf: $(BES_NO_NC_GLOBAL_CONF_IN) $(top_srcdir)/configure.ac
-#	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+#	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 #	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 #		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes_no_nc_global.conf
 

--- a/modules/netcdf_handler/Makefile.am
+++ b/modules/netcdf_handler/Makefile.am
@@ -52,7 +52,7 @@ data/fnoc1.nc data/fnoc1.das data/fnoc1.nc.html data/zero_length_array.nc
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = nc.conf
 
-nc.conf: nc.conf.in $(top_srcdir)/config.status
+nc.conf: nc.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > nc.conf
 
 C4_DIR=./cccc

--- a/modules/netcdf_handler/tests/Makefile.am
+++ b/modules/netcdf_handler/tests/Makefile.am
@@ -17,7 +17,8 @@ CLEANFILES = bes.conf bes_mds.conf $(srcdir)/package.m4
 
 EXTRA_DIST = nc netcdf_handlerTest netcdf_handlerTest.at \
 nc4_netcdf_handler_tests nc4_netcdf_handler_tests.at \
-atlocal.in $(BES_CONF_IN) $(BES_MDS_CONF_IN) $(srcdir)/package.m4
+atlocal.in $(BES_CONF_IN) $(BES_MDS_CONF_IN) $(srcdir)/package.m4 \
+handler_tests_macros.m4
 
 DISTCLEANFILES = atconfig
 
@@ -28,12 +29,12 @@ BES_MDS_CONF_IN = bes_mds.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(srcdir)/$(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 
 bes_mds.conf: $(srcdir)/$(BES_MDS_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes_mds.conf
 ############## Autotest follows #####################

--- a/modules/netcdf_handler/tests/Makefile.am
+++ b/modules/netcdf_handler/tests/Makefile.am
@@ -67,7 +67,7 @@ AUTOTEST = $(AUTOM4TE) --language=autotest
 % : %.at
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/ngap_module/Makefile.am
+++ b/modules/ngap_module/Makefile.am
@@ -38,7 +38,7 @@ CLEANFILES = *~ ngap.conf
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = ngap.conf
 
-ngap.conf: ngap.conf.in $(top_srcdir)/config.status
+ngap.conf: ngap.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > ngap.conf
 
 C4_DIR=./cccc

--- a/modules/ngap_module/tests/Makefile.am
+++ b/modules/ngap_module/tests/Makefile.am
@@ -28,7 +28,7 @@ DISTCLEANFILES =  atconfig
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/ngap_module/tests/Makefile.am
+++ b/modules/ngap_module/tests/Makefile.am
@@ -50,7 +50,7 @@ AUTOTEST = $(AUTOM4TE) --language=autotest
 $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/ngap_module/unit-tests/Makefile.am
+++ b/modules/ngap_module/unit-tests/Makefile.am
@@ -39,8 +39,8 @@ noinst_HEADERS = test_config.h
 # are no '../' seqeunces in the paths. The BES will reject paths with 'dot dot'
 # in them in certain circumstances. jhrg 1/21/18
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 
@@ -50,7 +50,7 @@ BES_CONF_IN = bes.conf.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/ugrid_functions/tests/Makefile.am
+++ b/modules/ugrid_functions/tests/Makefile.am
@@ -55,7 +55,7 @@ AUTOTEST = $(AUTOM4TE) --language=autotest
 $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/ugrid_functions/tests/Makefile.am
+++ b/modules/ugrid_functions/tests/Makefile.am
@@ -30,7 +30,7 @@ BES_CONF_IN = bes.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/ugrid_functions/unit-tests/Makefile.am
+++ b/modules/ugrid_functions/unit-tests/Makefile.am
@@ -43,8 +43,8 @@ DISTCLEANFILES =
 BUILT_SOURCES = test_config.h
 
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 

--- a/modules/usage/Makefile.am
+++ b/modules/usage/Makefile.am
@@ -42,7 +42,7 @@ DISTCLEANFILES = usage.conf
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = usage.conf
 
-usage.conf: usage.conf.in $(top_srcdir)/config.status
+usage.conf: usage.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > usage.conf
 
 C4_DIR=./cccc

--- a/modules/w10n_handler/Makefile.am
+++ b/modules/w10n_handler/Makefile.am
@@ -41,7 +41,7 @@ CLEANFILES = *~ w10n.conf bes.log
 moduledir = $(sysconfdir)/bes/modules
 module_DATA =  w10n.conf
 
-w10n.conf: w10n.conf.in $(top_srcdir)/config.status
+w10n.conf: w10n.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > w10n.conf
 
 # Not nearly as clean as it could be, but this removes .svn directories

--- a/modules/w10n_handler/tests/Makefile.am
+++ b/modules/w10n_handler/tests/Makefile.am
@@ -27,7 +27,7 @@ BES_CONF_IN = bes.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 

--- a/modules/w10n_handler/tests/Makefile.am
+++ b/modules/w10n_handler/tests/Makefile.am
@@ -49,7 +49,7 @@ $(TESTSUITE): $(srcdir)/w10n_handlerTest.at $(srcdir)/package.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@.tmp $@.at
 	mv $@.tmp $@
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/w10n_handler/unit-tests/Makefile.am
+++ b/modules/w10n_handler/unit-tests/Makefile.am
@@ -37,8 +37,8 @@ noinst_HEADERS = test_config.h
 # are no '../' seqeunces in the paths. The BES will reject paths with 'dot dot'
 # in them in certain circumstances. jhrg 1/21/18
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 

--- a/modules/xml_data_handler/Makefile.am
+++ b/modules/xml_data_handler/Makefile.am
@@ -54,7 +54,7 @@ DISTCLEANFILES = xml_data_handler.conf
 moduledir = $(sysconfdir)/bes/modules
 module_DATA = xml_data_handler.conf
 
-xml_data_handler.conf: xml_data_handler.conf.in $(top_srcdir)/config.status
+xml_data_handler.conf: xml_data_handler.conf.in $(top_builddir)/config.status
 	sed -e "s%[@]bes_modules_dir[@]%${lib_besdir}%" $< > xml_data_handler.conf
 
 C4_DIR=./cccc

--- a/modules/xml_data_handler/tests/Makefile.am
+++ b/modules/xml_data_handler/tests/Makefile.am
@@ -23,7 +23,7 @@ BES_CONF_IN = bes.conf.modules.in
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 
@@ -46,9 +46,10 @@ AUTOM4TE = $(SHELL) $(top_srcdir)/conf/missing --run autom4te
 
 AUTOTEST = $(AUTOM4TE) --language=autotest
 
-$(TESTSUITE): $(srcdir)/package.m4  $(srcdir)/testsuite.at bes.conf $(TEST_FILES)
-	$(AUTOTEST) -I '$(srcdir)' -o ${srcdir}/$@.tmp $@.at
-	mv ${srcdir}/$@.tmp ${srcdir}/$@
+$(TESTSUITE): $(srcdir)/package.m4  $(TESTSUITE).at
+	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
+
+# mv ${srcdir}/$@.tmp ${srcdir}/$@
 
 # The `:;' works around a Bash 3.2 bug when the output is not writeable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac

--- a/modules/xml_data_handler/tests/Makefile.am
+++ b/modules/xml_data_handler/tests/Makefile.am
@@ -51,7 +51,7 @@ $(TESTSUITE): $(srcdir)/package.m4  $(TESTSUITE).at
 
 # mv ${srcdir}/$@.tmp ${srcdir}/$@
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/modules/xml_data_handler/unit-tests/Makefile.am
+++ b/modules/xml_data_handler/unit-tests/Makefile.am
@@ -34,8 +34,8 @@ DISTCLEANFILES = *.Po
 BUILT_SOURCES = test_config.h
 
 test_config.h: $(srcdir)/test_config.h.in Makefile
-	@mod_abs_srcdir=`echo ${abs_srcdir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
-	mod_abs_builddir=`echo ${abs_builddir} | sed 's%\(.*\)/\(.[^/]*\)/[.][.]%\1%g'`; \
+	@mod_abs_srcdir=`python -c "import os; print os.path.abspath('${abs_srcdir}')"`; \
+	mod_abs_builddir=`python -c "import os; print os.path.abspath('${abs_builddir}')"`; \
 	sed -e "s%[@]abs_srcdir[@]%$${mod_abs_srcdir}%" \
 	    -e "s%[@]abs_builddir[@]%$${mod_abs_builddir}%" $< > test_config.h
 

--- a/xmlcommand/tests/Makefile.am
+++ b/xmlcommand/tests/Makefile.am
@@ -81,7 +81,7 @@ AUTOTEST = $(AUTOM4TE) --language=autotest
 $(TESTSUITE): $(TESTSUITE).at $(srcdir)/package.m4 $(srcdir)/handler_tests_macros.m4 bes.conf
 	$(AUTOTEST) -I '$(srcdir)' -o $@ $@.at
 
-# The `:;' works around a Bash 3.2 bug when the output is not writeable.
+# The `:;' works around a Bash 3.2 bug when the output is not writable.
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 	:;{ \
 	echo '# Signature of the current package.' && \

--- a/xmlcommand/tests/Makefile.am
+++ b/xmlcommand/tests/Makefile.am
@@ -51,7 +51,7 @@ $(builddir)/data:
 # @abs_top_srcdir@ does not contain '../'. This happens when using 
 # configure's value for the parameter when running the distcheck target.
 bes.conf: $(BES_CONF_IN) $(top_srcdir)/configure.ac
-	@clean_abs_top_srcdir=`echo ${abs_top_srcdir} | sed 's/\(.*\)\/\(.[^\/]*\)\/\.\./\1/g'`; \
+	@clean_abs_top_srcdir=`python -c "import os; print os.path.abspath('${abs_top_srcdir}')"`; \
 	sed -e "s%[@]abs_top_srcdir[@]%$$clean_abs_top_srcdir%" \
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" $< > bes.conf
 


### PR DESCRIPTION
This PR introduces fixes needed to use automake 1.16 and it's 'distcheck' target. This will be needed when Travis updates automake, which could happen soon.