### PR TITLE
Curl bad ptr patch

### DIFF
--- a/dispatch/BESLog.cc
+++ b/dispatch/BESLog.cc
@@ -186,7 +186,7 @@ void BESLog::dump_time()
         status = strftime(buf, sizeof buf, "%FT%T%Z", localtime(&now));
 #endif
 
-    char buf[sizeof "YYYY-MM-DDTHH:MM:SS zone"];
+    char buf[sizeof "YYYY-MM-DDTHH:MM:SS zones"];
     int status = 0;
     if(d_use_unix_time){
         (*d_file_buffer) << now;

--- a/dispatch/BESLog.h
+++ b/dispatch/BESLog.h
@@ -114,7 +114,9 @@ private:
     // Flag to indicate whether to log verbose messages
     bool d_verbose;
 
-    bool d_use_local_time; ///< Use UTC by default
+    bool d_use_local_time; // Use UTC by default
+
+    bool d_use_unix_time; // Use the UNIX time value as the log time.
 
 protected:
     BESLog();

--- a/dispatch/TheBESKeys.cc
+++ b/dispatch/TheBESKeys.cc
@@ -345,7 +345,7 @@ void TheBESKeys::get_value(const string &s, string &val, bool &found)
         found = true;
         if ((*i).second.size() > 1) {
             string err = string("Multiple values for the key ") + s + " found, should only be one.";
-            throw BESSyntaxUserError(err, __FILE__, __LINE__);
+            throw BESInternalError(err, __FILE__, __LINE__);
         }
         if ((*i).second.size() == 1) {
             val = (*i).second[0];

--- a/dispatch/bes/bes.conf.in
+++ b/dispatch/bes/bes.conf.in
@@ -38,6 +38,12 @@ BES.LogName=@prefix@/var/bes.log
 # Regular mode only records 'get' commands.
 BES.LogVerbose=no
 
+# By setting BES.LogUnixTime to true the server will make loge entries using
+# the value of UNIX time (seconds since 1970-01-01T00:00:00 UTC). Any other
+# value, or omitting the key wil cause the server to ouput times as in
+# ISO-8601 date format
+BES.LogUnixTime=false
+
 # Set to 'yes' to use local time in the bes log. UTC is used by default.
 # BES.LogTimeLocal=yes
 

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -454,6 +454,7 @@ static const useconds_t uone_second = 1000*1000; // one second in micro seconds 
         if (!curl)
             throw BESInternalError("Could not initialize libcurl.",__FILE__, __LINE__);
 
+        // Error Buffer (for use during this setup) --------------------------------------------------------------------
         res = curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, error_buffer);
         if(res!=CURLE_OK){
             throw BESInternalError(string("CURL Error: ").append(error_message(res,error_buffer)), __FILE__, __LINE__);
@@ -463,10 +464,8 @@ static const useconds_t uone_second = 1000*1000; // one second in micro seconds 
         // Load in the default headers to send with a request. The empty Pragma
         // headers overrides libcurl's default Pragma: no-cache header (which
         // will disable caching by Squid, etc.).
-
         // the empty Pragma never appears in the outgoing headers when this isn't present
         // d_request_headers->push_back(string("Pragma: no-cache"));
-
         // d_request_headers->push_back(string("Cache-Control: no-cache"));
 
         // Allow compressed responses. Sending an empty string enables all supported compression types.
@@ -563,7 +562,7 @@ static const useconds_t uone_second = 1000*1000; // one second in micro seconds 
         }
 
         // Set the user agent to curls version response because, well, that's what command line curl does :)
-        res = curl_easy_setopt(curl, CURLOPT_USERAGENT,  hyrax_user_agent() );
+        res = curl_easy_setopt(curl, CURLOPT_USERAGENT,  hyrax_user_agent().c_str() );
         if(res!=CURLE_OK){
             throw BESInternalError(string("CURL Error: ").append(error_message(res,error_buffer)), __FILE__, __LINE__);
         }
@@ -843,7 +842,7 @@ static const useconds_t uone_second = 1000*1000; // one second in micro seconds 
         if (!d_handle)
             throw BESInternalError(string("ERROR! Failed to acquire cURL Easy Handle! "), __FILE__, __LINE__);
 
-        // Error Buffer ------------------------------------------------------------------------------------------------
+        // Error Buffer (for use during this setup) --------------------------------------------------------------------
         if (CURLE_OK != (res = curl_easy_setopt(d_handle, CURLOPT_ERRORBUFFER, errbuf)))
             throw BESInternalError(string("CURL Error: ").append(error_message(res,errbuf)), __FILE__, __LINE__);
 

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -70,6 +70,10 @@ using namespace http;
 
 #define prolog std::string("CurlUtils::").append(__func__).append("() - ")
 
+string hyrax_user_agent(){
+    // return curl_version();
+    return "Hyrax";
+}
 
 namespace curl {
 static const unsigned int retry_limit = 10; // Amazon's suggestion
@@ -559,7 +563,7 @@ static const useconds_t uone_second = 1000*1000; // one second in micro seconds 
         }
 
         // Set the user agent to curls version response because, well, that's what command line curl does :)
-        res = curl_easy_setopt(curl, CURLOPT_USERAGENT, curl_version());
+        res = curl_easy_setopt(curl, CURLOPT_USERAGENT,  hyrax_user_agent() );
         if(res!=CURLE_OK){
             throw BESInternalError(string("CURL Error: ").append(error_message(res,error_buffer)), __FILE__, __LINE__);
         }

--- a/http/CurlUtils.h
+++ b/http/CurlUtils.h
@@ -66,6 +66,8 @@ namespace curl {
     std::string hyrax_user_agent();
     void set_error_buffer(CURL *curl, char *error_buffer);
     void unset_error_buffer(CURL *curl);
+    void check_setopt_result(CURLcode result, std::string msg_base, std::string opt_name, char *ebuf, std::string file, unsigned int line );
+    unsigned long max_redirects();
 
 } // namespace curl
 

--- a/http/CurlUtils.h
+++ b/http/CurlUtils.h
@@ -38,7 +38,7 @@
 
 namespace curl {
 
-    CURL *init(char *error_buffer);
+    CURL *init();
 
     bool configureProxy(CURL *curl, const std::string &url);
 

--- a/http/CurlUtils.h
+++ b/http/CurlUtils.h
@@ -64,6 +64,8 @@ namespace curl {
     bool is_retryable(std::string url);
     std::string get_netrc_filename();
     std::string hyrax_user_agent();
+    void set_error_buffer(CURL *curl, char *error_buffer);
+    void unset_error_buffer(CURL *curl);
 
 } // namespace curl
 

--- a/http/CurlUtils.h
+++ b/http/CurlUtils.h
@@ -63,7 +63,7 @@ namespace curl {
     BESRegex *get_cache_effective_urls_skip_regex();
     bool is_retryable(std::string url);
     std::string get_netrc_filename();
-
+    std::string hyrax_user_agent();
 
 } // namespace curl
 

--- a/http/RemoteResource.cc
+++ b/http/RemoteResource.cc
@@ -71,7 +71,7 @@ namespace http {
         d_uid = uid;
         d_echo_token = echo_token;
 
-        d_curl = curl::init(d_error_buffer);
+        d_curl = curl::init();
 
         d_resourceCacheFileName.clear();
         d_response_headers = new vector<string>();

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -407,7 +407,7 @@ static void *easy_handle_read_data(void *handle) {
  * d_max_parallel_transfers are added to the 'multi' handle.
  */
 void dmrpp_multi_handle::read_data() {
-#if 1 //HAVE_CURL_MULTI_API
+#if HAVE_CURL_MULTI_API
     useconds_t retry_time = uone_second/4;
     // Use the libcurl Multi API here. Alternate version follows...
     try {

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -433,7 +433,7 @@ void dmrpp_multi_handle::read_data() {
 
         CURLMsg *msg = 0;
         int msgs_left = 0;
-        char empty[1];
+        char empty[1]; // TODO Replace this with the actual error buffer that's in use in the CURL handle msg->easy_handle
         empty[0] = 0;
         while ((msg = curl_multi_info_read(p_impl->curlm, &msgs_left))) {
             if (msg->msg == CURLMSG_DONE) {

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -210,7 +210,7 @@ dmrpp_easy_handle::dmrpp_easy_handle() : d_request_headers(0) {
     CURLcode res;
 
     if (CURLE_OK != (res = curl_easy_setopt(d_handle, CURLOPT_ERRORBUFFER, d_errbuf)))
-        throw BESInternalError(string("CURL Error: ").append(curl_easy_strerror(res)), __FILE__, __LINE__);
+        throw BESInternalError(string("CURL Error: ").append(curl::error_message(res,d_errbuf)), __FILE__, __LINE__);
 
 #if CURL_VERBOSE
     if (CURLE_OK != (res = curl_easy_setopt(d_handle, CURLOPT_DEBUGFUNCTION, curl_trace)))
@@ -440,7 +440,7 @@ void dmrpp_multi_handle::read_data() {
 
                 CURLcode res = msg->data.result;
                 if (res != CURLE_OK)
-                    throw BESInternalError(string("Error HTTP: ").append(curl_easy_strerror(res)), __FILE__, __LINE__);
+                    throw BESInternalError(string("Error HTTP: ").append(curl::error_message(res,"")), __FILE__, __LINE__);
 
                 // Note: 'eh' is the easy handle returned by culr_multi_info_read(),
                 // but in it's private field is our dmrpp_easy_handle object. We need
@@ -448,7 +448,7 @@ void dmrpp_multi_handle::read_data() {
                 dmrpp_easy_handle *dmrpp_easy_handle = 0;
                 res = curl_easy_getinfo(eh, CURLINFO_PRIVATE, &dmrpp_easy_handle);
                 if (res != CURLE_OK)
-                    throw BESInternalError(string("Could not access easy handle: ").append(curl_easy_strerror(res)), __FILE__, __LINE__);
+                    throw BESInternalError(string("Could not access easy handle: ").append(curl::error_message(res,"")), __FILE__, __LINE__);
 
                 // This code has to work with both http/s: and file: protocols. Here we check the
                 // HTTP status code. If the protocol is not HTTP, we assume since msg->data.result

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -665,7 +665,7 @@ CurlHandlePool::get_easy_handle(Chunk *chunk) {
         curl_easy_setopt(handle->d_handle, CURLOPT_MAXREDIRS, 20);
 
         // Set the user agent something otherwise TEA will never redirect to URS.
-        curl_easy_setopt(handle->d_handle, CURLOPT_USERAGENT, "Hyrax"/* curl_version()*/);
+        curl_easy_setopt(handle->d_handle, CURLOPT_USERAGENT, curl::hyrax_user_agent());
 
         // This means libcurl will use Basic, Digest, GSS Negotiate, or NTLM,
         // choosing the the 'safest' one supported by the server.

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -209,8 +209,7 @@ dmrpp_easy_handle::dmrpp_easy_handle() : d_request_headers(0) {
 
     CURLcode res;
 
-    if (CURLE_OK != (res = curl_easy_setopt(d_handle, CURLOPT_ERRORBUFFER, d_errbuf)))
-        throw BESInternalError(string("CURL Error: ").append(curl::error_message(res,d_errbuf)), __FILE__, __LINE__);
+    curl::set_error_buffer(d_handle, d_errbuf);
 
 #if CURL_VERBOSE
     if (CURLE_OK != (res = curl_easy_setopt(d_handle, CURLOPT_DEBUGFUNCTION, curl_trace)))

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -212,37 +212,37 @@ dmrpp_easy_handle::dmrpp_easy_handle() : d_request_headers(0) {
     curl::set_error_buffer(d_handle, d_errbuf);
 
 #if CURL_VERBOSE
-    if (CURLE_OK != (res = curl_easy_setopt(d_handle, CURLOPT_DEBUGFUNCTION, curl_trace)))
-        throw BESInternalError(string("CURL Error: ").append(curl::error_message(res, d_errbuf)), __FILE__, __LINE__);
+     res = curl_easy_setopt(d_handle, CURLOPT_DEBUGFUNCTION, curl_trace);
+     curl::check_setopt_result(res, prolog, "CURLOPT_DEBUGFUNCTION", d_errbuf, __FILE__, __LINE__);
     // Many tests fail with this option, but it's still useful to see how connections
     // are treated. jhrg 10/2/18
-    if (CURLE_OK != (res = curl_easy_setopt(d_handle, CURLOPT_VERBOSE, 1L)))
-        throw BESInternalError(string("CURL Error: ").append(curl::error_message(res, d_errbuf)), __FILE__, __LINE__);
+    res = curl_easy_setopt(d_handle, CURLOPT_VERBOSE, 1L);
+    curl::check_setopt_result(res, prolog, "CURLOPT_VERBOSE", d_errbuf, __FILE__, __LINE__);
 #endif
 
-    if (CURLE_OK != (res = curl_easy_setopt(d_handle, CURLOPT_HEADERFUNCTION, chunk_header_callback)))
-        throw BESInternalError(string("CURL Error: ").append(curl::error_message(res, d_errbuf)), __FILE__, __LINE__);
+    res = curl_easy_setopt(d_handle, CURLOPT_HEADERFUNCTION, chunk_header_callback);
+    curl::check_setopt_result(res, prolog, "CURLOPT_HEADERFUNCTION", d_errbuf, __FILE__, __LINE__);
 
     // Pass all data to the 'write_data' function
-    if (CURLE_OK != (res = curl_easy_setopt(d_handle, CURLOPT_WRITEFUNCTION, chunk_write_data)))
-        throw BESInternalError(string("CURL Error: ").append(curl::error_message(res, d_errbuf)), __FILE__, __LINE__);
+    res = curl_easy_setopt(d_handle, CURLOPT_WRITEFUNCTION, chunk_write_data);
+    curl::check_setopt_result(res, prolog, "CURLOPT_WRITEFUNCTION", d_errbuf, __FILE__, __LINE__);
 
 #ifdef CURLOPT_TCP_KEEPALIVE
     /* enable TCP keep-alive for this transfer */
-    if (CURLE_OK != (res = curl_easy_setopt(d_handle, CURLOPT_TCP_KEEPALIVE, 1L)))
-        throw BESInternalError(string("CURL Error: ").append(curl::error_message(res)), __FILE__, __LINE__);
+    res = curl_easy_setopt(d_handle, CURLOPT_TCP_KEEPALIVE, 1L);
+    curl::check_setopt_result(res, prolog, "CURLOPT_TCP_KEEPALIVE", d_errbuf, __FILE__, __LINE__);
 #endif
 
 #ifdef CURLOPT_TCP_KEEPIDLE
     /* keep-alive idle time to 120 seconds */
-    if (CURLE_OK != (res = curl_easy_setopt(d_handle, CURLOPT_TCP_KEEPIDLE, 120L)))
-        throw BESInternalError(string("CURL Error: ").append(curl::error_message(res)), __FILE__, __LINE__);
+     res = curl_easy_setopt(d_handle, CURLOPT_TCP_KEEPIDLE, 120L);
+    curl::check_setopt_result(res, prolog, "CURLOPT_TCP_KEEPIDLE", d_errbuf, __FILE__, __LINE__);
 #endif
 
 #ifdef CURLOPT_TCP_KEEPINTVL
     /* interval time between keep-alive probes: 120 seconds */
-    if (CURLE_OK != (res = curl_easy_setopt(d_handle, CURLOPT_TCP_KEEPINTVL, 120L)))
-        throw BESInternalError(string("CURL Error: ").append(curl::error_message(res)), __FILE__, __LINE__)
+    res = curl_easy_setopt(d_handle, CURLOPT_TCP_KEEPINTVL, 120L)
+    curl::check_setopt_result(res, prolog, "CURLOPT_TCP_KEEPINTVL", d_errbuf, __FILE__, __LINE__);
 #endif
 
     d_in_use = false;
@@ -407,7 +407,7 @@ static void *easy_handle_read_data(void *handle) {
  * d_max_parallel_transfers are added to the 'multi' handle.
  */
 void dmrpp_multi_handle::read_data() {
-#if HAVE_CURL_MULTI_API
+#if 1 //HAVE_CURL_MULTI_API
     useconds_t retry_time = uone_second/4;
     // Use the libcurl Multi API here. Alternate version follows...
     try {
@@ -433,13 +433,15 @@ void dmrpp_multi_handle::read_data() {
 
         CURLMsg *msg = 0;
         int msgs_left = 0;
+        char empty[1];
+        empty[0] = 0;
         while ((msg = curl_multi_info_read(p_impl->curlm, &msgs_left))) {
             if (msg->msg == CURLMSG_DONE) {
                 CURL *eh = msg->easy_handle;
 
                 CURLcode res = msg->data.result;
                 if (res != CURLE_OK)
-                    throw BESInternalError(string("Error HTTP: ").append(curl::error_message(res,"")), __FILE__, __LINE__);
+                    throw BESInternalError(string("Error HTTP: ").append(curl::error_message(res,empty)), __FILE__, __LINE__);
 
                 // Note: 'eh' is the easy handle returned by culr_multi_info_read(),
                 // but in it's private field is our dmrpp_easy_handle object. We need
@@ -447,7 +449,7 @@ void dmrpp_multi_handle::read_data() {
                 dmrpp_easy_handle *dmrpp_easy_handle = 0;
                 res = curl_easy_getinfo(eh, CURLINFO_PRIVATE, &dmrpp_easy_handle);
                 if (res != CURLE_OK)
-                    throw BESInternalError(string("Could not access easy handle: ").append(curl::error_message(res,"")), __FILE__, __LINE__);
+                    throw BESInternalError(string("Could not access easy handle: ").append(curl::error_message(res,empty)), __FILE__, __LINE__);
 
                 // This code has to work with both http/s: and file: protocols. Here we check the
                 // HTTP status code. If the protocol is not HTTP, we assume since msg->data.result
@@ -624,61 +626,62 @@ CurlHandlePool::get_easy_handle(Chunk *chunk) {
 
         handle->d_chunk = chunk;
 
-        CURLcode res = curl_easy_setopt(handle->d_handle, CURLOPT_URL, chunk->get_data_url().c_str());
-        if (res != CURLE_OK)
-            throw BESInternalError(string("HTTP Error setting URL: ").append(
-                    curl::error_message(res, handle->d_errbuf)), __FILE__, __LINE__);
+        CURLcode res;
+
+
+        res = curl_easy_setopt(handle->d_handle, CURLOPT_URL, chunk->get_data_url().c_str());
+        curl::check_setopt_result(res, prolog, "CURLOPT_URL", handle->d_errbuf, __FILE__, __LINE__);
 
         // get the offset to offset + size bytes
-        if (CURLE_OK !=
-            (res = curl_easy_setopt(handle->d_handle, CURLOPT_RANGE, chunk->get_curl_range_arg_string().c_str())))
-            throw BESInternalError(
-                    string("HTTP Error setting Range: ").append(curl::error_message(res, handle->d_errbuf)), __FILE__,
-                    __LINE__);
+        res = curl_easy_setopt(handle->d_handle, CURLOPT_RANGE, chunk->get_curl_range_arg_string().c_str());
+        curl::check_setopt_result(res, prolog, "CURLOPT_RANGE", handle->d_errbuf, __FILE__, __LINE__);
 
         // Pass this to chunk_header_callback as the fourth argument
-        if (CURLE_OK != (res = curl_easy_setopt(handle->d_handle, CURLOPT_HEADERDATA, reinterpret_cast<void *>(chunk))))
-            throw BESInternalError(string("CURL Error setting chunk as header callback data: ").append(
-                    curl::error_message(res, handle->d_errbuf)),
-                                   __FILE__, __LINE__);
+        res = curl_easy_setopt(handle->d_handle, CURLOPT_HEADERDATA, reinterpret_cast<void *>(chunk));
+        curl::check_setopt_result(res, prolog, "CURLOPT_HEADERDATA", handle->d_errbuf, __FILE__, __LINE__);
 
         // Pass this to chunk_write_data as the fourth argument
-        if (CURLE_OK != (res = curl_easy_setopt(handle->d_handle, CURLOPT_WRITEDATA, reinterpret_cast<void *>(chunk))))
-            throw BESInternalError(string("CURL Error setting chunk as response callback data: ").append(
-                    curl::error_message(res, handle->d_errbuf)),
-                                   __FILE__, __LINE__);
+        res = curl_easy_setopt(handle->d_handle, CURLOPT_WRITEDATA, reinterpret_cast<void *>(chunk));
+        curl::check_setopt_result(res, prolog, "CURLOPT_WRITEDATA", handle->d_errbuf, __FILE__, __LINE__);
 
         // store the easy_handle so that we can call release_handle in multi_handle::read_data()
-        if (CURLE_OK != (res = curl_easy_setopt(handle->d_handle, CURLOPT_PRIVATE, reinterpret_cast<void *>(handle))))
-            throw BESInternalError(string("CURL Error setting easy_handle as private data: ").append(
-                    curl::error_message(res, handle->d_errbuf)), __FILE__,
-                                   __LINE__);
+        res = curl_easy_setopt(handle->d_handle, CURLOPT_PRIVATE, reinterpret_cast<void *>(handle));
+        curl::check_setopt_result(res, prolog, "CURLOPT_PRIVATE", handle->d_errbuf, __FILE__, __LINE__);
 
         // Enabled cookies
-        // #TODO #FIXME Make these file names configuration based.
-        curl_easy_setopt(handle->d_handle, CURLOPT_COOKIEFILE, curl::get_cookie_filename().c_str());
-        curl_easy_setopt(handle->d_handle, CURLOPT_COOKIEJAR, curl::get_cookie_filename().c_str());
+        res = curl_easy_setopt(handle->d_handle, CURLOPT_COOKIEFILE, curl::get_cookie_filename().c_str());
+        curl::check_setopt_result(res, prolog, "CURLOPT_COOKIEFILE", handle->d_errbuf, __FILE__, __LINE__);
+
+        res  = curl_easy_setopt(handle->d_handle, CURLOPT_COOKIEJAR, curl::get_cookie_filename().c_str());
+        curl::check_setopt_result(res, prolog, "CURLOPT_COOKIEJAR", handle->d_errbuf, __FILE__, __LINE__);
 
         // Follow 302 (redirect) responses
-        curl_easy_setopt(handle->d_handle, CURLOPT_FOLLOWLOCATION, 1);
-        curl_easy_setopt(handle->d_handle, CURLOPT_MAXREDIRS, 20);
+        res = curl_easy_setopt(handle->d_handle, CURLOPT_FOLLOWLOCATION, 1);
+        curl::check_setopt_result(res, prolog, "CURLOPT_FOLLOWLOCATION", handle->d_errbuf, __FILE__, __LINE__);
+
+        res = curl_easy_setopt(handle->d_handle, CURLOPT_MAXREDIRS, curl::max_redirects());
+        curl::check_setopt_result(res, prolog, "CURLOPT_MAXREDIRS", handle->d_errbuf, __FILE__, __LINE__);
 
         // Set the user agent something otherwise TEA will never redirect to URS.
-        curl_easy_setopt(handle->d_handle, CURLOPT_USERAGENT, curl::hyrax_user_agent().c_str());
+        res = curl_easy_setopt(handle->d_handle, CURLOPT_USERAGENT, curl::hyrax_user_agent().c_str());
+        curl::check_setopt_result(res, prolog, "CURLOPT_USERAGENT", handle->d_errbuf, __FILE__, __LINE__);
 
         // This means libcurl will use Basic, Digest, GSS Negotiate, or NTLM,
         // choosing the the 'safest' one supported by the server.
         // This requires curl 7.10.6 which is still in pre-release. 07/25/03 jhrg
-        curl_easy_setopt(handle->d_handle, CURLOPT_HTTPAUTH, (long) CURLAUTH_ANY);
+        res = curl_easy_setopt(handle->d_handle, CURLOPT_HTTPAUTH, (long) CURLAUTH_ANY);
+        curl::check_setopt_result(res, prolog, "CURLOPT_HTTPAUTH", handle->d_errbuf, __FILE__, __LINE__);
 
         // Enable using the .netrc credentials file.
-        curl_easy_setopt(handle->d_handle, CURLOPT_NETRC, 1);
+        res = curl_easy_setopt(handle->d_handle, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
+        curl::check_setopt_result(res, prolog, "CURLOPT_NETRC", handle->d_errbuf, __FILE__, __LINE__);
 
         // If the configuration specifies a particular .netrc credentials file, use it.
         // TODO move this operation into constructor and stash the value.
         string netrc_file = curl::get_netrc_filename();
         if (!netrc_file.empty()) {
-            curl_easy_setopt(handle->d_handle, CURLOPT_NETRC_FILE, netrc_file.c_str());
+            res = curl_easy_setopt(handle->d_handle, CURLOPT_NETRC_FILE, netrc_file.c_str());
+            curl::check_setopt_result(res, prolog, "CURLOPT_NETRC_FILE", handle->d_errbuf, __FILE__, __LINE__);
         }
         VERBOSE(__FILE__ << "::get_easy_handle() is using the netrc file '"
                          << ((!netrc_file.empty()) ? netrc_file : "~/.netrc") << "'" << endl);
@@ -727,9 +730,8 @@ CurlHandlePool::get_easy_handle(Chunk *chunk) {
             handle->d_request_headers = temp;
 
 
-            if (CURLE_OK != (res = curl_easy_setopt(handle->d_handle, CURLOPT_HTTPHEADER, handle->d_request_headers)))
-                throw BESInternalError(string("CURL Error setting HTTP headers for S3 authentication: ").append(
-                        curl::error_message(res, handle->d_errbuf)), __FILE__, __LINE__);
+            res = curl_easy_setopt(handle->d_handle, CURLOPT_HTTPHEADER, handle->d_request_headers);
+            curl::check_setopt_result(res, prolog, "CURLOPT_HTTPHEADER", handle->d_errbuf, __FILE__, __LINE__);
         }
     }
 

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -665,7 +665,7 @@ CurlHandlePool::get_easy_handle(Chunk *chunk) {
         curl_easy_setopt(handle->d_handle, CURLOPT_MAXREDIRS, 20);
 
         // Set the user agent something otherwise TEA will never redirect to URS.
-        curl_easy_setopt(handle->d_handle, CURLOPT_USERAGENT, curl::hyrax_user_agent());
+        curl_easy_setopt(handle->d_handle, CURLOPT_USERAGENT, curl::hyrax_user_agent().c_str());
 
         // This means libcurl will use Basic, Digest, GSS Negotiate, or NTLM,
         // choosing the the 'safest' one supported by the server.

--- a/modules/ngap_module/NgapApi.cc
+++ b/modules/ngap_module/NgapApi.cc
@@ -160,33 +160,33 @@ namespace ngap {
         // Pick up the values of said tokens.
         string cmr_url = get_cmr_search_endpoint_url() + "?";
 
-        char error_buffer[CURL_ERROR_SIZE];
-        CURL *curl = curl::init(error_buffer);  // This may throw either Error or InternalErr
-        char *esc_url_content;
+        {
+            CURL *curl = curl_easy_init();
+            char *esc_url_content;
 
-        esc_url_content = curl_easy_escape(curl, tokens[1].c_str(), tokens[1].size());
-        cmr_url += CMR_PROVIDER + "=" + esc_url_content + "&";
-        curl_free(esc_url_content);
-
-        esc_url_content = curl_easy_escape(curl, tokens[3].c_str(), tokens[3].size());
-        if (tokens[2] == NGAP_COLLECTIONS_KEY) {
-            cmr_url += CMR_ENTRY_TITLE + "=" + esc_url_content + "&";
-        }
-        else if(tokens[2] == NGAP_CONCEPTS_KEY){
-            cmr_url += CMR_COLLECTION_CONCEPT_ID + "=" + esc_url_content + "&";
-        }
-        else {
+            esc_url_content = curl_easy_escape(curl, tokens[1].c_str(), tokens[1].size());
+            cmr_url += CMR_PROVIDER + "=" + esc_url_content + "&";
             curl_free(esc_url_content);
-            throw BESSyntaxUserError(string("The specified path '") + restified_path +
-                                     "' does not conform to the NGAP request interface API.", __FILE__, __LINE__);
+
+            esc_url_content = curl_easy_escape(curl, tokens[3].c_str(), tokens[3].size());
+            if (tokens[2] == NGAP_COLLECTIONS_KEY) {
+                cmr_url += CMR_ENTRY_TITLE + "=" + esc_url_content + "&";
+            }
+            else if(tokens[2] == NGAP_CONCEPTS_KEY){
+                cmr_url += CMR_COLLECTION_CONCEPT_ID + "=" + esc_url_content + "&";
+            }
+            else {
+                curl_free(esc_url_content);
+                throw BESSyntaxUserError(string("The specified path '") + restified_path +
+                                         "' does not conform to the NGAP request interface API.", __FILE__, __LINE__);
+            }
+            curl_free(esc_url_content);
+
+            esc_url_content = curl_easy_escape(curl, tokens[5].c_str(), tokens[5].size());
+            cmr_url += CMR_GRANULE_UR + "=" + esc_url_content;
+            curl_free(esc_url_content);
+            curl_easy_cleanup(curl);
         }
-        curl_free(esc_url_content);
-
-        esc_url_content = curl_easy_escape(curl, tokens[5].c_str(), tokens[5].size());
-        cmr_url += CMR_GRANULE_UR + "=" + esc_url_content;
-        curl_free(esc_url_content);
-        curl_easy_cleanup(curl);
-
 
         BESDEBUG(MODULE, prolog << "CMR Request URL: " << cmr_url << endl);
 #if 1


### PR DESCRIPTION
This patch fixes a memory issue caused by allowing the char err_buf[CURL_ERROR_SIZE] array to leave scope before the cURL handle was utilized.

A couple of additional patches, including:
-  A config param for using UNIX time values for log time. 
- Made a SSOT for the User-Agent utilized by Hyrax.