### PR TITLE
Ngap stopwatch

### DIFF
--- a/dap/BESDapResponseBuilder.cc
+++ b/dap/BESDapResponseBuilder.cc
@@ -114,6 +114,7 @@
 
 #include "BESUtil.h"
 #include "BESDebug.h"
+#include "BESLog.h"
 #include "BESStopWatch.h"
 #include "DapFunctionUtils.h"
 
@@ -798,7 +799,7 @@ bool BESDapResponseBuilder::store_dap2_result(ostream &out, DDS &dds, Constraint
 void BESDapResponseBuilder::serialize_dap2_data_dds(ostream &out, DDS **dds, ConstraintEvaluator &eval, bool ce_eval)
 {
     BESStopWatch sw;
-    if (BESISDEBUG(TIMING_LOG)) sw.start("BESDapResponseBuilder::serialize_dap2_data_dds", "");
+    if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose()) sw.start(prolog +"Timer", "");
 
     BESDEBUG(MODULE, prolog << "BEGIN" << endl);
 
@@ -987,6 +988,9 @@ BESDapResponseBuilder::process_dap2_dds(BESResponseObject *obj, BESDataHandlerIn
 libdap::DDS *
 BESDapResponseBuilder::intern_dap2_data(BESResponseObject *obj, BESDataHandlerInterface &dhi)
 {
+    BESStopWatch sw;
+    if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose()) sw.start(prolog +"Timer", "");
+
     BESDEBUG(MODULE, prolog << "BEGIN"<< endl);
 
     dhi.first_container();
@@ -1441,6 +1445,8 @@ void BESDapResponseBuilder::send_dap4_data_using_ce(ostream &out, DMR &dmr, bool
 
 void BESDapResponseBuilder::intern_dap4_data_using_ce(DMR &dmr)
 {
+    BESStopWatch sw;
+    if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose()) sw.start(prolog +"Timer", "");
     if (!d_dap4ce.empty()) {
         BESDEBUG("dap", "BESDapResponseBuilder::intern_dap4_data_using_ce() - expression constraint is not empty. " <<endl);
         D4ConstraintEvaluator parser(&dmr);
@@ -1498,6 +1504,9 @@ void BESDapResponseBuilder::send_dap4_data(ostream &out, DMR &dmr, bool with_mim
  */
 void BESDapResponseBuilder::serialize_dap4_data(std::ostream &out, libdap::DMR &dmr, bool with_mime_headers)
 {
+    BESStopWatch sw;
+    if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose()) sw.start(prolog +"Timer", "");
+
     BESDEBUG(MODULE, prolog << "BEGIN" << endl);
 
     if (with_mime_headers) set_mime_binary(out, dap4_data, x_plain, last_modified_time(d_dataset), dmr.dap_version());
@@ -1641,6 +1650,8 @@ bool BESDapResponseBuilder::store_dap4_result(ostream &out, libdap::DMR &dmr)
 libdap::DMR *
 BESDapResponseBuilder::intern_dap4_data(BESResponseObject *obj, BESDataHandlerInterface &dhi)
 {
+    BESStopWatch sw;
+    if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose()) sw.start(prolog +"Timer", "");
     BESDEBUG("dap", "BESDapResponseBuilder::intern_dap4_data() - BEGIN"<< endl);
 
     dhi.first_container();

--- a/dap/unit-tests/input-files/test.keys
+++ b/dap/unit-tests/input-files/test.keys
@@ -1,1 +1,3 @@
 # Intentionally empty
+# I had to add the log file to this because called code uses the VERBOSE log now.
+BES.LogName=./bes.log

--- a/http/EffectiveUrlCache.cc
+++ b/http/EffectiveUrlCache.cc
@@ -40,7 +40,9 @@
 #include "BESSyntaxUserError.h"
 #include "TheBESKeys.h"
 #include "BESDebug.h"
+#include "BESStopWatch.h"
 #include "BESUtil.h"
+#include "BESLog.h"
 #include "CurlUtils.h"
 #include "HttpNames.h"
 
@@ -211,6 +213,9 @@ http::url *EffectiveUrlCache::get_effective_url(const string &source_url) {
 http::url *EffectiveUrlCache::get_effective_url(const string &source_url, BESRegex *skip_regex)
 {
     BESDEBUG(MODULE, prolog << "BEGIN url: " << source_url << endl);
+    BESStopWatch sw;
+    if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose())
+        sw.start(prolog + "full method");
 
     http::url *effective_url = NULL;
 
@@ -250,6 +255,10 @@ http::url *EffectiveUrlCache::get_effective_url(const string &source_url, BESReg
         // It not found or expired, reload.
         if(retrieve_and_cache){
             BESDEBUG(MODULE, prolog << "Acquiring effective URL for  " << source_url << endl);
+            BESStopWatch moo;
+            if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose())
+                moo.start(prolog + " Only Retrieve and Cache");
+
 
             string effective_url_str;
             curl::retrieve_effective_url(source_url, effective_url_str);

--- a/http/EffectiveUrlCache.cc
+++ b/http/EffectiveUrlCache.cc
@@ -213,9 +213,12 @@ http::url *EffectiveUrlCache::get_effective_url(const string &source_url) {
 http::url *EffectiveUrlCache::get_effective_url(const string &source_url, BESRegex *skip_regex)
 {
     BESDEBUG(MODULE, prolog << "BEGIN url: " << source_url << endl);
-    BESStopWatch sw;
-    if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose())
-        sw.start(prolog + "full method");
+
+#if 0
+    //BESStopWatch sw;
+    //if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose())
+    //    sw.start(prolog + "full method");
+#endif
 
     http::url *effective_url = NULL;
 

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -772,8 +772,8 @@ CurlHandlePool::get_easy_handle(Chunk *chunk) {
             res = curl_easy_setopt(handle->d_handle, CURLOPT_NETRC_FILE, netrc_file.c_str());
             curl::eval_curl_easy_setopt_result(res, prolog, "CURLOPT_NETRC_FILE", handle->d_errbuf, __FILE__, __LINE__);
         }
-        VERBOSE(__FILE__ << "::get_easy_handle() is using the netrc file '"
-                         << ((!netrc_file.empty()) ? netrc_file : "~/.netrc") << "'" << endl);
+        //VERBOSE(__FILE__ << "::get_easy_handle() is using the netrc file '"
+        //<< ((!netrc_file.empty()) ? netrc_file : "~/.netrc") << "'" << endl);
 
         AccessCredentials *credentials = CredentialsManager::theCM()->get(handle->d_url);
         if (credentials && credentials->isS3Cred()) {

--- a/modules/dmrpp_module/DmrppParserSax2.cc
+++ b/modules/dmrpp_module/DmrppParserSax2.cc
@@ -1552,9 +1552,10 @@ void DmrppParserSax2::intern(istream &f, DMR *dest_dmr)
 {
     // Code example from libxml2 docs re: read from a stream.
 
-    if (!f.good()) throw Error("Input stream not open or read error");
-    if (!dest_dmr) throw InternalErr(__FILE__, __LINE__, "DMR object is null");
+    if (!f.good()) throw BESInternalError(prolog + "ERROR - Supplied istream instance not open or read error",__FILE__,__LINE__);
+    if (!dest_dmr) throw BESInternalError(prolog + "THe supplied DMR object pointer  is null", __FILE__, __LINE__);
 
+    Error foo;
     d_dmr = dest_dmr; // dump values here
 
     int line_num = 1;
@@ -1562,7 +1563,7 @@ void DmrppParserSax2::intern(istream &f, DMR *dest_dmr)
 
     // Get the XML prolog line (looks like: <?xml ... ?> )
     getline(f, line);
-    if (line.length() == 0) throw Error("No input found while parsing the DMR.");
+    if (line.length() == 0) throw BESInternalError(prolog + "ERROR - No input found when parsing the DMR++",__FILE__,__LINE__);
 
     BESDEBUG(PARSER, prolog << "line: (" << line_num << "): " << endl << line << endl << endl);
 

--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -214,7 +214,7 @@ bool DmrppRequestHandler::dap_build_dmr(BESDataHandlerInterface &dhi)
 bool DmrppRequestHandler::dap_build_dap4data(BESDataHandlerInterface &dhi)
 {
     BESStopWatch sw;
-    if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose()) sw.start(prolog + "timer" , dhi.data[REQUEST_ID]);
+    if (BESISDEBUG(TIMING_LOG)) sw.start(prolog + "timer" , dhi.data[REQUEST_ID]);
 
     BESDEBUG(module, "Entering dap_build_dap4data..." << endl);
 
@@ -267,7 +267,7 @@ bool DmrppRequestHandler::dap_build_dap4data(BESDataHandlerInterface &dhi)
 bool DmrppRequestHandler::dap_build_dap2data(BESDataHandlerInterface & dhi)
 {
     BESStopWatch sw;
-    if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose()) sw.start(prolog + "timer" , dhi.data[REQUEST_ID]);
+    if (BESISDEBUG(TIMING_LOG)) sw.start(prolog + "timer" , dhi.data[REQUEST_ID]);
 
     BESDEBUG(module, __func__ << "() - BEGIN" << endl);
 

--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -54,6 +54,7 @@
 #include <BESConstraintFuncs.h>
 #include <BESServiceRegistry.h>
 #include <BESUtil.h>
+#include <BESLog.h>
 #include <TheBESKeys.h>
 
 #include <BESDapError.h>
@@ -72,6 +73,8 @@
 using namespace bes;
 using namespace libdap;
 using namespace std;
+
+#define prolog std::string("DmrppRequestHandler::").append(__func__).append("() - ")
 
 namespace dmrpp {
 
@@ -210,6 +213,9 @@ bool DmrppRequestHandler::dap_build_dmr(BESDataHandlerInterface &dhi)
 
 bool DmrppRequestHandler::dap_build_dap4data(BESDataHandlerInterface &dhi)
 {
+    BESStopWatch sw;
+    if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose()) sw.start(prolog + "timer" , dhi.data[REQUEST_ID]);
+
     BESDEBUG(module, "Entering dap_build_dap4data..." << endl);
 
     BESResponseObject *response = dhi.response_handler->get_response_object();
@@ -261,7 +267,7 @@ bool DmrppRequestHandler::dap_build_dap4data(BESDataHandlerInterface &dhi)
 bool DmrppRequestHandler::dap_build_dap2data(BESDataHandlerInterface & dhi)
 {
     BESStopWatch sw;
-    if (BESISDEBUG(TIMING_LOG)) sw.start("DmrppRequestHandler::dap_build_dap2data()", dhi.data[REQUEST_ID]);
+    if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose()) sw.start(prolog + "timer" , dhi.data[REQUEST_ID]);
 
     BESDEBUG(module, __func__ << "() - BEGIN" << endl);
 

--- a/modules/ngap_module/NgapApi.cc
+++ b/modules/ngap_module/NgapApi.cc
@@ -46,6 +46,8 @@
 #include "BESSyntaxUserError.h"
 #include "BESDebug.h"
 #include "BESUtil.h"
+#include "BESStopWatch.h"
+#include "BESLog.h"
 #include "TheBESKeys.h"
 #include "CurlUtils.h"
 #include "url_impl.h"
@@ -192,7 +194,13 @@ namespace ngap {
 #if 1
         BESDEBUG(MODULE, prolog << "Building new RemoteResource." << endl);
         http::RemoteResource cmr_query(cmr_url, uid);
-        cmr_query.retrieveResource();
+        {
+            BESStopWatch besTimer;
+            if(BESLog::TheLog()->is_verbose()){
+                besTimer.start("CMR Query: " + cmr_url);
+            }
+            cmr_query.retrieveResource();
+        }
         rapidjson::Document cmr_response = cmr_query.get_as_json();
 #else
         rapidjson::Document cmr_response = ngap_curl::http_get_as_json(cmr_url);

--- a/modules/ngap_module/NgapContainer.cc
+++ b/modules/ngap_module/NgapContainer.cc
@@ -34,6 +34,8 @@
 #include <streambuf>
 #include <time.h>
 
+#include "BESStopWatch.h"
+#include "BESLog.h"
 #include "BESSyntaxUserError.h"
 #include "BESNotFoundError.h"
 #include "BESInternalError.h"
@@ -219,8 +221,14 @@ namespace ngap {
                 replace_template = DATA_ACCESS_URL_KEY;
                 replace_value = data_access_url_str;
             }
-            d_dmrpp_rresource = new http::RemoteResource(dmrpp_url);
-            d_dmrpp_rresource->retrieveResource(replace_template, replace_value);
+            {
+                d_dmrpp_rresource = new http::RemoteResource(dmrpp_url);
+                BESStopWatch besTimer;
+                if(BESLog::TheLog()->is_verbose()){
+                    besTimer.start("DMR++ retrieval: "+ dmrpp_url);
+                }
+                d_dmrpp_rresource->retrieveResource(replace_template, replace_value);
+            }
         }
         BESDEBUG(MODULE, prolog << "Retrieved remote resource: " << dmrpp_url << endl);
 


### PR DESCRIPTION
In this PR I have:

I added timers to
```
EffectiveUrlCache::get_effective_url()                   // Resolution of CF URLs to S3 Urls
DmrppRequestHandler::dap_build_dap4data()                // Data Access - may subsume get_effective_url()
DmrppRequestHandler::dap_build_dap2data()                // Data Access - may subsume get_effective_url()
NgapApi::convert_ngap_resty_path_to_data_access_url()    // CMR query
NgapContainer::access()                                  // dmr++ retrieval fro s3  
```

The new timers activation is dependent on the existing timer trigger and on verbose logging:
```
BESStopWatch sw;
if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose()) 
    sw.start(prolog + "timer" , dhi.data[REQUEST_ID]);
```

I made changes to BESStopwatch so that output can go to either:
```
std::stringstream msg;
msg << "[" << BESDebug::GetPidStr() << "][" << _log_name << "]";
msg << "[" << _req_id << "][STOPPED][" << stoptime << " ms]";
msg << "[" << _timer_name << "][ELAPSED][" << elapsed << " ms]" << endl;
if (BESDebug::GetStrm())
    *(BESDebug::GetStrm()) << msg.str();
VERBOSE(msg.str() );
```
