### PR TITLE
Moving stopwatch closer to remote access

### DIFF
--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -45,6 +45,7 @@
 #include "TheBESKeys.h"
 #include "BESUtil.h"
 #include "BESLog.h"
+#include "BESStopWatch.h"
 
 // #include "util.h"
 #include "BESDebug.h"
@@ -1398,6 +1399,10 @@ bool eval_curl_easy_perform_code(
         request_headers = add_auth_headers(request_headers);
 
         try {
+            BESStopWatch sw;
+            if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose())
+                sw.start(prolog + " Following Redirects Starting With: " + target_url);
+
             ceh = init_effective_url_retriever_handle(target_url, request_headers, resp_hdrs);
 
             super_easy_perform(ceh);

--- a/http/EffectiveUrlCache.cc
+++ b/http/EffectiveUrlCache.cc
@@ -258,10 +258,6 @@ http::url *EffectiveUrlCache::get_effective_url(const string &source_url, BESReg
         // It not found or expired, reload.
         if(retrieve_and_cache){
             BESDEBUG(MODULE, prolog << "Acquiring effective URL for  " << source_url << endl);
-            BESStopWatch moo;
-            if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose())
-                moo.start(prolog + " Only Retrieve and Cache");
-
 
             string effective_url_str;
             curl::retrieve_effective_url(source_url, effective_url_str);


### PR DESCRIPTION
Because the previous position of the stop watch and the name assigned to sit failed to make clear what was being timed. The stopwatch is now in the correct position in the code and the name of the stopwatch should make understanding the log entry easier.