### PR TITLE
Rpm fix

### DIFF
--- a/bes.spec
+++ b/bes.spec
@@ -192,7 +192,9 @@ exit 0
 %{bespkidir}/
 
 %attr (-,%{besuser},%{besgroup}) %{beslogdir}
-%attr (-,%{besuser},%{besgroup}) %{bespiddir}
+# The directory bespiddir was specific to the bes, but it became a system directory.
+# Thus, its bad form to change the owner and group to the 'bes.' jhrg 7/8/20
+# %attr (-,%{besuser},%{besgroup}) %{bespiddir}
 %attr (-,%{besuser},%{besgroup}) %{bescachedir}
 
 # Make sure that the BES, once running, can write to the MDS directory. jhrg 11/7/18

--- a/bes.spec.all_static
+++ b/bes.spec.all_static
@@ -212,7 +212,9 @@ exit 0
 %{bespkidir}/
 
 %attr (-,%{besuser},%{besgroup}) %{beslogdir}
-%attr (-,%{besuser},%{besgroup}) %{bespiddir}
+# The directory bespiddir was specific to the bes, but it became a system directory.
+# Thus, its bad form to change the owner and group to the 'bes.' jhrg 7/8/20
+# %attr (-,%{besuser},%{besgroup}) %{bespiddir}
 %attr (-,%{besuser},%{besgroup}) %{bescachedir}
 
 # Make sure that the BES, once running, can write to the MDS directory. jhrg 11/7/18

--- a/bes.spec.c6.all_static
+++ b/bes.spec.c6.all_static
@@ -212,7 +212,9 @@ exit 0
 %{bespkidir}/
 
 %attr (-,%{besuser},%{besgroup}) %{beslogdir}
-%attr (-,%{besuser},%{besgroup}) %{bespiddir}
+# The directory bespiddir was specific to the bes, but it became a system directory.
+# Thus, its bad form to change the owner and group to the 'bes.' jhrg 7/8/20
+# %attr (-,%{besuser},%{besgroup}) %{bespiddir}
 %attr (-,%{besuser},%{besgroup}) %{bescachedir}
 
 # Make sure that the BES, once running, can write to the MDS directory. jhrg 11/7/18

--- a/modules/ngap_module/curl_utils.cc
+++ b/modules/ngap_module/curl_utils.cc
@@ -740,7 +740,7 @@ bool eval_get_response(CURL *eh) {
     /**
      * @brief Performs a small (4 byte) range get on the target URL. If successfull the value of  last_accessed_url will
      * be set to the value of the last accessed URL (CURLINFO_EFFECTIVE_URL), including the query string.
-     * are
+     *
      * @param url The URL to follow
      * @param last_accessed_url The last accessed URL (CURLINFO_EFFECTIVE_URL), including the query string
      */


### PR DESCRIPTION
This should address the HYRAX-195 ticket. We were setting the owner of /var/run where we used to set the owner of /var/run/bes... However, the latter is not supported by CentOS SA tools.