### PR TITLE
Dmrpp refactor 2

### DIFF
--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -72,7 +72,7 @@ using namespace http;
 
 namespace curl {
 static const unsigned int retry_limit = 10; // Amazon's suggestion
-static const useconds_t uone_second = 1000*1000; // one second in micro seconds (which is 1000
+static const useconds_t uone_second = 1000 * 1000; // one second in micro seconds (which is 1000
 
 // Forward declaration
 curl_slist *add_auth_headers(struct curl_slist *request_headers);
@@ -82,7 +82,7 @@ int curl_trace = 0;
 
 #define CLIENT_ERR_MIN 400
 #define CLIENT_ERR_MAX 417
-    const char *http_client_errors[CLIENT_ERR_MAX - CLIENT_ERR_MIN + 1] = {
+const char *http_client_errors[CLIENT_ERR_MAX - CLIENT_ERR_MIN + 1] = {
         "Bad Request:",
         "Unauthorized: Contact the server administrator.",
         "Payment Required.",
@@ -101,1212 +101,1201 @@ int curl_trace = 0;
         "Unsupported Media Type.",
         "Requested Range Not Satisfiable.",
         "Expectation Failed."
-    };
+};
 
 #define SERVER_ERR_MIN 500
 #define SERVER_ERR_MAX 505
-    const char *http_server_errors[SERVER_ERR_MAX - SERVER_ERR_MIN + 1] =
-    {
-        "Internal Server Error.",
-        "Not Implemented.",
-        "Bad Gateway.",
-        "Service Unavailable.",
-        "Gateway Time-out.",
-        "HTTP Version Not Supported."
-    };
+const char *http_server_errors[SERVER_ERR_MAX - SERVER_ERR_MIN + 1] =
+        {
+                "Internal Server Error.",
+                "Not Implemented.",
+                "Bad Gateway.",
+                "Service Unavailable.",
+                "Gateway Time-out.",
+                "HTTP Version Not Supported."
+        };
 
-    /**
-     * @brief Translates an HTTP status code into an error message.
-     *
-     * It works for those code greater than or equal to 400.
-     *
-     * @param status The HTTP status to associate with an error message
-     * @return The error message assciated with status.
-     */
-    string http_status_to_string(int status) {
-        if (status >= CLIENT_ERR_MIN && status <= CLIENT_ERR_MAX)
-            return string(http_client_errors[status - CLIENT_ERR_MIN]);
-        else if (status >= SERVER_ERR_MIN && status <= SERVER_ERR_MAX)
-            return string(http_server_errors[status - SERVER_ERR_MIN]);
-        else{
-            stringstream msg;
-            msg << "Unknown HTTP Error: " << status;
-            return msg.str();
-        }
+/**
+ * @brief Translates an HTTP status code into an error message.
+ *
+ * It works for those code greater than or equal to 400.
+ *
+ * @param status The HTTP status to associate with an error message
+ * @return The error message assciated with status.
+ */
+string http_status_to_string(int status) {
+    if (status >= CLIENT_ERR_MIN && status <= CLIENT_ERR_MAX)
+        return string(http_client_errors[status - CLIENT_ERR_MIN]);
+    else if (status >= SERVER_ERR_MIN && status <= SERVER_ERR_MAX)
+        return string(http_server_errors[status - SERVER_ERR_MIN]);
+    else {
+        stringstream msg;
+        msg << "Unknown HTTP Error: " << status;
+        return msg.str();
+    }
+}
+
+/**
+ * @brief Translate a cURL authentication type value (int) into a human readable string.
+ * @param auth_type The cURL authentication type value to convert
+ * @return The human readable string associated with auth_type.
+ */
+static string getCurlAuthTypeName(const int auth_type) {
+
+    string authTypeString;
+    int match;
+
+    match = auth_type & CURLAUTH_BASIC;
+    if (match) {
+        authTypeString += "CURLAUTH_BASIC";
     }
 
-    /**
-     * @brief Translate a cURL authentication type value (int) into a human readable string.
-     * @param auth_type The cURL authentication type value to convert
-     * @return The human readable string associated with auth_type.
-     */
-    static string getCurlAuthTypeName(const int auth_type) {
+    match = auth_type & CURLAUTH_DIGEST;
+    if (match) {
+        if (!authTypeString.empty())
+            authTypeString += " ";
+        authTypeString += "CURLAUTH_DIGEST";
+    }
 
-        string authTypeString;
-        int match;
+    match = auth_type & CURLAUTH_DIGEST_IE;
+    if (match) {
+        if (!authTypeString.empty())
+            authTypeString += " ";
+        authTypeString += "CURLAUTH_DIGEST_IE";
+    }
 
-        match = auth_type & CURLAUTH_BASIC;
-        if (match) {
-            authTypeString += "CURLAUTH_BASIC";
-        }
+    match = auth_type & CURLAUTH_GSSNEGOTIATE;
+    if (match) {
+        if (!authTypeString.empty())
+            authTypeString += " ";
+        authTypeString += "CURLAUTH_GSSNEGOTIATE";
+    }
 
-        match = auth_type & CURLAUTH_DIGEST;
-        if (match) {
-            if (!authTypeString.empty())
-                authTypeString += " ";
-            authTypeString += "CURLAUTH_DIGEST";
-        }
-
-        match = auth_type & CURLAUTH_DIGEST_IE;
-        if (match) {
-            if (!authTypeString.empty())
-                authTypeString += " ";
-            authTypeString += "CURLAUTH_DIGEST_IE";
-        }
-
-        match = auth_type & CURLAUTH_GSSNEGOTIATE;
-        if (match) {
-            if (!authTypeString.empty())
-                authTypeString += " ";
-            authTypeString += "CURLAUTH_GSSNEGOTIATE";
-        }
-
-        match = auth_type & CURLAUTH_NTLM;
-        if (match) {
-            if (!authTypeString.empty())
-                authTypeString += " ";
-            authTypeString += "CURLAUTH_NTLM";
-        }
+    match = auth_type & CURLAUTH_NTLM;
+    if (match) {
+        if (!authTypeString.empty())
+            authTypeString += " ";
+        authTypeString += "CURLAUTH_NTLM";
+    }
 
 #if 0
-        match = auth_type & CURLAUTH_ANY;
-        if(match){
-            if(!authTypeString.empty())
-                authTypeString += " ";
-            authTypeString += "CURLAUTH_ANY";
-        }
+    match = auth_type & CURLAUTH_ANY;
+    if(match){
+        if(!authTypeString.empty())
+            authTypeString += " ";
+        authTypeString += "CURLAUTH_ANY";
+    }
 
 
-        match = auth_type & CURLAUTH_ANY;
-        if(match){
-            if(!authTypeString.empty())
-                authTypeString += " ";
-            authTypeString += "CURLAUTH_ANYSAFE";
-        }
+    match = auth_type & CURLAUTH_ANY;
+    if(match){
+        if(!authTypeString.empty())
+            authTypeString += " ";
+        authTypeString += "CURLAUTH_ANYSAFE";
+    }
 
 
-        match = auth_type & CURLAUTH_ANY;
-        if(match){
-            if(!authTypeString.empty())
-                authTypeString += " ";
-            authTypeString += "CURLAUTH_ONLY";
-        }
+    match = auth_type & CURLAUTH_ANY;
+    if(match){
+        if(!authTypeString.empty())
+            authTypeString += " ";
+        authTypeString += "CURLAUTH_ONLY";
+    }
 #endif
 
-        return authTypeString;
+    return authTypeString;
+}
+
+/**
+ * @brief A libcurl callback function that ignores the data entirely. nothing is written. Ever.
+ */
+static size_t writeNothing(char */* data */, size_t /* size */, size_t nmemb, void * /* userdata */) {
+    return nmemb;
+}
+
+/**
+ * libcurl call back function that is used to write data to a passed open file descriptor (that would
+ * be instead of the default open FILE *)
+ */
+static size_t writeToOpenfileDescriptor(char *data, size_t /* size */, size_t nmemb, void *userdata) {
+
+    int *fd = (int *) userdata;
+
+    BESDEBUG(MODULE, prolog << "Bytes received " << nmemb << endl);
+    int wrote = write(*fd, data, nmemb);
+    BESDEBUG(MODULE, prolog << "Bytes written " << wrote << endl);
+
+    return wrote;
+}
+
+
+/**
+ * @brief A libcurl callback function used to read response headers.
+ *
+ * Read headers, line by line, from ptr.
+ * The fourth param is really supposed to be a FILE,
+ * but libcurl just holds the pointer and passes it to this function
+ * without using it itself.
+ * What actually happens? This code was moved and I am not sure how this works
+ * (which it does) now. I use that to pass in a pointer to the HTTPConnect that
+ * initiated the HTTP request so that there's some place to dump the headers.
+ *
+ * Note that this function just saves the headers in a
+ * vector of strings. Later on the code (see fetch_url()) parses the headers
+ * special to the DAP.
+ *
+ * @param ptr A pointer to one line of character data; one header.
+ * @param size Size of each character (nominally one byte).
+ * @param nmemb Number of bytes.
+ * @param resp_hdrs A pointer to a vector<string>. Set in read_url.
+ * @return The number of bytes processed. Must be equal to size * nmemb or
+ * libcurl will report an error.
+ */
+static size_t save_http_response_headers(void *ptr, size_t size, size_t nmemb, void *resp_hdrs) {
+    BESDEBUG(MODULE, prolog << "Inside the header parser." << endl);
+    vector<string> *hdrs = static_cast<vector<string> * >(resp_hdrs);
+
+    // Grab the header, minus the trailing newline. Or \r\n pair.
+    string complete_line;
+    if (nmemb > 1 && *(static_cast<char *>(ptr) + size * (nmemb - 2)) == '\r')
+        complete_line.assign(static_cast<char *>(ptr), size * (nmemb - 2));
+    else
+        complete_line.assign(static_cast<char *>(ptr), size * (nmemb - 1));
+
+    // Store all non-empty headers that are not HTTP status codes
+    if (complete_line != "" && complete_line.find("HTTP") == string::npos) {
+        BESDEBUG(MODULE, prolog << "Header line: " << complete_line << endl);
+        hdrs->push_back(complete_line);
     }
 
-    /**
-     * @brief A libcurl callback function that ignores the data entirely. nothing is written. Ever.
-     */
-    static size_t writeNothing(char */* data */, size_t /* size */, size_t nmemb, void * /* userdata */) {
-        return nmemb;
-    }
-
-    /**
-     * libcurl call back function that is used to write data to a passed open file descriptor (that would
-     * be instead of the default open FILE *)
-     */
-    static size_t writeToOpenfileDescriptor(char *data, size_t /* size */, size_t nmemb, void *userdata) {
-
-        int *fd = (int *) userdata;
-
-        BESDEBUG(MODULE, prolog << "Bytes received " << nmemb << endl);
-        int wrote = write(*fd, data, nmemb);
-        BESDEBUG(MODULE, prolog << "Bytes written " << wrote << endl);
-
-        return wrote;
-    }
+    return size * nmemb;
+}
 
 
-    /**
-     * @brief A libcurl callback function used to read response headers.
-     *
-     * Read headers, line by line, from ptr.
-     * The fourth param is really supposed to be a FILE,
-     * but libcurl just holds the pointer and passes it to this function
-     * without using it itself.
-     * What actually happens? This code was moved and I am not sure how this works
-     * (which it does) now. I use that to pass in a pointer to the HTTPConnect that
-     * initiated the HTTP request so that there's some place to dump the headers.
-     *
-     * Note that this function just saves the headers in a
-     * vector of strings. Later on the code (see fetch_url()) parses the headers
-     * special to the DAP.
-     *
-     * @param ptr A pointer to one line of character data; one header.
-     * @param size Size of each character (nominally one byte).
-     * @param nmemb Number of bytes.
-     * @param resp_hdrs A pointer to a vector<string>. Set in read_url.
-     * @return The number of bytes processed. Must be equal to size * nmemb or
-     * libcurl will report an error.
-     */
-    static size_t save_http_response_headers(void *ptr, size_t size, size_t nmemb, void *resp_hdrs) {
-        BESDEBUG(MODULE, prolog << "Inside the header parser." << endl);
-        vector<string> *hdrs = static_cast<vector<string> * >(resp_hdrs);
+/**
+ * @brief A libcurl callback for debugging protocol issues.
+ * @param info
+ * @param msg
+ * @param size
+ * @return
+ */
+static int curl_debug(CURL *, curl_infotype info, char *msg, size_t size, void *) {
+    string message(msg, size);
 
-        // Grab the header, minus the trailing newline. Or \r\n pair.
-        string complete_line;
-        if (nmemb > 1 && *(static_cast<char *>(ptr) + size * (nmemb - 2)) == '\r')
-            complete_line.assign(static_cast<char *>(ptr), size * (nmemb - 2));
-        else
-            complete_line.assign(static_cast<char *>(ptr), size * (nmemb - 1));
-
-        // Store all non-empty headers that are not HTTP status codes
-        if (complete_line != "" && complete_line.find("HTTP") == string::npos) {
-            BESDEBUG(MODULE, prolog << "Header line: " << complete_line << endl);
-            hdrs->push_back(complete_line);
-        }
-
-        return size * nmemb;
-    }
-
-
-     /**
-      * @brief A libcurl callback for debugging protocol issues.
-      * @param info
-      * @param msg
-      * @param size
-      * @return
-      */
-    static int curl_debug(CURL *, curl_infotype info, char *msg, size_t size, void *) {
-        string message(msg, size);
-
-        switch (info) {
-            case CURLINFO_TEXT:
-                BESDEBUG(MODULE, prolog << "Text: " << message << endl);
-                break;
-            case CURLINFO_HEADER_IN:
-                BESDEBUG(MODULE, prolog << "Header in: " << message << endl);
-                break;
-            case CURLINFO_HEADER_OUT:
-                BESDEBUG(MODULE, prolog << "Header out: " << endl << message << endl);
-                break;
-            case CURLINFO_DATA_IN:
-                BESDEBUG(MODULE, prolog << "Data in: " << message << endl);
-                break;
-            case CURLINFO_DATA_OUT:
-                BESDEBUG(MODULE, prolog << "Data out: " << message << endl);
-                break;
-            case CURLINFO_END:
-                BESDEBUG(MODULE, prolog << "End: " << message << endl);
-                break;
+    switch (info) {
+        case CURLINFO_TEXT:
+            BESDEBUG(MODULE, prolog << "Text: " << message << endl);
+            break;
+        case CURLINFO_HEADER_IN:
+            BESDEBUG(MODULE, prolog << "Header in: " << message << endl);
+            break;
+        case CURLINFO_HEADER_OUT:
+            BESDEBUG(MODULE, prolog << "Header out: " << endl << message << endl);
+            break;
+        case CURLINFO_DATA_IN:
+            BESDEBUG(MODULE, prolog << "Data in: " << message << endl);
+            break;
+        case CURLINFO_DATA_OUT:
+            BESDEBUG(MODULE, prolog << "Data out: " << message << endl);
+            break;
+        case CURLINFO_END:
+            BESDEBUG(MODULE, prolog << "End: " << message << endl);
+            break;
 #ifdef CURLINFO_SSL_DATA_IN
-                case CURLINFO_SSL_DATA_IN:
-            BESDEBUG(MODULE,  prolog << "SSL Data in: " << message << endl ); break;
+            case CURLINFO_SSL_DATA_IN:
+        BESDEBUG(MODULE,  prolog << "SSL Data in: " << message << endl ); break;
 #endif
 #ifdef CURLINFO_SSL_DATA_OUT
-                case CURLINFO_SSL_DATA_OUT:
-            BESDEBUG(MODULE,  prolog << "SSL Data out: " << message << endl ); break;
+            case CURLINFO_SSL_DATA_OUT:
+        BESDEBUG(MODULE,  prolog << "SSL Data out: " << message << endl ); break;
 #endif
-            default:
-                BESDEBUG(MODULE, prolog << "Curl info: " << message << endl);
-                break;
-        }
-        return 0;
+        default:
+            BESDEBUG(MODULE, prolog << "Curl info: " << message << endl);
+            break;
+    }
+    return 0;
+}
+
+
+/**
+ * @brief Functor to add a single string to a curl_slist.
+ *
+ * This is used to transfer a list of headers from a vector<string> object to a curl_slist.
+ */
+class BuildHeaders : public std::unary_function<const string &, void> {
+    struct curl_slist *d_cl;
+
+public:
+    BuildHeaders() : d_cl(0) {}
+
+    void operator()(const string &header) {
+        BESDEBUG(MODULE, prolog << "Adding '" << header.c_str() << "' to the header list." << endl);
+        d_cl = curl_slist_append(d_cl, header.c_str());
     }
 
+    struct curl_slist *get_headers() {
+        return d_cl;
+    }
+};
 
-    /**
-     * @brief Functor to add a single string to a curl_slist.
-     *
-     * This is used to transfer a list of headers from a vector<string> object to a curl_slist.
-     */
-    class BuildHeaders : public std::unary_function<const string &, void> {
-        struct curl_slist *d_cl;
+/**
+ * @brief Configure the proxy options for the passed curl object.
+ * The passed URL is the target URL. If the target URL matches the
+ * HttpUtils::NoProxyRegex in the config file, then no proxying is done.
+ *
+ * The proxy configuration is stored in the http configuration file, http.conf.
+ * The configuration utilizes the following keys. The:
+ * Http.ProxyHost=<hostname or ip address>
+ * Http.ProxyPort=<port number>
+ * Http.ProxyAuthType=<basic | digest | ntlm>
+ * Http.ProxyUser=<username>
+ * Http.ProxyPassword=<password>
+ * Http.ProxyUserPW=<username:password>
+ * Http.ProxyProtocol=< https | http >
+ * Http.NoProxy=<regex_to_match_no_proxy_urls>
+ *
+ * @param curl The cURL easy handle to configure.
+ * @param target_url The url used to configure the proxy
+ * @return
+ */
+bool configure_curl_handle_for_proxy(CURL *ceh, const string &target_url) {
+    BESDEBUG(MODULE, prolog << "BEGIN." << endl);
 
-    public:
-        BuildHeaders() : d_cl(0) {}
+    bool using_proxy = false;
 
-        void operator()(const string &header) {
-            BESDEBUG(MODULE, prolog << "Adding '" << header.c_str() << "' to the header list." << endl);
-            d_cl = curl_slist_append(d_cl, header.c_str());
+    if (!HttpUtils::ProxyConfigured) {
+        HttpUtils::load_proxy_from_keys();
+    }
+
+    // I pulled this because I could never find where it was applied
+    // to the curl state in HTTPConnect
+    //string proxyProtocol = GatewayUtils::ProxyProtocol;
+
+    // TODO remove these local variables (if possible) and pass the values into curl_easy_setopt() directly from HttpUtils
+    string proxyHost = HttpUtils::ProxyHost;
+    int proxyPort = HttpUtils::ProxyPort;
+    string proxyPassword = HttpUtils::ProxyPassword;
+    string proxyUser = HttpUtils::ProxyUser;
+    string proxyUserPW = HttpUtils::ProxyUserPW;
+    int proxyAuthType = HttpUtils::ProxyAuthType;
+
+    if (!proxyHost.empty()) {
+        using_proxy = true;
+        if (proxyPort == 0)
+            proxyPort = 8080;
+
+        // Apparently we don't need this...
+        //if(proxyProtocol.empty())
+        // proxyProtocol = "http";
+
+    }
+    if (using_proxy) {
+        BESDEBUG(MODULE, prolog << "Found proxy configuration." << endl);
+
+        // Don't set up the proxy server for URLs that match the 'NoProxy'
+        // regex set in the gateway.conf file.
+
+        // Don't create the regex if the string is empty
+        if (!HttpUtils::NoProxyRegex.empty()) {
+            BESDEBUG(MODULE, prolog << "Found NoProxyRegex." << endl);
+            BESRegex r(HttpUtils::NoProxyRegex.c_str());
+            if (r.match(target_url.c_str(), target_url.length()) != -1) {
+                BESDEBUG(MODULE,
+                         prolog << "Found NoProxy match. Regex: " << HttpUtils::NoProxyRegex << "; Url: " << target_url
+                                << endl);
+                using_proxy = false;
+            }
         }
 
-        struct curl_slist *get_headers() {
-            return d_cl;
-        }
-    };
-
-
-    /**
-     * @brief Configure the proxy options for the passed curl object.
-     * The passed URL is the target URL. If the target URL matches the
-     * HttpUtils::NoProxyRegex in the config file, then no proxying is done.
-     *
-     * The proxy configuration is stored in the http configuration file, http.conf.
-     * The configuration utilizes the following keys. The:
-     * Http.ProxyHost=<hostname or ip address>
-     * Http.ProxyPort=<port number>
-     * Http.ProxyAuthType=<basic | digest | ntlm>
-     * Http.ProxyUser=<username>
-     * Http.ProxyPassword=<password>
-     * Http.ProxyUserPW=<username:password>
-     * Http.ProxyProtocol=< https | http >
-     * Http.NoProxy=<regex_to_match_no_proxy_urls>
-     *
-     * @param curl The cURL easy handle to configure.
-     * @param target_url The url used to configure the proxy
-     * @return
-     */
-    bool configure_curl_handle_for_proxy(CURL *ceh, const string &target_url) {
-        BESDEBUG(MODULE,  prolog << "BEGIN." << endl);
-
-        bool using_proxy = false;
-
-        if(!HttpUtils::ProxyConfigured){
-            HttpUtils::load_proxy_from_keys();
-        }
-
-        // I pulled this because I could never find where it was applied
-        // to the curl state in HTTPConnect
-        //string proxyProtocol = GatewayUtils::ProxyProtocol;
-
-        // TODO remove these local variables (if possible) and pass the values into curl_easy_setopt() directly from HttpUtils
-        string proxyHost = HttpUtils::ProxyHost;
-        int proxyPort = HttpUtils::ProxyPort;
-        string proxyPassword = HttpUtils::ProxyPassword;
-        string proxyUser = HttpUtils::ProxyUser;
-        string proxyUserPW = HttpUtils::ProxyUserPW;
-        int proxyAuthType = HttpUtils::ProxyAuthType;
-
-        if (!proxyHost.empty()) {
-            using_proxy = true;
-            if (proxyPort == 0)
-                proxyPort = 8080;
-
-            // Apparently we don't need this...
-            //if(proxyProtocol.empty())
-            // proxyProtocol = "http";
-
-        }
         if (using_proxy) {
-            BESDEBUG(MODULE,  prolog << "Found proxy configuration." << endl);
+            CURLcode res;
+            char error_buffer[CURL_ERROR_SIZE];
 
-            // Don't set up the proxy server for URLs that match the 'NoProxy'
-            // regex set in the gateway.conf file.
+            BESDEBUG(MODULE, prolog << "Setting up a proxy server." << endl);
+            BESDEBUG(MODULE, prolog << "Proxy host: " << proxyHost << endl);
+            BESDEBUG(MODULE, prolog << "Proxy port: " << proxyPort << endl);
 
-            // Don't create the regex if the string is empty
-            if (!HttpUtils::NoProxyRegex.empty()) {
-                BESDEBUG(MODULE,  prolog << "Found NoProxyRegex." << endl);
-                BESRegex r(HttpUtils::NoProxyRegex.c_str());
-                if (r.match(target_url.c_str(), target_url.length()) != -1) {
-                    BESDEBUG(MODULE, prolog << "Found NoProxy match. Regex: " << HttpUtils::NoProxyRegex << "; Url: " << target_url << endl);
-                    using_proxy = false;
+            set_error_buffer(ceh, error_buffer);
+
+            res = curl_easy_setopt(ceh, CURLOPT_PROXY, proxyHost.data());
+            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_PROXY", error_buffer, __FILE__, __LINE__);
+
+            res = curl_easy_setopt(ceh, CURLOPT_PROXYPORT, proxyPort);
+            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_PROXYPORT", error_buffer, __FILE__, __LINE__);
+
+            // oddly "#ifdef CURLOPT_PROXYAUTH" doesn't work - even though CURLOPT_PROXYAUTH is defined and valued at 111 it
+            // fails the test. Eclipse hover over the CURLOPT_PROXYAUTH symbol shows: "CINIT(PROXYAUTH, LONG, 111)",
+            // for what that's worth
+
+            // According to http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYAUTH
+            // As of 4/21/08 only NTLM, Digest and Basic work.
+
+            res = curl_easy_setopt(ceh, CURLOPT_PROXYAUTH, proxyAuthType);
+            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_PROXYAUTH", error_buffer, __FILE__, __LINE__);
+            BESDEBUG(MODULE, prolog << "Using CURLOPT_PROXYAUTH = " << getCurlAuthTypeName(proxyAuthType) << endl);
+
+            if (!proxyUser.empty()) {
+                res = curl_easy_setopt(ceh, CURLOPT_PROXYUSERNAME, proxyUser.data());
+                eval_curl_easy_setopt_result(res, prolog, "CURLOPT_PROXYUSERNAME", error_buffer, __FILE__, __LINE__);
+                BESDEBUG(MODULE, prolog << "CURLOPT_PROXYUSERNAME : " << proxyUser << endl);
+
+                if (!proxyPassword.empty()) {
+                    res = curl_easy_setopt(ceh, CURLOPT_PROXYPASSWORD, proxyPassword.data());
+                    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_PROXYPASSWORD", error_buffer, __FILE__,
+                                                 __LINE__);
+                    BESDEBUG(MODULE, prolog << "CURLOPT_PROXYPASSWORD: " << proxyPassword << endl);
                 }
             }
-
-            if (using_proxy) {
-                CURLcode res;
-                char error_buffer[CURL_ERROR_SIZE];
-
-                BESDEBUG(MODULE, prolog << "Setting up a proxy server." << endl);
-                BESDEBUG(MODULE, prolog << "Proxy host: " << proxyHost << endl);
-                BESDEBUG(MODULE, prolog << "Proxy port: " << proxyPort << endl);
-
-                set_error_buffer(ceh,error_buffer);
-
-                res = curl_easy_setopt(ceh, CURLOPT_PROXY, proxyHost.data());
-                eval_curl_easy_setopt_result(res, prolog, "CURLOPT_PROXY", error_buffer, __FILE__, __LINE__);
-
-                res = curl_easy_setopt(ceh, CURLOPT_PROXYPORT, proxyPort);
-                eval_curl_easy_setopt_result(res, prolog, "CURLOPT_PROXYPORT", error_buffer, __FILE__, __LINE__);
-
-// #ifdef CURLOPT_PROXYAUTH
-
-                // oddly "#ifdef CURLOPT_PROXYAUTH" doesn't work - even though CURLOPT_PROXYAUTH is defined and valued at 111 it
-                // fails the test. Eclipse hover over the CURLOPT_PROXYAUTH symbol shows: "CINIT(PROXYAUTH, LONG, 111)",
-                // for what that's worth
-
-                // According to http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYAUTH As of 4/21/08 only NTLM, Digest and Basic work.
-
-
-                res = curl_easy_setopt(ceh, CURLOPT_PROXYAUTH, proxyAuthType);
-                eval_curl_easy_setopt_result(res, prolog, "CURLOPT_PROXYAUTH", error_buffer, __FILE__, __LINE__);
-                BESDEBUG(MODULE, prolog << "Using CURLOPT_PROXYAUTH = " << getCurlAuthTypeName(proxyAuthType) << endl);
-// #endif
-
-
-
-                if (!proxyUser.empty()) {
-                    res = curl_easy_setopt(ceh, CURLOPT_PROXYUSERNAME, proxyUser.data());
-                    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_PROXYUSERNAME", error_buffer, __FILE__, __LINE__);
-                    BESDEBUG(MODULE,  prolog << "CURLOPT_PROXYUSERNAME : " << proxyUser << endl);
-
-                    if (!proxyPassword.empty()) {
-                        res = curl_easy_setopt(ceh, CURLOPT_PROXYPASSWORD, proxyPassword.data());
-                        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_PROXYPASSWORD", error_buffer, __FILE__,
-                                                     __LINE__);
-                        BESDEBUG(MODULE, prolog << "CURLOPT_PROXYPASSWORD: " << proxyPassword << endl);
-                    }
-                } else if (!proxyUserPW.empty()) {
-                    res = curl_easy_setopt(ceh, CURLOPT_PROXYUSERPWD, proxyUserPW.data());
-                    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_PROXYUSERPWD", error_buffer, __FILE__, __LINE__);
-                    BESDEBUG(MODULE, prolog << "CURLOPT_PROXYUSERPWD : " << proxyUserPW << endl);
-                }
-                unset_error_buffer(ceh);
+            else if (!proxyUserPW.empty()) {
+                res = curl_easy_setopt(ceh, CURLOPT_PROXYUSERPWD, proxyUserPW.data());
+                eval_curl_easy_setopt_result(res, prolog, "CURLOPT_PROXYUSERPWD", error_buffer, __FILE__, __LINE__);
+                BESDEBUG(MODULE, prolog << "CURLOPT_PROXYUSERPWD : " << proxyUserPW << endl);
             }
+            unset_error_buffer(ceh);
         }
-        BESDEBUG(MODULE,  prolog << "END." << endl);
+    }
+    BESDEBUG(MODULE, prolog << "END." << endl);
 
-        return using_proxy;
+    return using_proxy;
+}
+
+CURL *init(const string &target_url,
+           const struct curl_slist *http_request_headers,
+           vector<string> *http_response_hdrs) {
+    CURL *swanky_new_curl_easy_handle = curl_easy_init();
+    return init(swanky_new_curl_easy_handle, target_url, http_request_headers, http_response_hdrs);
+}
+
+/**
+ * Get's a new instance of a cURL easy handle (CURL*) and performs
+ * a basic configuration of that instance.
+ *  - Accept compressed responses
+ *  - Any authentication type
+ *  - Follow redirects
+ *  - User agent set to value of hyrax_user_agent().
+ *
+ *
+ * @param target_url
+ * @param http_request_headers
+ * @param http_response_hdrs
+ * @return
+ */
+CURL *init(CURL *ceh,
+           const string &target_url,
+           const struct curl_slist *http_request_headers,
+           vector<string> *http_response_hdrs
+) {
+    char error_buffer[CURL_ERROR_SIZE];
+    error_buffer[0] = 0; // Null terminate this string for safety.
+    CURLcode res;
+
+    if (!ceh)
+        throw BESInternalError("Could not initialize cURL easy handle.", __FILE__, __LINE__);
+
+    // SET Error Buffer (for use during this setup) ----------------------------------------------------------------
+    set_error_buffer(ceh, error_buffer);
+
+    // Target URL --------------------------------------------------------------------------------------------------
+    res = curl_easy_setopt(ceh, CURLOPT_URL, target_url.c_str());
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_URL", error_buffer, __FILE__, __LINE__);
+
+    // Load in the default headers to send with a request. The empty Pragma
+    // headers overrides libcurl's default Pragma: no-cache header (which
+    // will disable caching by Squid, etc.).
+    // the empty Pragma never appears in the outgoing headers when this isn't present
+    // d_request_headers->push_back(string("Pragma: no-cache"));
+    // d_request_headers->push_back(string("Cache-Control: no-cache"));
+
+    //TODO Do we need this test? what if the pointer is null? Probably it's fine...
+    if (http_request_headers) {
+        // Add the http_request_headers to the cURL handle.
+        res = curl_easy_setopt(ceh, CURLOPT_HTTPHEADER, http_request_headers);
+        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_HTTPHEADER", error_buffer, __FILE__, __LINE__);
     }
 
-    CURL *init(const string &target_url,
-               const struct curl_slist *http_request_headers,
-               vector<string> *http_response_hdrs )
-    {
-        CURL *swanky_new_curl_easy_handle = curl_easy_init();
-        return init(swanky_new_curl_easy_handle, target_url, http_request_headers, http_response_hdrs);
+
+    if (http_response_hdrs) {
+        res = curl_easy_setopt(ceh, CURLOPT_HEADERFUNCTION, save_http_response_headers);
+        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_HEADERFUNCTION", error_buffer, __FILE__, __LINE__);
+
+        // Pass save_http_response_headers() a pointer to the vector<string> where the
+        // response headers may be stored. Callers can use the resp_hdrs
+        // value/result parameter to get the raw response header information .
+        res = curl_easy_setopt(ceh, CURLOPT_WRITEHEADER, http_response_hdrs);
+        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEHEADER", error_buffer, __FILE__, __LINE__);
     }
 
-     /**
-      * Get's a new instance of a cURL easy handle (CURL*) and performs
-      * a basic configuration of that instance.
-      *  - Accept compressed responses
-      *  - Any authentication type
-      *  - Follow redirects
-      *  - User agent set to value of hyrax_user_agent().
-      *
-      *
-      * @param target_url
-      * @param http_request_headers
-      * @param http_response_hdrs
-      * @return
-      */
-    CURL *init(CURL *ceh,
-               const string &target_url,
-               const struct curl_slist *http_request_headers,
-               vector<string> *http_response_hdrs
-        )
-        {
-        char error_buffer[CURL_ERROR_SIZE];
-        error_buffer[0]=0; // Null terminate this string for safety.
-        CURLcode res;
-
-        if (!ceh)
-            throw BESInternalError("Could not initialize cURL easy handle.",__FILE__, __LINE__);
-
-        // SET Error Buffer (for use during this setup) ----------------------------------------------------------------
-        set_error_buffer(ceh,error_buffer);
-
-        // Target URL --------------------------------------------------------------------------------------------------
-        res = curl_easy_setopt(ceh, CURLOPT_URL, target_url.c_str());
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_URL", error_buffer, __FILE__, __LINE__);
-
-        // Load in the default headers to send with a request. The empty Pragma
-        // headers overrides libcurl's default Pragma: no-cache header (which
-        // will disable caching by Squid, etc.).
-        // the empty Pragma never appears in the outgoing headers when this isn't present
-        // d_request_headers->push_back(string("Pragma: no-cache"));
-        // d_request_headers->push_back(string("Cache-Control: no-cache"));
-
-        //TODO Do we need this test? what if the pointer is null? Probably it's fine...
-        if(http_request_headers){
-            // Add the http_request_headers to the cURL handle.
-            res = curl_easy_setopt(ceh, CURLOPT_HTTPHEADER, http_request_headers);
-            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_HTTPHEADER", error_buffer, __FILE__, __LINE__);
-        }
-
-
-        if(http_response_hdrs){
-            res = curl_easy_setopt(ceh, CURLOPT_HEADERFUNCTION, save_http_response_headers);
-            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_HEADERFUNCTION", error_buffer, __FILE__, __LINE__);
-
-            // Pass save_http_response_headers() a pointer to the vector<string> where the
-            // response headers may be stored. Callers can use the resp_hdrs
-            // value/result parameter to get the raw response header information .
-            res = curl_easy_setopt(ceh, CURLOPT_WRITEHEADER, http_response_hdrs);
-            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEHEADER", error_buffer, __FILE__, __LINE__);
-        }
-
-        // Allow compressed responses. Sending an empty string enables all supported compression types.
+    // Allow compressed responses. Sending an empty string enables all supported compression types.
 #ifndef CURLOPT_ACCEPT_ENCODING
-        res = curl_easy_setopt(ceh, CURLOPT_ENCODING, "");
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_ENCODING", error_buffer, __FILE__, __LINE__);
+    res = curl_easy_setopt(ceh, CURLOPT_ENCODING, "");
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_ENCODING", error_buffer, __FILE__, __LINE__);
 #else
-        res = curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
-        check_setopt_result(res, prolog, "CURLOPT_ACCEPT_ENCODING", error_buffer, __FILE__,__LINE__);
+    res = curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+    check_setopt_result(res, prolog, "CURLOPT_ACCEPT_ENCODING", error_buffer, __FILE__,__LINE__);
 #endif
-        // Disable Progress Meter
-        res = curl_easy_setopt(ceh, CURLOPT_NOPROGRESS, 1L);
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_NOPROGRESS", error_buffer, __FILE__, __LINE__);
+    // Disable Progress Meter
+    res = curl_easy_setopt(ceh, CURLOPT_NOPROGRESS, 1L);
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_NOPROGRESS", error_buffer, __FILE__, __LINE__);
 
-        // Disable cURL signal handling
-        res = curl_easy_setopt(ceh, CURLOPT_NOSIGNAL, 1L);
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_NOSIGNAL", error_buffer, __FILE__, __LINE__);
-
-
-        // -  -  -  - -  -  -  - -  -  -  - -  -  -  - -  -  -  - -  -  -  - -  -  -  -
-        // Authentication config.
-        //
-
-        // We have to set FailOnError to false for any of the non-Basic
-        // authentication schemes to work. 07/28/03 jhrg
-        res = curl_easy_setopt(ceh, CURLOPT_FAILONERROR, 0L);
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_FAILONERROR", error_buffer, __FILE__, __LINE__);
+    // Disable cURL signal handling
+    res = curl_easy_setopt(ceh, CURLOPT_NOSIGNAL, 1L);
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_NOSIGNAL", error_buffer, __FILE__, __LINE__);
 
 
-        // CURLAUTH_ANY means libcurl will use Basic, Digest, GSS Negotiate, or NTLM,
-        // choosing the the 'safest' one supported by the server.
-        // This requires curl 7.10.6 which is still in pre-release. 07/25/03 jhrg
-        res = curl_easy_setopt(ceh, CURLOPT_HTTPAUTH, (long) CURLAUTH_ANY);
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_HTTPAUTH", error_buffer, __FILE__, __LINE__);
+    // -  -  -  - -  -  -  - -  -  -  - -  -  -  - -  -  -  - -  -  -  - -  -  -  -
+    // Authentication config.
+    //
+
+    // We have to set FailOnError to false for any of the non-Basic
+    // authentication schemes to work. 07/28/03 jhrg
+    res = curl_easy_setopt(ceh, CURLOPT_FAILONERROR, 0L);
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_FAILONERROR", error_buffer, __FILE__, __LINE__);
 
 
-        // CURLOPT_NETRC means to use the netrc file for credentials.
-        // CURL_NETRC_OPTIONAL Means that if the supplied URL contains a username
-        // and password to prefer that to using the content of the netrc file.
-        res = curl_easy_setopt(ceh, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_NETRC", error_buffer, __FILE__, __LINE__);
-
-        // If the configuration specifies a particular .netrc credentials file, use it.
-        string netrc_file = get_netrc_filename();
-        if (!netrc_file.empty()) {
-            res = curl_easy_setopt(ceh, CURLOPT_NETRC_FILE, netrc_file.c_str());
-            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_NETRC_FILE", error_buffer, __FILE__, __LINE__);
-
-        }
-        VERBOSE(prolog << " is using the netrc file '"
-                         << ((!netrc_file.empty()) ? netrc_file : "~/.netrc") << "'" << endl);
+    // CURLAUTH_ANY means libcurl will use Basic, Digest, GSS Negotiate, or NTLM,
+    // choosing the the 'safest' one supported by the server.
+    // This requires curl 7.10.6 which is still in pre-release. 07/25/03 jhrg
+    res = curl_easy_setopt(ceh, CURLOPT_HTTPAUTH, (long) CURLAUTH_ANY);
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_HTTPAUTH", error_buffer, __FILE__, __LINE__);
 
 
-        // -  -  -  - -  -  -  - -  -  -  - -  -  -  - -  -  -  - -  -  -  - -  -  -  -
-        // Cookies
-        //
-        res = curl_easy_setopt(ceh, CURLOPT_COOKIEFILE, curl::get_cookie_filename().c_str());
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_COOKIEFILE", error_buffer, __FILE__, __LINE__);
+    // CURLOPT_NETRC means to use the netrc file for credentials.
+    // CURL_NETRC_OPTIONAL Means that if the supplied URL contains a username
+    // and password to prefer that to using the content of the netrc file.
+    res = curl_easy_setopt(ceh, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_NETRC", error_buffer, __FILE__, __LINE__);
 
-        res = curl_easy_setopt(ceh, CURLOPT_COOKIEJAR, curl::get_cookie_filename().c_str());
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_COOKIEJAR", error_buffer, __FILE__, __LINE__);
+    // If the configuration specifies a particular .netrc credentials file, use it.
+    string netrc_file = get_netrc_filename();
+    if (!netrc_file.empty()) {
+        res = curl_easy_setopt(ceh, CURLOPT_NETRC_FILE, netrc_file.c_str());
+        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_NETRC_FILE", error_buffer, __FILE__, __LINE__);
 
-        // save_http_response_headers
+    }
+    VERBOSE(prolog << " is using the netrc file '"
+                   << ((!netrc_file.empty()) ? netrc_file : "~/.netrc") << "'" << endl);
 
 
-        // Follow 302 (redirect) responses
-        res = curl_easy_setopt(ceh, CURLOPT_FOLLOWLOCATION, 1L);
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_FOLLOWLOCATION", error_buffer, __FILE__, __LINE__);
+    // -  -  -  - -  -  -  - -  -  -  - -  -  -  - -  -  -  - -  -  -  - -  -  -  -
+    // Cookies
+    //
+    res = curl_easy_setopt(ceh, CURLOPT_COOKIEFILE, curl::get_cookie_filename().c_str());
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_COOKIEFILE", error_buffer, __FILE__, __LINE__);
 
-        res = curl_easy_setopt(ceh, CURLOPT_MAXREDIRS, max_redirects());
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_MAXREDIRS", error_buffer, __FILE__, __LINE__);
+    res = curl_easy_setopt(ceh, CURLOPT_COOKIEJAR, curl::get_cookie_filename().c_str());
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_COOKIEJAR", error_buffer, __FILE__, __LINE__);
 
-        // Set the user agent to Hyrax's user agent value
-        res = curl_easy_setopt(ceh, CURLOPT_USERAGENT,  hyrax_user_agent().c_str() );
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_USERAGENT", error_buffer, __FILE__, __LINE__);
+    // save_http_response_headers
+
+    // Follow 302 (redirect) responses
+    res = curl_easy_setopt(ceh, CURLOPT_FOLLOWLOCATION, 1L);
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_FOLLOWLOCATION", error_buffer, __FILE__, __LINE__);
+
+    res = curl_easy_setopt(ceh, CURLOPT_MAXREDIRS, max_redirects());
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_MAXREDIRS", error_buffer, __FILE__, __LINE__);
+
+    // Set the user agent to Hyrax's user agent value
+    res = curl_easy_setopt(ceh, CURLOPT_USERAGENT, hyrax_user_agent().c_str());
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_USERAGENT", error_buffer, __FILE__, __LINE__);
 
 #if 0
-        // If the user turns off SSL validation...
-    if (!d_rcr->get_validate_ssl() == 0) {
-        res = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
-        check_setopt_result(res, prolog, "CURLOPT_SSL_VERIFYPEER", error_buffer, __FILE__, __LINE__);
-        res = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
-        check_setopt_result(res, prolog, "CURLOPT_SSL_VERIFYHOST", error_buffer, __FILE__, __LINE__);
-    }
+    // If the user turns off SSL validation...
+if (!d_rcr->get_validate_ssl() == 0) {
+    res = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+    check_setopt_result(res, prolog, "CURLOPT_SSL_VERIFYPEER", error_buffer, __FILE__, __LINE__);
+    res = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+    check_setopt_result(res, prolog, "CURLOPT_SSL_VERIFYHOST", error_buffer, __FILE__, __LINE__);
+}
 #endif
 
-        if (curl_trace) {
-            BESDEBUG(MODULE,  prolog << "Curl version: " << curl_version() << endl);
-            res = curl_easy_setopt(ceh, CURLOPT_VERBOSE, 1L);
-            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_VERBOSE", error_buffer, __FILE__, __LINE__);
-            BESDEBUG(MODULE,  prolog << "Curl in verbose mode." << endl);
+    if (curl_trace) {
+        BESDEBUG(MODULE, prolog << "Curl version: " << curl_version() << endl);
+        res = curl_easy_setopt(ceh, CURLOPT_VERBOSE, 1L);
+        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_VERBOSE", error_buffer, __FILE__, __LINE__);
+        BESDEBUG(MODULE, prolog << "Curl in verbose mode." << endl);
 
-            res = curl_easy_setopt(ceh, CURLOPT_DEBUGFUNCTION, curl_debug);
-            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_DEBUGFUNCTION", error_buffer, __FILE__, __LINE__);
-            BESDEBUG(MODULE,  prolog << "Curl debugging function installed." << endl);
-        }
-
-        // We unset the error buffer here because we know that curl::configure_curl_handle_for_proxy() will use it's own.
-        unset_error_buffer(ceh);
-        // Configure the a proxy for this url (if appropriate).
-         curl::configure_curl_handle_for_proxy(ceh, target_url);
-
-        BESDEBUG(MODULE,  prolog << "curl: " << (void *) ceh << endl);
-        return ceh;
+        res = curl_easy_setopt(ceh, CURLOPT_DEBUGFUNCTION, curl_debug);
+        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_DEBUGFUNCTION", error_buffer, __FILE__, __LINE__);
+        BESDEBUG(MODULE, prolog << "Curl debugging function installed." << endl);
     }
 
-    string get_range_arg_string(const unsigned long long &offset, const unsigned long long &size)
-    {
-        ostringstream range;   // range-get needs a string arg for the range
-        range << offset << "-" << offset + size - 1;
-        BESDEBUG(MODULE,  prolog << " range: " << range.str() << endl);
-        return range.str();
+    // We unset the error buffer here because we know that curl::configure_curl_handle_for_proxy() will use it's own.
+    unset_error_buffer(ceh);
+    // Configure the a proxy for this url (if appropriate).
+    curl::configure_curl_handle_for_proxy(ceh, target_url);
+
+    BESDEBUG(MODULE, prolog << "curl: " << (void *) ceh << endl);
+    return ceh;
+}
+
+string get_range_arg_string(const unsigned long long &offset, const unsigned long long &size) {
+    ostringstream range;   // range-get needs a string arg for the range
+    range << offset << "-" << offset + size - 1;
+    BESDEBUG(MODULE, prolog << " range: " << range.str() << endl);
+    return range.str();
+}
+
+/**
+ * @brief Returns an cURL easy handle for tracing redirects.
+ *
+ * The returned cURL easy handle is configured to make a 4 byte
+ * range get from the url. When theis cURL handle is "exercised"
+ * at the end the cURL handles CURLINFO_EFFECTIVE_URL value will
+ * be the place from which the 4 bytes were retrieved, the
+ * terminus if the redirect sequence.
+ * @param target_url The URL to target
+ * @param req_headers A curl_slist containing any necessary request headers
+ * to be transmitted with the HTTP request.
+ * @param resp_hdrs A vector into which any response headeres associated
+ * the servers response will be placed.
+ * @return A cURL easy handle configured as described above,
+ */
+CURL *init_effective_url_retriever_handle(const string &target_url, struct curl_slist *req_headers,
+                                          vector<string> &resp_hdrs) {
+    char error_buffer[CURL_ERROR_SIZE];
+    CURLcode res;
+    CURL *ceh = 0;
+
+    error_buffer[0] = 0; // null terminate empty string
+
+    ceh = curl::init(target_url, req_headers, &resp_hdrs);
+
+    set_error_buffer(ceh, error_buffer);
+
+    // get the offset to offset + size bytes
+    res = curl_easy_setopt(ceh, CURLOPT_RANGE, get_range_arg_string(0, 4).c_str());
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_RANGE", error_buffer, __FILE__, __LINE__);
+
+    res = curl_easy_setopt(ceh, CURLOPT_WRITEFUNCTION, writeNothing);
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEFUNCTION", error_buffer, __FILE__, __LINE__);
+
+    // Pass save_raw_http_headers() a pointer to the vector<string> where the
+    // response headers may be stored. Callers can use the resp_hdrs
+    // value/result parameter to get the raw response header information .
+    res = curl_easy_setopt(ceh, CURLOPT_WRITEHEADER, &resp_hdrs);
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEHEADER", error_buffer, __FILE__, __LINE__);
+
+    unset_error_buffer(ceh);
+
+    return ceh;
+}
+
+/**
+ *
+ * Use libcurl to dereference a URL. Read the information referenced by
+ * url into the file pointed to by the open file descriptor fd.
+ *
+ * @param target_url The URL to dereference.
+ * @param fd  An open file descriptor (as in 'open' as opposed to 'fopen') which
+ * will be the destination for the data; the caller can assume that when this
+ * method returns that the body of the response can be retrieved by reading
+ * from this file descriptor.
+ * @param http_response_headers Value/result parameter for the HTTP Response Headers.
+ * @param http_request_headers A pointer to a vector of HTTP request headers. Default is
+ * null. These headers will be appended to the list of default headers.
+ * @return The HTTP status code.
+ * @exception Error Thrown if libcurl encounters a problem; the libcurl
+ * error message is stuffed into the Error object.
+ */
+void http_get_and_write_resource(const string &target_url,
+                                 const int fd,
+                                 vector<string> *http_response_headers) {
+
+    char error_buffer[CURL_ERROR_SIZE];
+    CURLcode res;
+    CURL *ceh = NULL;
+    curl_slist *req_headers = NULL;
+    BuildHeaders header_builder;
+
+    BESDEBUG(MODULE, prolog << "BEGIN" << endl);
+    // Before we do anything, make sure that the URL is OK to pursue.
+    if (!bes::AllowedHosts::theHosts()->is_allowed(target_url)) {
+        string err = (string) "The specified URL " + target_url
+                     + " does not match any of the accessible services in"
+                     + " the allowed hosts list.";
+        BESDEBUG(MODULE, prolog << err << endl);
+        throw BESSyntaxUserError(err, __FILE__, __LINE__);
     }
 
+    // Add the authorization headers
+    req_headers = add_auth_headers(req_headers);
 
-    /**
-     * @brief Returns an cURL easy handle for tracing redirects.
-     *
-     * The returned cURL easy handle is configured to make a 4 byte
-     * range get from the url. When theis cURL handle is "exercised"
-     * at the end the cURL handles CURLINFO_EFFECTIVE_URL value will
-     * be the place from which the 4 bytes were retrieved, the
-     * terminus if the redirect sequence.
-     * @param target_url The URL to target
-     * @param req_headers A curl_slist containing any necessary request headers
-     * to be transmitted with the HTTP request.
-     * @param resp_hdrs A vector into which any response headeres associated
-     * the servers response will be placed.
-     * @return A cURL easy handle configured as described above,
-     */
-    CURL *init_effective_url_retriever_handle(const string &target_url, struct curl_slist *req_headers, vector<string> &resp_hdrs)
-    {
-        char error_buffer[CURL_ERROR_SIZE];
-        CURLcode res;
-        CURL *ceh = 0;
-
-        error_buffer[0]=0; // null terminate empty string
-
-        ceh = curl::init(target_url, req_headers, &resp_hdrs);
+    try {
+        // OK! Make the cURL handle
+        ceh = init(target_url, req_headers, http_response_headers);
 
         set_error_buffer(ceh, error_buffer);
 
-        // get the offset to offset + size bytes
-        res = curl_easy_setopt(ceh, CURLOPT_RANGE, get_range_arg_string(0,4).c_str());
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_RANGE", error_buffer, __FILE__, __LINE__);
-
-        res = curl_easy_setopt(ceh, CURLOPT_WRITEFUNCTION, writeNothing);
+        res = curl_easy_setopt(ceh, CURLOPT_WRITEFUNCTION, writeToOpenfileDescriptor);
         eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEFUNCTION", error_buffer, __FILE__, __LINE__);
 
-        // Pass save_raw_http_headers() a pointer to the vector<string> where the
-        // response headers may be stored. Callers can use the resp_hdrs
-        // value/result parameter to get the raw response header information .
-        res = curl_easy_setopt(ceh, CURLOPT_WRITEHEADER, &resp_hdrs);
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEHEADER", error_buffer, __FILE__, __LINE__);
+#ifdef CURLOPT_WRITEDATA
+        res = curl_easy_setopt(ceh, CURLOPT_WRITEDATA, &fd);
+        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEDATA", error_buffer, __FILE__, __LINE__);
+#else
+        res = curl_easy_setopt(ceh, CURLOPT_FILE, &fd);
+        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_FILE", error_buffer, __FILE__, __LINE__);
+#endif
+        unset_error_buffer(ceh);
+
+        super_easy_perform(ceh);
+
+        // Free the header list
+        if (req_headers)
+            curl_slist_free_all(req_headers);
+        if (ceh)
+            curl_easy_cleanup(ceh);
+        BESDEBUG(MODULE, prolog << "Called curl_easy_cleanup()." << endl);
+    }
+    catch (...) {
+        if (req_headers)
+            curl_slist_free_all(req_headers);
+        if (ceh)
+            curl_easy_cleanup(ceh);
+        throw;
+    }
+    BESDEBUG(MODULE, prolog << "END" << endl);
+}
+
+/**
+ * Returns a cURL error message string based on the conents of the error_buf or, if the error_buf is empty, the
+ * CURLcode code.
+ * @param response_code
+ * @param error_buf
+ * @return
+ */
+string error_message(const CURLcode response_code, char *error_buffer) {
+    std::ostringstream oss;
+    size_t len = strlen(error_buffer);
+    if (len) {
+        oss << "cURL_error_buffer: '" << error_buffer;
+    }
+    oss << "' cURL_message: '" << curl_easy_strerror(response_code);
+    oss << "' (code: " << (int) response_code << ")";
+    return oss.str();
+}
+
+/*
+* @brief Callback passed to libcurl to handle reading a single byte.
+*
+* This callback assumes that the size of the data is small enough
+* that all of the bytes will be either read at once or that a local
+        * temporary buffer can be used to build up the values.
+*
+* @param buffer Data from libcurl
+* @param size Number of bytes
+* @param nmemb Total size of data in this call is 'size * nmemb'
+* @param data Pointer to this
+* @return The number of bytes read
+*/
+size_t c_write_data(void *buffer, size_t size, size_t nmemb, void *data) {
+    size_t nbytes = size * nmemb;
+    //cerr << "ngap_write_data() bytes: " << nbytes << "  size: " << size << "  nmemb: " << nmemb << " buffer: " << buffer << "  data: " << data << endl;
+    memcpy(data, buffer, nbytes);
+    return nbytes;
+}
+
+/**
+ * @brief http_get_as_string() This function de-references the target_url and returns the response document as a std:string.
+ *
+ * @param target_url The URL to dereference.
+ * @return JSON document parsed from the response document returned by target_url
+ */
+std::string http_get_as_string(const std::string &target_url) {
+
+    // @TODO @FIXME Make the size of this buffer one of:
+    //              a) A configuration setting.
+    //              b) A new parameter to the function. (unsigned long)
+    //              c) Do a HEAD on the URL, check for the Content-Length header and plan accordingly.
+    //
+    char response_buf[1024 * 1024];
+
+    http_get(target_url, response_buf);
+    string response(response_buf);
+    return response;
+}
+
+/**
+ * @brief http_get_as_json() This function de-references the target_url and parses the response into a JSON document.
+ * No attempt to cache is performed, the HTTP request is made for each invocation of this method.
+ *
+ * @param target_url The URL to dereference.
+ * @return JSON document parsed from the response document returned by target_url
+ */
+rapidjson::Document http_get_as_json(const std::string &target_url) {
+
+    // @TODO @FIXME Make the size of this buffer one of:
+    //              a) A configuration setting.
+    //              b) A new parameter to the function. (unsigned long)
+    //              c) Do a HEAD on the URL, check for the Content-Length header and plan accordingly.
+    //
+
+    char response_buf[1024 * 1024];
+
+    curl::http_get(target_url, response_buf);
+    rapidjson::Document d;
+    d.Parse(response_buf);
+    return d;
+}
+
+/**
+ * Derefernce the target URL and put the response in response_buf
+ * @param target_url The URL to dereference.
+ * @param response_buf The buffer into which to put the response.
+ */
+void http_get(const std::string &target_url, char *response_buf) {
+
+    char errbuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
+    CURL *ceh = NULL;     ///< The libcurl handle object.
+    CURLcode res;
+
+    curl_slist *request_headers = NULL;
+    // Add the authorization headers
+    request_headers = add_auth_headers(request_headers);
+
+    try {
+
+        ceh = curl::init(target_url, request_headers, NULL);
+        if (!ceh)
+            throw BESInternalError(string("ERROR! Failed to acquire cURL Easy Handle! "), __FILE__, __LINE__);
+
+        // Error Buffer (for use during this setup) ----------------------------------------------------------------
+        set_error_buffer(ceh, errbuf);
+
+        // Pass all data to the 'write_data' function --------------------------------------------------------------
+        res = curl_easy_setopt(ceh, CURLOPT_WRITEFUNCTION, c_write_data);
+        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEFUNCTION", errbuf, __FILE__, __LINE__);
+
+        // Pass this to write_data as the fourth argument ----------------------------------------------------------
+        res = curl_easy_setopt(ceh, CURLOPT_WRITEDATA, reinterpret_cast<void *>(response_buf));
+        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEDATA", errbuf, __FILE__, __LINE__);
 
         unset_error_buffer(ceh);
 
-        return ceh;
+        super_easy_perform(ceh);
+
+        if (request_headers)
+            curl_slist_free_all(request_headers);
+        if (ceh)
+            curl_easy_cleanup(ceh);
     }
-
-
-    /**
-     *
-     * Use libcurl to dereference a URL. Read the information referenced by
-     * url into the file pointed to by the open file descriptor fd.
-     *
-     * @param target_url The URL to dereference.
-     * @param fd  An open file descriptor (as in 'open' as opposed to 'fopen') which
-     * will be the destination for the data; the caller can assume that when this
-     * method returns that the body of the response can be retrieved by reading
-     * from this file descriptor.
-     * @param http_response_headers Value/result parameter for the HTTP Response Headers.
-     * @param http_request_headers A pointer to a vector of HTTP request headers. Default is
-     * null. These headers will be appended to the list of default headers.
-     * @return The HTTP status code.
-     * @exception Error Thrown if libcurl encounters a problem; the libcurl
-     * error message is stuffed into the Error object.
-     */
-    void http_get_and_write_resource(const string &target_url,
-                                     const int fd,
-                                     vector<string> *http_response_headers) {
-
-        char error_buffer[CURL_ERROR_SIZE];
-        CURLcode res;
-        CURL *ceh = NULL;
-        curl_slist *req_headers = NULL;
-        BuildHeaders header_builder;
-
-        BESDEBUG(MODULE, prolog << "BEGIN" << endl);
-        // Before we do anything, make sure that the URL is OK to pursue.
-        if (!bes::AllowedHosts::theHosts()->is_allowed(target_url)) {
-            string err = (string) "The specified URL " + target_url
-                         + " does not match any of the accessible services in"
-                         + " the allowed hosts list.";
-            BESDEBUG(MODULE, prolog << err << endl);
-            throw BESSyntaxUserError(err, __FILE__, __LINE__);
-        }
-
-        // Add the authorization headers
-        req_headers = add_auth_headers(req_headers);
-
-        try {
-            // OK! Make the cURL handle
-            ceh = init(target_url, req_headers, http_response_headers);
-
-            set_error_buffer(ceh,error_buffer);
-
-            res = curl_easy_setopt(ceh, CURLOPT_WRITEFUNCTION, writeToOpenfileDescriptor);
-            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEFUNCTION", error_buffer, __FILE__, __LINE__);
-
-#ifdef CURLOPT_WRITEDATA
-            res = curl_easy_setopt(ceh, CURLOPT_WRITEDATA, &fd);
-            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEDATA", error_buffer, __FILE__, __LINE__);
-#else
-            res = curl_easy_setopt(ceh, CURLOPT_FILE, &fd);
-            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_FILE", error_buffer, __FILE__, __LINE__);
-#endif
-            unset_error_buffer(ceh);
-
-            super_easy_perform(ceh);
-
-            // Free the header list
-            if(req_headers)
-                curl_slist_free_all(req_headers);
-            if(ceh)
-                curl_easy_cleanup(ceh);
-            BESDEBUG(MODULE, prolog << "Called curl_easy_cleanup()." << endl);
-        }
-        catch(...){
-            if(req_headers)
-                curl_slist_free_all(req_headers);
-            if(ceh)
-                curl_easy_cleanup(ceh);
-            throw;
-        }
-        BESDEBUG(MODULE, prolog << "END" << endl);
+    catch (...) {
+        if (request_headers)
+            curl_slist_free_all(request_headers);
+        if (ceh)
+            curl_easy_cleanup(ceh);
     }
-
-    /**
-     * Returns a cURL error message string based on the conents of the error_buf or, if the error_buf is empty, the
-     * CURLcode code.
-     * @param response_code
-     * @param error_buf
-     * @return
-     */
-    string error_message(const CURLcode response_code, char *error_buffer) {
-        std::ostringstream oss;
-        size_t len = strlen(error_buffer);
-        if (len) {
-            oss << "cURL_error_buffer: '" << error_buffer;
-        }
-        oss << "' cURL_message: '" << curl_easy_strerror(response_code);
-        oss << "' (code: " << (int) response_code << ")";
-        return oss.str();
-    }
-
-    /*
-    * @brief Callback passed to libcurl to handle reading a single byte.
-    *
-    * This callback assumes that the size of the data is small enough
-    * that all of the bytes will be either read at once or that a local
-            * temporary buffer can be used to build up the values.
-    *
-    * @param buffer Data from libcurl
-    * @param size Number of bytes
-    * @param nmemb Total size of data in this call is 'size * nmemb'
-    * @param data Pointer to this
-    * @return The number of bytes read
-    */
-    size_t c_write_data(void *buffer, size_t size, size_t nmemb, void *data) {
-        size_t nbytes = size * nmemb;
-        //cerr << "ngap_write_data() bytes: " << nbytes << "  size: " << size << "  nmemb: " << nmemb << " buffer: " << buffer << "  data: " << data << endl;
-        memcpy(data, buffer, nbytes);
-        return nbytes;
-    }
-
-    /**
-     * @brief http_get_as_string() This function de-references the target_url and returns the response document as a std:string.
-     *
-     * @param target_url The URL to dereference.
-     * @return JSON document parsed from the response document returned by target_url
-     */
-    std::string http_get_as_string(const std::string &target_url){
-
-        // @TODO @FIXME Make the size of this buffer one of:
-        //              a) A configuration setting.
-        //              b) A new parameter to the function. (unsigned long)
-        //              c) Do a HEAD on the URL, check for the Content-Length header and plan accordingly.
-        //
-        char response_buf[1024 * 1024];
-
-        http_get(target_url, response_buf);
-        string response(response_buf);
-        return response;
-    }
-
-    /**
-     * @brief http_get_as_json() This function de-references the target_url and parses the response into a JSON document.
-     * No attempt to cache is performed, the HTTP request is made for each invocation of this method.
-     *
-     * @param target_url The URL to dereference.
-     * @return JSON document parsed from the response document returned by target_url
-     */
-    rapidjson::Document http_get_as_json(const std::string &target_url){
-
-        // @TODO @FIXME Make the size of this buffer one of:
-        //              a) A configuration setting.
-        //              b) A new parameter to the function. (unsigned long)
-        //              c) Do a HEAD on the URL, check for the Content-Length header and plan accordingly.
-        //
-
-        char response_buf[1024 * 1024];
-
-        curl::http_get(target_url, response_buf);
-        rapidjson::Document d;
-        d.Parse(response_buf);
-        return d;
-    }
-
-    /**
-     * Derefernce the target URL and put the response in response_buf
-     * @param target_url The URL to dereference.
-     * @param response_buf The buffer into which to put the response.
-     */
-    void http_get(const std::string &target_url, char *response_buf) {
-
-        char errbuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
-        CURL *ceh=NULL;     ///< The libcurl handle object.
-        CURLcode res;
-
-        curl_slist *request_headers=NULL;
-        // Add the authorization headers
-        request_headers = add_auth_headers(request_headers);
-
-        try {
-
-            ceh = curl::init(target_url, request_headers, NULL);
-            if (!ceh)
-                throw BESInternalError(string("ERROR! Failed to acquire cURL Easy Handle! "), __FILE__, __LINE__);
-
-            // Error Buffer (for use during this setup) ----------------------------------------------------------------
-            set_error_buffer(ceh, errbuf);
-
-            // Pass all data to the 'write_data' function --------------------------------------------------------------
-            res = curl_easy_setopt(ceh, CURLOPT_WRITEFUNCTION, c_write_data);
-            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEFUNCTION", errbuf, __FILE__, __LINE__);
-
-            // Pass this to write_data as the fourth argument ----------------------------------------------------------
-            res = curl_easy_setopt(ceh, CURLOPT_WRITEDATA, reinterpret_cast<void *>(response_buf));
-            eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEDATA", errbuf, __FILE__, __LINE__);
-
-            unset_error_buffer(ceh);
-
-            super_easy_perform(ceh);
-
-            if(request_headers)
-                curl_slist_free_all(request_headers);
-            if(ceh)
-                curl_easy_cleanup(ceh);
-        }
-        catch(...){
-            if(request_headers)
-                curl_slist_free_all(request_headers);
-            if(ceh)
-                curl_easy_cleanup(ceh);
-        }
-    }
+}
 
 #if 0
-    /**
-     *
-     * @param target_url
-     * @param cookies_file
-     * @param response_buff
-     * @return
-     */
-    CURL *set_up_easy_handle(const string &target_url, struct curl_slist *request_headers, char *response_buff) {
-        char errbuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
-        CURL *d_handle;     ///< The libcurl handle object.
-        CURLcode res;
+/**
+ *
+ * @param target_url
+ * @param cookies_file
+ * @param response_buff
+ * @return
+ */
+CURL *set_up_easy_handle(const string &target_url, struct curl_slist *request_headers, char *response_buff) {
+    char errbuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
+    CURL *d_handle;     ///< The libcurl handle object.
+    CURLcode res;
 
-        d_handle = curl::init(target_url,request_headers,NULL);
-        if (!d_handle)
-            throw BESInternalError(string("ERROR! Failed to acquire cURL Easy Handle! "), __FILE__, __LINE__);
+    d_handle = curl::init(target_url,request_headers,NULL);
+    if (!d_handle)
+        throw BESInternalError(string("ERROR! Failed to acquire cURL Easy Handle! "), __FILE__, __LINE__);
 
-        // Error Buffer (for use during this setup) --------------------------------------------------------------------
-        set_error_buffer(d_handle,errbuf);
+    // Error Buffer (for use during this setup) --------------------------------------------------------------------
+    set_error_buffer(d_handle,errbuf);
 
-        // Pass all data to the 'write_data' function ------------------------------------------------------------------
-        res = curl_easy_setopt(d_handle, CURLOPT_WRITEFUNCTION, c_write_data);
-        check_setopt_result(res, prolog, "CURLOPT_WRITEFUNCTION", errbuf, __FILE__, __LINE__);
+    // Pass all data to the 'write_data' function ------------------------------------------------------------------
+    res = curl_easy_setopt(d_handle, CURLOPT_WRITEFUNCTION, c_write_data);
+    check_setopt_result(res, prolog, "CURLOPT_WRITEFUNCTION", errbuf, __FILE__, __LINE__);
 
-        // Pass this to write_data as the fourth argument --------------------------------------------------------------
-        res = curl_easy_setopt(d_handle, CURLOPT_WRITEDATA, reinterpret_cast<void *>(response_buff));
-        check_setopt_result(res, prolog, "CURLOPT_WRITEDATA", errbuf, __FILE__, __LINE__);
+    // Pass this to write_data as the fourth argument --------------------------------------------------------------
+    res = curl_easy_setopt(d_handle, CURLOPT_WRITEDATA, reinterpret_cast<void *>(response_buff));
+    check_setopt_result(res, prolog, "CURLOPT_WRITEDATA", errbuf, __FILE__, __LINE__);
 
 #if 0
-        // handled by curl::init() - SBL 9.10.20
-        // Follow redirects --------------------------------------------------------------------------------------------
-        res = curl_easy_setopt(d_handle, CURLOPT_FOLLOWLOCATION, 1L);
-        check_setopt_result(res, prolog, "CURLOPT_FOLLOWLOCATION", errbuf, __FILE__, __LINE__);
+    // handled by curl::init() - SBL 9.10.20
+    // Follow redirects --------------------------------------------------------------------------------------------
+    res = curl_easy_setopt(d_handle, CURLOPT_FOLLOWLOCATION, 1L);
+    check_setopt_result(res, prolog, "CURLOPT_FOLLOWLOCATION", errbuf, __FILE__, __LINE__);
 
-        // Use cookies -------------------------------------------------------------------------------------------------
-        res = curl_easy_setopt(d_handle, CURLOPT_COOKIEFILE, cookies_file.c_str());
-        check_setopt_result(res, prolog, "CURLOPT_COOKIEFILE", errbuf, __FILE__, __LINE__);
+    // Use cookies -------------------------------------------------------------------------------------------------
+    res = curl_easy_setopt(d_handle, CURLOPT_COOKIEFILE, cookies_file.c_str());
+    check_setopt_result(res, prolog, "CURLOPT_COOKIEFILE", errbuf, __FILE__, __LINE__);
 
-        res = curl_easy_setopt(d_handle, CURLOPT_COOKIEJAR, cookies_file.c_str());
-        check_setopt_result(res, prolog, "CURLOPT_COOKIEJAR", errbuf, __FILE__, __LINE__);
+    res = curl_easy_setopt(d_handle, CURLOPT_COOKIEJAR, cookies_file.c_str());
+    check_setopt_result(res, prolog, "CURLOPT_COOKIEJAR", errbuf, __FILE__, __LINE__);
 
-        // Authenticate using best available ---------------------------------------------------------------------------
-        res = curl_easy_setopt(d_handle, CURLOPT_HTTPAUTH, (long) CURLAUTH_ANY);
-        check_setopt_result(res, prolog, "CURLOPT_HTTPAUTH", errbuf, __FILE__, __LINE__);
+    // Authenticate using best available ---------------------------------------------------------------------------
+    res = curl_easy_setopt(d_handle, CURLOPT_HTTPAUTH, (long) CURLAUTH_ANY);
+    check_setopt_result(res, prolog, "CURLOPT_HTTPAUTH", errbuf, __FILE__, __LINE__);
 
-        // Use .netrc for credentials ----------------------------------------------------------------------------------
-        res = curl_easy_setopt(d_handle, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
-        check_setopt_result(res, prolog, "CURLOPT_NETRC", errbuf, __FILE__, __LINE__);
+    // Use .netrc for credentials ----------------------------------------------------------------------------------
+    res = curl_easy_setopt(d_handle, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
+    check_setopt_result(res, prolog, "CURLOPT_NETRC", errbuf, __FILE__, __LINE__);
 
-        // If the configuration specifies a particular .netrc credentials file, use it. --------------------------------
-        string netrc_file = get_netrc_filename();
-        if (!netrc_file.empty()) {
-            res = curl_easy_setopt(d_handle, CURLOPT_NETRC_FILE, netrc_file.c_str());
-            check_setopt_result(res, prolog, "CURLOPT_NETRC_FILE", errbuf, __FILE__, __LINE__);
+    // If the configuration specifies a particular .netrc credentials file, use it. --------------------------------
+    string netrc_file = get_netrc_filename();
+    if (!netrc_file.empty()) {
+        res = curl_easy_setopt(d_handle, CURLOPT_NETRC_FILE, netrc_file.c_str());
+        check_setopt_result(res, prolog, "CURLOPT_NETRC_FILE", errbuf, __FILE__, __LINE__);
+    }
+
+    VERBOSE(__FILE__ << "::get_easy_handle() is using the netrc file '"
+                     << ((!netrc_file.empty()) ? netrc_file : "~/.netrc") << "'" << endl);
+#endif
+
+    unset_error_buffer(d_handle);
+
+    return d_handle;
+}
+#endif
+
+/**
+ * @brief Performs a curl_easy_perform(), retrying if certain types of errors are encountered.
+ *
+ * This function contains the operational frame work and state checking for performing retries of
+ * failed requests as necessary.
+ *
+ * The code that contains the state assessment is held in the functions
+ * - curl::eval_curl_easy_perform_code()
+ * - curl::eval_http_get_response()
+ *
+ * These functions have a tri-state behavior:
+ *   - If the assessed operation was a success they return true.
+ *   - If the assessed operation had what is considered a retryable failure, they return false.
+ *   - If the assessed operation had any other failure, a BESInternalError is thrown.
+ * These functions are used in the retry logic of this curl::super_easy_perform() to
+ * determine when there was success, when to keep trying, and if to give up.
+ *
+ * @param c_handle The CURL easy handle on which to operate
+ */
+void super_easy_perform(CURL *c_handle) {
+    unsigned int attempts = 0;
+    useconds_t retry_time = uone_second / 4;
+    bool success;
+    CURLcode curl_code;
+    char curlErrorBuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
+    string target_url;
+
+    string empty_str;
+    target_url = get_effective_url(c_handle, empty_str);
+    // We check the value of target_url to see if the URL was correctly set in the cURL handle.
+    if (target_url.empty())
+        throw BESInternalError("URL acquisition failed.", __FILE__, __LINE__);
+
+    // SET Error Buffer --------------------------------------------------------------------------------------------
+    set_error_buffer(c_handle, curlErrorBuf);
+    do {
+        curlErrorBuf[0] = 0; // Initialize to empty string
+        ++attempts;
+        BESDEBUG(MODULE, prolog << "Requesting URL: " << target_url << " attempt: " << attempts << endl);
+
+        curl_code = curl_easy_perform(c_handle);
+        success = eval_curl_easy_perform_code(c_handle, target_url, curl_code, curlErrorBuf, attempts);
+        if (success) {
+            // Nothing obvious went wrong with the curl_easy_perform() so now we check the HTTP stuff
+            success = eval_http_get_response(c_handle, curlErrorBuf, target_url);
         }
-
-        VERBOSE(__FILE__ << "::get_easy_handle() is using the netrc file '"
-                         << ((!netrc_file.empty()) ? netrc_file : "~/.netrc") << "'" << endl);
-#endif
-
-        unset_error_buffer(d_handle);
-
-        return d_handle;
-    }
-#endif
-
-    /**
-     * @brief Performs a curl_easy_perform(), retrying if certain types of errors are encountered.
-     *
-     * This function contains the operational frame work and state checking for performing retries of
-     * failed requests as necessary.
-     *
-     * The code that contains the state assessment is held in the functions
-     * - curl::eval_curl_easy_perform_code()
-     * - curl::eval_http_get_response()
-     *
-     * These functions have a tri-state behavior:
-     *   - If the assessed operation was a success they return true.
-     *   - If the assessed operation had what is considered a retryable failure, they return false.
-     *   - If the assessed operation had any other failure, a BESInternalError is thrown.
-     * These functions are used in the retry logic of this curl::super_easy_perform() to
-     * determine when there was success, when to keep trying, and if to give up.
-     *
-     * @param c_handle The CURL easy handle on which to operate
-     */
-    void super_easy_perform(CURL *c_handle)
-    {
-        unsigned int attempts = 0;
-        useconds_t retry_time = uone_second / 4;
-        bool success;
-        CURLcode curl_code;
-        char curlErrorBuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
-        string target_url;
-
-        string empty_str;
-        target_url = get_effective_url(c_handle,empty_str);
-        // We check the value of target_url to see if the URL was correctly set in the cURL handle.
-        if (target_url.empty())
-            throw BESInternalError("URL acquisition failed.", __FILE__, __LINE__);
-
-        // SET Error Buffer --------------------------------------------------------------------------------------------
-        set_error_buffer(c_handle, curlErrorBuf);
-        do {
-            curlErrorBuf[0]=0; // Initialize to empty string
-            ++attempts;
-            BESDEBUG(MODULE, prolog << "Requesting URL: " << target_url << " attempt: " << attempts <<  endl);
-
-            curl_code = curl_easy_perform(c_handle);
-            success = eval_curl_easy_perform_code(c_handle, target_url, curl_code, curlErrorBuf, attempts);
-            if(success){
-                // Nothing obvious went wrong with the curl_easy_perform() so now we check the HTTP stuff
-                success = eval_http_get_response(c_handle, curlErrorBuf, target_url);
+        // If the curl_easy_perform failed, or if the http request failed then
+        // we keep trying until we have exceeded the retry_limit.
+        if (!success) {
+            if (attempts == retry_limit) {
+                string msg = prolog + "ERROR - Problem with data transfer. Number of re-tries exceeded. Giving up.";
+                LOG(msg << endl);
+                throw BESInternalError(msg, __FILE__, __LINE__);
             }
-            // If the curl_easy_perform failed, or if the http request failed then
-            // we keep trying until we have exceeded the retry_limit.
-            if (!success) {
-                if (attempts == retry_limit) {
-                    string msg = prolog + "ERROR - Problem with data transfer. Number of re-tries exceeded. Giving up.";
-                    LOG(msg << endl);
-                    throw BESInternalError(msg, __FILE__, __LINE__);
-                }
-                else {
-                    LOG(prolog << "ERROR - Problem with data transfer. Will retry (url: " << target_url <<
-                               " attempt: " << attempts << ")." << endl);
-                    usleep(retry_time);
-                    retry_time *= 2;
-                }
+            else {
+                LOG(prolog << "ERROR - Problem with data transfer. Will retry (url: " << target_url <<
+                           " attempt: " << attempts << ")." << endl);
+                usleep(retry_time);
+                retry_time *= 2;
             }
-        } while (!success);
-        // Unset the buffer as it goes out of scope
-        unset_error_buffer(c_handle);
-    }
+        }
+    } while (!success);
+    // Unset the buffer as it goes out of scope
+    unset_error_buffer(c_handle);
+}
 
 #if 0
 
-    /**
-    * Execute the HTTP VERB from the passed cURL handle "c_handle" and retrieve the response.
-    * @param c_handle The cURL easy handle to execute and read.
-    */
-    void read_data(CURL *c_handle) {
+/**
+* Execute the HTTP VERB from the passed cURL handle "c_handle" and retrieve the response.
+* @param c_handle The cURL easy handle to execute and read.
+*/
+void read_data(CURL *c_handle) {
 
-        unsigned int attempts = 0;
-        useconds_t retry_time = uone_second / 4;
-        bool success;
-        CURLcode curl_code;
-        char curlErrorBuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
-        char *urlp = NULL;
+    unsigned int attempts = 0;
+    useconds_t retry_time = uone_second / 4;
+    bool success;
+    CURLcode curl_code;
+    char curlErrorBuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
+    char *urlp = NULL;
 
-        curl_easy_getinfo(c_handle, CURLINFO_EFFECTIVE_URL, &urlp);
-        // Checking the curl_easy_getinfo return value in this case is pointless. If it's CURLE_OK then we
-        // still have to check the value of urlp to see if the URL was correctly set in the
-        // cURL handle. If it fails then it fails, and urlp is not set. If we just focus on the value of urlp then
-        // we can just check the one thing.
-        if (!urlp)
-            throw BESInternalError("URL acquisition failed.", __FILE__, __LINE__);
+    curl_easy_getinfo(c_handle, CURLINFO_EFFECTIVE_URL, &urlp);
+    // Checking the curl_easy_getinfo return value in this case is pointless. If it's CURLE_OK then we
+    // still have to check the value of urlp to see if the URL was correctly set in the
+    // cURL handle. If it fails then it fails, and urlp is not set. If we just focus on the value of urlp then
+    // we can just check the one thing.
+    if (!urlp)
+        throw BESInternalError("URL acquisition failed.", __FILE__, __LINE__);
 
-        // SET Error Buffer --------------------------------------------------------------------------------------------
-        set_error_buffer(c_handle, curlErrorBuf);
-        do {
-            // bool do_retry;
-            curlErrorBuf[0]=0; // Initialize to empty string
-            ++attempts;
-            BESDEBUG(MODULE, prolog << "Requesting URL: " << urlp << " attempt: " << attempts <<  endl);
+    // SET Error Buffer --------------------------------------------------------------------------------------------
+    set_error_buffer(c_handle, curlErrorBuf);
+    do {
+        // bool do_retry;
+        curlErrorBuf[0]=0; // Initialize to empty string
+        ++attempts;
+        BESDEBUG(MODULE, prolog << "Requesting URL: " << urlp << " attempt: " << attempts <<  endl);
 
-            curl_code = curl_easy_perform(c_handle);
-            success = eval_curl_easy_perform_code(c_handle, urlp, curl_code, curlErrorBuf, attempts);
-            if(success){
-                // Nothing obvious went wrong with the curl_easy_perfom() so now we check the HTTP stuff
-                success = eval_http_get_response(c_handle, urlp);
+        curl_code = curl_easy_perform(c_handle);
+        success = eval_curl_easy_perform_code(c_handle, urlp, curl_code, curlErrorBuf, attempts);
+        if(success){
+            // Nothing obvious went wrong with the curl_easy_perfom() so now we check the HTTP stuff
+            success = eval_http_get_response(c_handle, urlp);
+        }
+        // If the curl_easy_perform failed, or if the http request failed then
+        // we keep trying until we have exceeded the retry_limit.
+        if (!success) {
+            if (attempts == retry_limit) {
+                string msg = prolog + "ERROR - Problem with data transfer. Number of re-tries exceeded. Giving up.";
+                LOG(msg << endl);
+                throw BESInternalError(msg, __FILE__, __LINE__);
             }
-            // If the curl_easy_perform failed, or if the http request failed then
-            // we keep trying until we have exceeded the retry_limit.
-            if (!success) {
-                if (attempts == retry_limit) {
-                    string msg = prolog + "ERROR - Problem with data transfer. Number of re-tries exceeded. Giving up.";
-                    LOG(msg << endl);
-                    throw BESInternalError(msg, __FILE__, __LINE__);
-                }
-                else {
-                    LOG(prolog << "ERROR - Problem with data transfer. Will retry (url: " << urlp <<
-                               " attempt: " << attempts << ")." << endl);
-                    usleep(retry_time);
-                    retry_time *= 2;
-                }
+            else {
+                LOG(prolog << "ERROR - Problem with data transfer. Will retry (url: " << urlp <<
+                           " attempt: " << attempts << ")." << endl);
+                usleep(retry_time);
+                retry_time *= 2;
             }
-        } while (!success);
+        }
+    } while (!success);
 
 #if 0
-        // Try until retry_limit or success...
-        do {
-            curlErrorBuf[0] = 0; // clear the error buffer with a null termination at index 0.
-            curl_code = curl_easy_perform(c_handle); // Do the thing...
-            ++tries;
+    // Try until retry_limit or success...
+    do {
+        curlErrorBuf[0] = 0; // clear the error buffer with a null termination at index 0.
+        curl_code = curl_easy_perform(c_handle); // Do the thing...
+        ++tries;
 
-            if (CURLE_OK != curl_code) { // Failure here is not an HTTP error, but a cURL error.
-                throw BESInternalError(
-                        string("read_data() - ERROR! Message: ").append(error_message(curl_code, curlErrorBuf)),
-                        __FILE__, __LINE__);
-            }
-
-            success = eval_get_response(c_handle, urlp);
-            // if(debug) cout << ngap_curl::probe_easy_handle(c_handle) << endl;
-            if (!success) {
-                if (tries == retry_limit) {
-                    string msg = prolog + "Data transfer error: Number of re-tries exceeded: "+ error_message(curl_code, curlErrorBuf);
-                    LOG(msg << endl);
-                    throw BESInternalError(msg, __FILE__, __LINE__);
-                }
-                else {
-                    if (BESDebug::IsSet(MODULE)) {
-                        stringstream ss;
-                        ss << "HTTP transfer 500 error, will retry (trial " << tries << " for: " << urlp << ").";
-                        BESDEBUG(MODULE, ss.str());
-                    }
-                    usleep(retry_time);
-                    retry_time *= 2;
-                }
-            }
-
-        } while (!success);
-#endif
-        unset_error_buffer(c_handle);
-    }
-#endif
-
-    string get_cookie_file_base() {
-        bool found = false;
-        string cookie_filename;
-        TheBESKeys::TheKeys()->get_value(HTTP_COOKIES_FILE_KEY, cookie_filename, found);
-        if (!found) {
-            cookie_filename = HTTP_DEFAULT_COOKIES_FILE;
-        }
-        return cookie_filename;
-    }
-    string get_cookie_filename() {
-        string cookie_file_base = get_cookie_file_base();
-        stringstream cf_with_pid;
-        cf_with_pid <<  cookie_file_base << "-" << getpid();
-        return cf_with_pid.str();
-    }
-
-    void clear_cookies(){
-        string cf = get_cookie_filename();
-        int ret = unlink(cf.c_str());
-        if(ret){
-            string msg = prolog + "() - Failed to unlink the cookie file: " + cf;
-            LOG(msg << endl);
-            BESDEBUG(MODULE, prolog << msg << endl);
-        }
-    }
-
-
-    /**
-     * Checks to see if the entire url matches any of the  "no retry" regular expressions held in the TheBESKeys
-     * under the HTTP_NO_RETRY_URL_REGEX_KEY which atm, is set to "Http.No.Retry.Regex"
-     * @param target_url The URL to be examined
-     * @return True if the target_url does not match a no retry regex, false if the entire target_url matches
-     * a "no retry" regex.
-     */
-    bool is_retryable(std::string target_url)
-    {
-        BESDEBUG(MODULE, prolog << "BEGIN" << endl);
-        bool retryable = true;
-
-        vector<string> nr_regexs;
-        bool found;
-        TheBESKeys::TheKeys()->get_values(HTTP_NO_RETRY_URL_REGEX_KEY,nr_regexs, found);
-        if(found){
-            vector<string>::iterator it;
-            for(it=nr_regexs.begin(); it != nr_regexs.end() && retryable ; it++){
-                BESRegex no_retry_regex((*it).c_str(), (*it).size());
-                int match_length;
-                match_length = no_retry_regex.match(target_url.c_str(), target_url.size(), 0);
-                if(match_length == target_url.size()){
-                    BESDEBUG(MODULE, prolog << "The url: '"<< target_url << "' fully matched the "
-                    << HTTP_NO_RETRY_URL_REGEX_KEY << ": '" <<  *it << "'" <<  endl);
-                    retryable = false;
-                }
-            }
-        }
-        BESDEBUG(MODULE, prolog << "END retryable: "<< (retryable?"true":"false") << endl);
-        return retryable;
-    }
-
-    /**
-     * @brief Evaluates the HTTP semantics of a the result of issuing a cURL GET request.
-     *
-     * This code requires that:
-     * - curl_easy_perform() has been called on the handle ceh.
-     * - The returned CURLcode value was CURLE_OK.
-     * This code operates under the assumption that the world is not perfect and that things
-     * fail, sometimes for no good reason, and trying the thing a again may be worth while.
-     *
-     * With that in mind, if:
-     *
-     *    CURLINFO_RESPONSE_CODE returns CURLE_GOT_NOTHING
-     *
-     * or if the HTTP response code was one of:
-     *
-     *   case 422: // Unprocessable Entity
-     *   case 500: // Internal server error
-     *   case 502: // Bad Gateway
-     *   case 503: // Service Unavailable
-     *   case 504: // Gateway Timeout
-     *
-     * This function will return false, indicating that there was a problem, but a retry
-     * might be reasonable.
-     *
-     * If another cURL error or different HTTP response error code is encountered a
-     * BESInternalError is thrown.
-     *
-     * This function returns true if the CURLINFO_RESPONSE_CODE response code is 200 (OK) or
-     * 206 (Partial Content)
-     *
-     * @param ceh The cURL easy_handle to evaluate.
-     * @return true if at all worked out, false if it didn't and a retry is reasonable.
-     * @throws BESInternalError When something really bad happens.
-    */
-    bool eval_http_get_response(CURL *ceh, char *error_buffer, const string &requested_url) {
-        BESDEBUG(MODULE, prolog << "Requested URL: " << requested_url << endl);
-        CURLcode curl_code;
-        string last_accessed_url = get_effective_url(ceh, requested_url);
-        BESDEBUG(MODULE, prolog << "Last Accessed URL(CURLINFO_EFFECTIVE_URL): " << last_accessed_url << endl);
-
-        long http_code = 0;
-
-        curl_code = curl_easy_getinfo(ceh, CURLINFO_RESPONSE_CODE, &http_code);
-        if (curl_code == CURLE_GOT_NOTHING) {
-            // First we check to see if the response was empty. This is a cURL error, not an HTTP error
-            // so we have to handle it like this. And we do that because this is one of the failure modes
-            // we see in the AWS cloud and by trapping this and returning false we are able to be resilient and retry.
-            stringstream msg;
-            msg << prolog << "ERROR - cURL returned CURLE_GOT_NOTHING. Message: '" ;
-            msg << error_message(curl_code, error_buffer) << "' ";
-            msg << "CURLINFO_EFFECTIVE_URL: " << last_accessed_url << " ";
-            msg << "A retry may be possible for: "<< requested_url << ")." << endl;
-            BESDEBUG(MODULE, msg.str());
-            LOG(msg.str());
-            return false;
-        }
-        else if(curl_code != CURLE_OK) {
-            // Not an error we are trapping so it's fail time.
+        if (CURLE_OK != curl_code) { // Failure here is not an HTTP error, but a cURL error.
             throw BESInternalError(
-                    string("Error acquiring HTTP response code: ").append(curl::error_message(curl_code, error_buffer)),
+                    string("read_data() - ERROR! Message: ").append(error_message(curl_code, curlErrorBuf)),
                     __FILE__, __LINE__);
         }
 
-        if (BESDebug::IsSet(MODULE)) {
-            long redirects;
-            curl_easy_getinfo(ceh, CURLINFO_REDIRECT_COUNT, &redirects);
-            BESDEBUG(MODULE, prolog << "CURLINFO_REDIRECT_COUNT: " << redirects << endl);
-
-            char *redirect_url = NULL;
-            curl_easy_getinfo(ceh, CURLINFO_REDIRECT_URL, &redirect_url);
-            if (redirect_url)
-                BESDEBUG(MODULE, prolog << "CURLINFO_REDIRECT_URL: " << redirect_url << endl);
-        }
-
-        stringstream msg;
-        if(http_code >= 400){
-            msg << "ERROR - The HTTP GET request for the source URL: " << requested_url << " FAILED. ";
-            msg << "CURLINFO_EFFECTIVE_URL: " << last_accessed_url;
-            msg << " The response had an HTTP status of " << http_code;
-            msg << " which means '" << http_status_to_string(http_code) << "'";
-            BESDEBUG(MODULE, prolog << msg.str() << endl);
-            LOG(msg.str() << endl);
-        }
-
-        // Newer Apache servers return 206 for range requests. jhrg 8/8/18
-        switch (http_code) {
-            case 200: // OK
-            case 206: // Partial content - this is to be expected since we use range gets
-                // cases 201-205 are things we should probably reject, unless we add more
-                // comprehensive HTTP/S processing here. jhrg 8/8/18
-                return true;
-
-            case 400: // Bad Request
-                throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
-
-            case 401: // Unauthorized
-            case 402: // Payment Required
-            case 403: // Forbidden
-                throw BESForbiddenError(msg.str(), __FILE__, __LINE__);
-
-            case 404: // Not Found
-                throw BESNotFoundError(msg.str(), __FILE__, __LINE__);
-
-            case 408: // Request Timeout
-                throw BESTimeoutError(msg.str(), __FILE__, __LINE__);
-
-            case 422: // Unprocessable Entity
-            case 500: // Internal server error
-            case 502: // Bad Gateway
-            case 503: // Service Unavailable
-            case 504: // Gateway Timeout
-            {
-                if(!is_retryable(last_accessed_url)){
-                    msg << " The semantics of this particular last accessed URL indicate that it should not be retried.";
-                    LOG(msg.str() << endl);
-                    throw BESInternalError(msg.str(), __FILE__, __LINE__);
-                }
-                return false;
+        success = eval_get_response(c_handle, urlp);
+        // if(debug) cout << ngap_curl::probe_easy_handle(c_handle) << endl;
+        if (!success) {
+            if (tries == retry_limit) {
+                string msg = prolog + "Data transfer error: Number of re-tries exceeded: "+ error_message(curl_code, curlErrorBuf);
+                LOG(msg << endl);
+                throw BESInternalError(msg, __FILE__, __LINE__);
             }
+            else {
+                if (BESDebug::IsSet(MODULE)) {
+                    stringstream ss;
+                    ss << "HTTP transfer 500 error, will retry (trial " << tries << " for: " << urlp << ").";
+                    BESDEBUG(MODULE, ss.str());
+                }
+                usleep(retry_time);
+                retry_time *= 2;
+            }
+        }
 
-            default: {
-                BESDEBUG(MODULE, msg.str() << endl);
-                throw BESInternalError(msg.str(), __FILE__, __LINE__);
+    } while (!success);
+#endif
+    unset_error_buffer(c_handle);
+}
+#endif
+
+string get_cookie_file_base() {
+    bool found = false;
+    string cookie_filename;
+    TheBESKeys::TheKeys()->get_value(HTTP_COOKIES_FILE_KEY, cookie_filename, found);
+    if (!found) {
+        cookie_filename = HTTP_DEFAULT_COOKIES_FILE;
+    }
+    return cookie_filename;
+}
+
+string get_cookie_filename() {
+    string cookie_file_base = get_cookie_file_base();
+    stringstream cf_with_pid;
+    cf_with_pid << cookie_file_base << "-" << getpid();
+    return cf_with_pid.str();
+}
+
+void clear_cookies() {
+    string cf = get_cookie_filename();
+    int ret = unlink(cf.c_str());
+    if (ret) {
+        string msg = prolog + "() - Failed to unlink the cookie file: " + cf;
+        LOG(msg << endl);
+        BESDEBUG(MODULE, prolog << msg << endl);
+    }
+}
+
+
+/**
+ * Checks to see if the entire url matches any of the  "no retry" regular expressions held in the TheBESKeys
+ * under the HTTP_NO_RETRY_URL_REGEX_KEY which atm, is set to "Http.No.Retry.Regex"
+ * @param target_url The URL to be examined
+ * @return True if the target_url does not match a no retry regex, false if the entire target_url matches
+ * a "no retry" regex.
+ */
+bool is_retryable(std::string target_url) {
+    BESDEBUG(MODULE, prolog << "BEGIN" << endl);
+    bool retryable = true;
+
+    vector<string> nr_regexs;
+    bool found;
+    TheBESKeys::TheKeys()->get_values(HTTP_NO_RETRY_URL_REGEX_KEY, nr_regexs, found);
+    if (found) {
+        vector<string>::iterator it;
+        for (it = nr_regexs.begin(); it != nr_regexs.end() && retryable; it++) {
+            BESRegex no_retry_regex((*it).c_str(), (*it).size());
+            int match_length;
+            match_length = no_retry_regex.match(target_url.c_str(), target_url.size(), 0);
+            if (match_length == target_url.size()) {
+                BESDEBUG(MODULE, prolog << "The url: '" << target_url << "' fully matched the "
+                                        << HTTP_NO_RETRY_URL_REGEX_KEY << ": '" << *it << "'" << endl);
+                retryable = false;
             }
         }
     }
+    BESDEBUG(MODULE, prolog << "END retryable: " << (retryable ? "true" : "false") << endl);
+    return retryable;
+}
 
+/**
+ * @brief Evaluates the HTTP semantics of a the result of issuing a cURL GET request.
+ *
+ * This code requires that:
+ * - curl_easy_perform() has been called on the handle ceh.
+ * - The returned CURLcode value was CURLE_OK.
+ * This code operates under the assumption that the world is not perfect and that things
+ * fail, sometimes for no good reason, and trying the thing a again may be worth while.
+ *
+ * With that in mind, if:
+ *
+ *    CURLINFO_RESPONSE_CODE returns CURLE_GOT_NOTHING
+ *
+ * or if the HTTP response code was one of:
+ *
+ *   case 422: // Unprocessable Entity
+ *   case 500: // Internal server error
+ *   case 502: // Bad Gateway
+ *   case 503: // Service Unavailable
+ *   case 504: // Gateway Timeout
+ *
+ * This function will return false, indicating that there was a problem, but a retry
+ * might be reasonable.
+ *
+ * If another cURL error or different HTTP response error code is encountered a
+ * BESInternalError is thrown.
+ *
+ * This function returns true if the CURLINFO_RESPONSE_CODE response code is 200 (OK) or
+ * 206 (Partial Content)
+ *
+ * @param ceh The cURL easy_handle to evaluate.
+ * @return true if at all worked out, false if it didn't and a retry is reasonable.
+ * @throws BESInternalError When something really bad happens.
+*/
+bool eval_http_get_response(CURL *ceh, char *error_buffer, const string &requested_url) {
+    BESDEBUG(MODULE, prolog << "Requested URL: " << requested_url << endl);
+    CURLcode curl_code;
+    string last_accessed_url = get_effective_url(ceh, requested_url);
+    BESDEBUG(MODULE, prolog << "Last Accessed URL(CURLINFO_EFFECTIVE_URL): " << last_accessed_url << endl);
+
+    long http_code = 0;
+
+    curl_code = curl_easy_getinfo(ceh, CURLINFO_RESPONSE_CODE, &http_code);
+    if (curl_code == CURLE_GOT_NOTHING) {
+        // First we check to see if the response was empty. This is a cURL error, not an HTTP error
+        // so we have to handle it like this. And we do that because this is one of the failure modes
+        // we see in the AWS cloud and by trapping this and returning false we are able to be resilient and retry.
+        stringstream msg;
+        msg << prolog << "ERROR - cURL returned CURLE_GOT_NOTHING. Message: '";
+        msg << error_message(curl_code, error_buffer) << "' ";
+        msg << "CURLINFO_EFFECTIVE_URL: " << last_accessed_url << " ";
+        msg << "A retry may be possible for: " << requested_url << ")." << endl;
+        BESDEBUG(MODULE, msg.str());
+        LOG(msg.str());
+        return false;
+    }
+    else if (curl_code != CURLE_OK) {
+        // Not an error we are trapping so it's fail time.
+        throw BESInternalError(
+                string("Error acquiring HTTP response code: ").append(curl::error_message(curl_code, error_buffer)),
+                __FILE__, __LINE__);
+    }
+
+    if (BESDebug::IsSet(MODULE)) {
+        long redirects;
+        curl_easy_getinfo(ceh, CURLINFO_REDIRECT_COUNT, &redirects);
+        BESDEBUG(MODULE, prolog << "CURLINFO_REDIRECT_COUNT: " << redirects << endl);
+
+        char *redirect_url = NULL;
+        curl_easy_getinfo(ceh, CURLINFO_REDIRECT_URL, &redirect_url);
+        if (redirect_url)
+            BESDEBUG(MODULE, prolog << "CURLINFO_REDIRECT_URL: " << redirect_url << endl);
+    }
+
+    stringstream msg;
+    if (http_code >= 400) {
+        msg << "ERROR - The HTTP GET request for the source URL: " << requested_url << " FAILED. ";
+        msg << "CURLINFO_EFFECTIVE_URL: " << last_accessed_url;
+        msg << " The response had an HTTP status of " << http_code;
+        msg << " which means '" << http_status_to_string(http_code) << "'";
+        BESDEBUG(MODULE, prolog << msg.str() << endl);
+        LOG(msg.str() << endl);
+    }
+
+    // Newer Apache servers return 206 for range requests. jhrg 8/8/18
+    switch (http_code) {
+        case 200: // OK
+        case 206: // Partial content - this is to be expected since we use range gets
+            // cases 201-205 are things we should probably reject, unless we add more
+            // comprehensive HTTP/S processing here. jhrg 8/8/18
+            return true;
+
+        case 400: // Bad Request
+            throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
+
+        case 401: // Unauthorized
+        case 402: // Payment Required
+        case 403: // Forbidden
+            throw BESForbiddenError(msg.str(), __FILE__, __LINE__);
+
+        case 404: // Not Found
+            throw BESNotFoundError(msg.str(), __FILE__, __LINE__);
+
+        case 408: // Request Timeout
+            throw BESTimeoutError(msg.str(), __FILE__, __LINE__);
+
+        case 422: // Unprocessable Entity
+        case 500: // Internal server error
+        case 502: // Bad Gateway
+        case 503: // Service Unavailable
+        case 504: // Gateway Timeout
+        {
+            if (!is_retryable(last_accessed_url)) {
+                msg << " The semantics of this particular last accessed URL indicate that it should not be retried.";
+                LOG(msg.str() << endl);
+                throw BESInternalError(msg.str(), __FILE__, __LINE__);
+            }
+            return false;
+        }
+
+        default: {
+            BESDEBUG(MODULE, msg.str() << endl);
+            throw BESInternalError(msg.str(), __FILE__, __LINE__);
+        }
+    }
+}
 
 
 /**
@@ -1335,46 +1324,46 @@ bool eval_curl_easy_perform_code(
         CURLcode curl_code,
         char *error_buffer,
         const unsigned int attempt
-        ){
+) {
     bool success = true;
     string last_accessed_url = get_effective_url(ceh, requested_url);
-    if( curl_code == CURLE_SSL_CONNECT_ERROR ){
+    if (curl_code == CURLE_SSL_CONNECT_ERROR) {
         stringstream msg;
         msg << prolog << "ERROR - cURL experienced a CURLE_SSL_CONNECT_ERROR error. Message: '";
         msg << error_message(curl_code, error_buffer) << "' ";
         msg << "CURLINFO_EFFECTIVE_URL: " << last_accessed_url << " ";
-        msg << "A retry may be possible for: "<< requested_url << " (attempt: " << attempt << ")." << endl;
-        BESDEBUG(MODULE,msg.str());
+        msg << "A retry may be possible for: " << requested_url << " (attempt: " << attempt << ")." << endl;
+        BESDEBUG(MODULE, msg.str());
         LOG(msg.str());
-        success =  false;
+        success = false;
     }
-    else if( curl_code == CURLE_SSL_CACERT_BADFILE ){
+    else if (curl_code == CURLE_SSL_CACERT_BADFILE) {
         stringstream msg;
         msg << prolog << "ERROR - cURL experienced a CURLE_SSL_CACERT_BADFILE error. Message: '";
         msg << error_message(curl_code, error_buffer) << "' ";
         msg << "CURLINFO_EFFECTIVE_URL: " << last_accessed_url << " ";
-        msg << "A retry may be possible for: "<< requested_url << " (attempt: " << attempt << ")." << endl;
-        BESDEBUG(MODULE,msg.str());
+        msg << "A retry may be possible for: " << requested_url << " (attempt: " << attempt << ")." << endl;
+        BESDEBUG(MODULE, msg.str());
         LOG(msg.str());
-        success =  false;
+        success = false;
     }
     else if (curl_code == CURLE_GOT_NOTHING) {
-            // First we check to see if the response was empty. This is a cURL error, not an HTTP error
-            // so we have to handle it like this. And we do that because this is one of the failure modes
-            // we see in the AWS cloud and by trapping this and returning false we are able to be resilient and retry.
-            stringstream msg;
-            msg << prolog << "ERROR - cURL returned CURLE_GOT_NOTHING. Message: " ;
-            msg << error_message(curl_code, error_buffer) << "' ";
-            msg << "CURLINFO_EFFECTIVE_URL: " << last_accessed_url << " ";
-            msg << "A retry may be possible for: "<< requested_url << " (attempt: " << attempt << ")." << endl;
-            BESDEBUG(MODULE, msg.str());
-            LOG(msg.str());
-            return false;
+        // First we check to see if the response was empty. This is a cURL error, not an HTTP error
+        // so we have to handle it like this. And we do that because this is one of the failure modes
+        // we see in the AWS cloud and by trapping this and returning false we are able to be resilient and retry.
+        stringstream msg;
+        msg << prolog << "ERROR - cURL returned CURLE_GOT_NOTHING. Message: ";
+        msg << error_message(curl_code, error_buffer) << "' ";
+        msg << "CURLINFO_EFFECTIVE_URL: " << last_accessed_url << " ";
+        msg << "A retry may be possible for: " << requested_url << " (attempt: " << attempt << ")." << endl;
+        BESDEBUG(MODULE, msg.str());
+        LOG(msg.str());
+        return false;
     }
     else if (CURLE_OK != curl_code) {
         stringstream msg;
         msg << "ERROR - Problem with data transfer. Message: " << error_message(curl_code, error_buffer);
-        string effective_url = get_effective_url(ceh,requested_url);
+        string effective_url = get_effective_url(ceh, requested_url);
         msg << " CURLINFO_EFFECTIVE_URL: " << effective_url;
         BESDEBUG(MODULE, prolog << msg.str() << endl);
         throw BESInternalError(msg.str(), __FILE__, __LINE__);
@@ -1382,213 +1371,210 @@ bool eval_curl_easy_perform_code(
     return success;
 }
 
-    /**
-     * @brief Performs a small (4 byte) range get on the target URL. If successfull the value of  last_accessed_url will
-     * be set to the value of the last accessed URL (CURLINFO_EFFECTIVE_URL), including the query string.
-     * are
-     * @param target_url The URL to follow
-     * @param last_accessed_url The last accessed URL (CURLINFO_EFFECTIVE_URL), including the query string
-     */
-    void retrieve_effective_url(const string &target_url, string &last_accessed_url) {
+/**
+ * @brief Performs a small (4 byte) range get on the target URL. If successfull the value of  last_accessed_url will
+ * be set to the value of the last accessed URL (CURLINFO_EFFECTIVE_URL), including the query string.
+ * are
+ * @param target_url The URL to follow
+ * @param last_accessed_url The last accessed URL (CURLINFO_EFFECTIVE_URL), including the query string
+ */
+void retrieve_effective_url(const string &target_url, string &last_accessed_url) {
+    vector<string> resp_hdrs;
+    CURL *ceh = NULL;
+    CURLcode curl_code;
+
+    curl_slist *request_headers = NULL;
+    // Add the authorization headers
+    request_headers = add_auth_headers(request_headers);
+
+    try {
+        BESStopWatch sw;
+        if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose())
+            sw.start(prolog + " Following Redirects Starting With: " + target_url);
+
+        ceh = init_effective_url_retriever_handle(target_url, request_headers, resp_hdrs);
+
+        super_easy_perform(ceh);
+
+        // After doing the thing with super_easy_perform() we retrieve the effective URL form the cURL handle.
+        last_accessed_url = get_effective_url(ceh, target_url);
+        BESDEBUG(MODULE, prolog << "Last Accessed URL(CURLINFO_EFFECTIVE_URL): " << last_accessed_url << endl);
+        LOG(prolog << "Source URL: '" << target_url << "' CURLINFO_EFFECTIVE_URL: '" << last_accessed_url << "'"
+                   << endl);
+
+        if (request_headers)
+            curl_slist_free_all(request_headers);
+        if (ceh)
+            curl_easy_cleanup(ceh);
+    }
+    catch (...) {
+        if (request_headers)
+            curl_slist_free_all(request_headers);
+        if (ceh)
+            curl_easy_cleanup(ceh);
+        throw;
+    }
+#if 0
+    {
+        unsigned int attempts = 0;
+        bool success = true;
+        useconds_t retry_time = uone_second / 4;
+
+        char error_buffer[CURL_ERROR_SIZE];
         vector<string> resp_hdrs;
         CURL *ceh = NULL;
         CURLcode curl_code;
 
-        curl_slist *request_headers=NULL;
+        struct curl_slist *request_headers = NULL;
         // Add the authorization headers
-        request_headers = add_auth_headers(request_headers);
+        request_headers = get_auth_headers(request_headers);
 
         try {
-            BESStopWatch sw;
-            if (BESISDEBUG(TIMING_LOG) || BESLog::TheLog()->is_verbose())
-                sw.start(prolog + " Following Redirects Starting With: " + target_url);
+            ceh = init_effective_url_retriever_handle(url, request_headers, resp_hdrs);
+            set_error_buffer(ceh, error_buffer);
+            do {
+                // bool do_retry;
+                error_buffer[0] = 0; // Initialize to empty string
+                ++attempts;
+                BESDEBUG(MODULE, prolog << "Requesting URL: " << target_url << " attempt: " << attempts << endl);
 
-            ceh = init_effective_url_retriever_handle(target_url, request_headers, resp_hdrs);
-
-            super_easy_perform(ceh);
-
-            // After doing the thing with super_easy_perform() we retrieve the effective URL form the cURL handle.
-            last_accessed_url = get_effective_url(ceh,target_url);
-            BESDEBUG(MODULE, prolog << "Last Accessed URL(CURLINFO_EFFECTIVE_URL): " << last_accessed_url << endl);
-            LOG(prolog << "Source URL: '" << target_url << "' CURLINFO_EFFECTIVE_URL: '" << last_accessed_url << "'" << endl);
-
-            if(request_headers)
-                curl_slist_free_all(request_headers);
-            if(ceh)
-                curl_easy_cleanup(ceh);
-        }
-        catch(...){
-            if(request_headers)
-                curl_slist_free_all(request_headers);
-            if(ceh)
-                curl_easy_cleanup(ceh);
-            throw;
-        }
-#if 0
-        {
-            unsigned int attempts = 0;
-            bool success = true;
-            useconds_t retry_time = uone_second / 4;
-
-            char error_buffer[CURL_ERROR_SIZE];
-            vector<string> resp_hdrs;
-            CURL *ceh = NULL;
-            CURLcode curl_code;
-
-            struct curl_slist *request_headers = NULL;
-            // Add the authorization headers
-            request_headers = get_auth_headers(request_headers);
-
-            try {
-                ceh = init_effective_url_retriever_handle(url, request_headers, resp_hdrs);
-                set_error_buffer(ceh, error_buffer);
-                do {
-                    // bool do_retry;
-                    error_buffer[0] = 0; // Initialize to empty string
-                    ++attempts;
-                    BESDEBUG(MODULE, prolog << "Requesting URL: " << target_url << " attempt: " << attempts << endl);
-
-                    curl_code = curl_easy_perform(ceh);
-                    success = eval_curl_easy_perform_code(ceh, target_url, curl_code, error_buffer, attempts);
-                    if (success) {
-                        // Nothing obvious went wrong with the curl_easy_perfom() so now we check the HTTP stuff
-                        success = eval_http_get_response(ceh, target_url);
-                        if (!success) {
-                            if (attempts == retry_limit) {
-                                string msg = prolog +
-                                             "ERROR - Problem with data transfer. Number of re-tries exceeded. Giving up.";
-                                LOG(msg << endl);
-                                throw BESInternalError(msg, __FILE__, __LINE__);
-                            } else {
-                                LOG(prolog << "ERROR - Problem with data transfer. Will retry (url: " << target_url <<
-                                           " attempt: " << attempts << ")." << endl);
-                            }
+                curl_code = curl_easy_perform(ceh);
+                success = eval_curl_easy_perform_code(ceh, target_url, curl_code, error_buffer, attempts);
+                if (success) {
+                    // Nothing obvious went wrong with the curl_easy_perfom() so now we check the HTTP stuff
+                    success = eval_http_get_response(ceh, target_url);
+                    if (!success) {
+                        if (attempts == retry_limit) {
+                            string msg = prolog +
+                                         "ERROR - Problem with data transfer. Number of re-tries exceeded. Giving up.";
+                            LOG(msg << endl);
+                            throw BESInternalError(msg, __FILE__, __LINE__);
+                        } else {
+                            LOG(prolog << "ERROR - Problem with data transfer. Will retry (url: " << target_url <<
+                                       " attempt: " << attempts << ")." << endl);
                         }
                     }
-                    // If it did not work we keep trying until we have exceeded the retry_limit.
-                    if (!success) {
-                        usleep(retry_time);
-                        retry_time *= 2;
-                    }
-                } while (!success);
-
-                char *effective_url = 0;
-                curl_easy_getinfo(ceh, CURLINFO_EFFECTIVE_URL, &effective_url);
-                BESDEBUG(MODULE, prolog << " CURLINFO_EFFECTIVE_URL: " << effective_url << endl);
-                last_accessed_url = effective_url;
-
-                LOG(prolog << "Source URL: '" << target_url << "' Last Accessed URL: '" << last_accessed_url << "'" << endl);
-
-                unset_error_buffer(ceh);
-
-                if (ceh) {
-                    curl_slist_free_all(request_headers);
-                    curl_easy_cleanup(ceh);
-                    ceh = 0;
                 }
-            }
-            catch (...) {
-                if (request_headers)
-                    curl_slist_free_all(request_headers);
-                if (ceh) {
-                    curl_easy_cleanup(ceh);
-                    ceh = 0;
+                // If it did not work we keep trying until we have exceeded the retry_limit.
+                if (!success) {
+                    usleep(retry_time);
+                    retry_time *= 2;
                 }
-                throw;
+            } while (!success);
+
+            char *effective_url = 0;
+            curl_easy_getinfo(ceh, CURLINFO_EFFECTIVE_URL, &effective_url);
+            BESDEBUG(MODULE, prolog << " CURLINFO_EFFECTIVE_URL: " << effective_url << endl);
+            last_accessed_url = effective_url;
+
+            LOG(prolog << "Source URL: '" << target_url << "' Last Accessed URL: '" << last_accessed_url << "'" << endl);
+
+            unset_error_buffer(ceh);
+
+            if (ceh) {
+                curl_slist_free_all(request_headers);
+                curl_easy_cleanup(ceh);
+                ceh = 0;
             }
         }
+        catch (...) {
+            if (request_headers)
+                curl_slist_free_all(request_headers);
+            if (ceh) {
+                curl_easy_cleanup(ceh);
+                ceh = 0;
+            }
+            throw;
+        }
+    }
 #endif
-    }
+}
 
-    /**
-     * @brief Return the location of the netrc file for Hyrax to utilize when
-     * making requests for remote resources.
-     *
-     * If no file is specifed an empty string is returned.
-     *
-     * @return The name of the netrc file specified in the configuration, possibly the empty
-     * string of none was specified.
-     */
-    string get_netrc_filename()
-    {
-        string netrc_filename;
-        bool found = false;
-        TheBESKeys::TheKeys()->get_value(HTTP_NETRC_FILE_KEY,netrc_filename,found);
-        if(found){
-            BESDEBUG(MODULE, prolog << "Using netrc file: " << netrc_filename << endl);
-        }
-        else {
-            BESDEBUG(MODULE, prolog << "Using default netrc file. (~/.netrc)" << endl);
-        }
-        return netrc_filename;
+/**
+ * @brief Return the location of the netrc file for Hyrax to utilize when
+ * making requests for remote resources.
+ *
+ * If no file is specifed an empty string is returned.
+ *
+ * @return The name of the netrc file specified in the configuration, possibly the empty
+ * string of none was specified.
+ */
+string get_netrc_filename() {
+    string netrc_filename;
+    bool found = false;
+    TheBESKeys::TheKeys()->get_value(HTTP_NETRC_FILE_KEY, netrc_filename, found);
+    if (found) {
+        BESDEBUG(MODULE, prolog << "Using netrc file: " << netrc_filename << endl);
     }
+    else {
+        BESDEBUG(MODULE, prolog << "Using default netrc file. (~/.netrc)" << endl);
+    }
+    return netrc_filename;
+}
 
-    /**
-     * Set the error buffer for the cURL easy handle ceh to error_buffer
-     * @param ceh
-     * @param error_buffer
-     */
-    void set_error_buffer(CURL *ceh, char *error_buffer)
-    {
-        CURLcode res;
-        res = curl_easy_setopt(ceh, CURLOPT_ERRORBUFFER, error_buffer);
-        eval_curl_easy_setopt_result(res, prolog, "CURLOPT_ERRORBUFFER", error_buffer, __FILE__, __LINE__);
-    }
+/**
+ * Set the error buffer for the cURL easy handle ceh to error_buffer
+ * @param ceh
+ * @param error_buffer
+ */
+void set_error_buffer(CURL *ceh, char *error_buffer) {
+    CURLcode res;
+    res = curl_easy_setopt(ceh, CURLOPT_ERRORBUFFER, error_buffer);
+    eval_curl_easy_setopt_result(res, prolog, "CURLOPT_ERRORBUFFER", error_buffer, __FILE__, __LINE__);
+}
 
-    /**
-     * Based on this thread: https://curl.haxx.se/mail/lib-2011-10/0078.html
-     * We "unset" the error buffer using a null pointer.
-     * @param ceh
-     */
-    void unset_error_buffer(CURL *ceh)
-    {
-        set_error_buffer(ceh,NULL);
-    }
+/**
+ * Based on this thread: https://curl.haxx.se/mail/lib-2011-10/0078.html
+ * We "unset" the error buffer using a null pointer.
+ * @param ceh
+ */
+void unset_error_buffer(CURL *ceh) {
+    set_error_buffer(ceh, NULL);
+}
 
 
-    /**
-     * A single source of truth for the User-Agent string used by Hyrax.
-     * @return The Hyrax User-Agent string.
-     */
-    string hyrax_user_agent(){
-        // return curl_version();
-        return "Hyrax";
-    }
+/**
+ * A single source of truth for the User-Agent string used by Hyrax.
+ * @return The Hyrax User-Agent string.
+ */
+string hyrax_user_agent() {
+    // return curl_version();
+    return "Hyrax";
+}
 
-    /**
-     * @brief Evaluuates the CURLcode returned by curl_easy_setopt()
-     *
-     * Throws a BESInternalError if curl_code != CURLE_OK
-     *
-     * A SSOT for this activity, which get's done a bunch.
-     *
-     * @param result The CURLcode value returned by the call to curl_easy_setopt()
-     * @param msg_base The prefix for any error message that gets generated.
-     * @param opt_name The string name of the option that was set.
-     * @param ebuf The cURL error buffer associated with the cURL easy handle
-     * at the time of the setopt call
-     * @param file The value of __FILE__ of the calling function.
-     * @param line The value of __LINE__ of the calling function.
-     */
-    void eval_curl_easy_setopt_result(
-            CURLcode curl_code,
-            string msg_base,
-            string opt_name,
-            char *ebuf,
-            string file,
-            unsigned int line)
-    {
-        if(curl_code!=CURLE_OK){
-            stringstream msg;
-            msg << msg_base << "ERROR - cURL failed to set " << opt_name << " Message: " << error_message(curl_code,ebuf);
-            throw BESInternalError(msg.str(), file, line);
-        }
+/**
+ * @brief Evaluuates the CURLcode returned by curl_easy_setopt()
+ *
+ * Throws a BESInternalError if curl_code != CURLE_OK
+ *
+ * A SSOT for this activity, which get's done a bunch.
+ *
+ * @param result The CURLcode value returned by the call to curl_easy_setopt()
+ * @param msg_base The prefix for any error message that gets generated.
+ * @param opt_name The string name of the option that was set.
+ * @param ebuf The cURL error buffer associated with the cURL easy handle
+ * at the time of the setopt call
+ * @param file The value of __FILE__ of the calling function.
+ * @param line The value of __LINE__ of the calling function.
+ */
+void eval_curl_easy_setopt_result(
+        CURLcode curl_code,
+        string msg_base,
+        string opt_name,
+        char *ebuf,
+        string file,
+        unsigned int line) {
+    if (curl_code != CURLE_OK) {
+        stringstream msg;
+        msg << msg_base << "ERROR - cURL failed to set " << opt_name << " Message: " << error_message(curl_code, ebuf);
+        throw BESInternalError(msg.str(), file, line);
     }
+}
 
-    unsigned long max_redirects(){
-        HttpUtils::load_max_redirects_from_keys();
-        return HttpUtils::MaxRedirects;
-    }
+unsigned long max_redirects() {
+    HttpUtils::load_max_redirects_from_keys();
+    return HttpUtils::MaxRedirects;
+}
 
 /**
  * @brief Adds the user id and/or the associated EDL auth token
@@ -1620,36 +1606,35 @@ bool eval_curl_easy_perform_code(
  * @param request_headers
  * @return
  */
-curl_slist *add_auth_headers(curl_slist *request_headers)
-{
-    curl_slist *temp=NULL;
+curl_slist *add_auth_headers(curl_slist *request_headers) {
+    curl_slist *temp = NULL;
     bool found;
     string s;
 
-    s = BESContextManager::TheManager()->get_context(EDL_UID_KEY,found);
-    if(found && !s.empty()){
+    s = BESContextManager::TheManager()->get_context(EDL_UID_KEY, found);
+    if (found && !s.empty()) {
         string uid_header = "User-Id: " + s;
         BESDEBUG(MODULE, prolog << "uid_header: " << uid_header << endl);
         temp = curl_slist_append(request_headers, uid_header.c_str());
-        if(temp)
+        if (temp)
             request_headers = temp;
     }
 
-    s = BESContextManager::TheManager()->get_context(EDL_AUTH_TOKEN_KEY,found);
-    if(found && !s.empty()){
+    s = BESContextManager::TheManager()->get_context(EDL_AUTH_TOKEN_KEY, found);
+    if (found && !s.empty()) {
         string authorization_header = "Authorization: " + s;
         BESDEBUG(MODULE, prolog << "authorization_header: " << authorization_header << endl);
         temp = curl_slist_append(request_headers, authorization_header.c_str());
-        if(temp)
+        if (temp)
             request_headers = temp;
     }
 
-    s = BESContextManager::TheManager()->get_context(EDL_ECHO_TOKEN_KEY,found);
-    if(found && !s.empty()){
+    s = BESContextManager::TheManager()->get_context(EDL_ECHO_TOKEN_KEY, found);
+    if (found && !s.empty()) {
         string echo_token_header = "Echo-Token: " + s;
         BESDEBUG(MODULE, prolog << "echo_token_header: " << echo_token_header << endl);
         temp = curl_slist_append(request_headers, echo_token_header.c_str());
-        if(temp)
+        if (temp)
             request_headers = temp;
     }
 
@@ -1663,11 +1648,10 @@ curl_slist *add_auth_headers(curl_slist *request_headers)
  * @param requested_url The original URL that was set in the cURL handle prior to a call to curl_easy_perform.
  * @return  The value of CURLINFO_EFFECTIVE_URL from the cURL handle ceh.
  */
-string get_effective_url(CURL *ceh, string requested_url)
-{
+string get_effective_url(CURL *ceh, string requested_url) {
     char *effectve_url = NULL;
     CURLcode curl_code = curl_easy_getinfo(ceh, CURLINFO_EFFECTIVE_URL, &effectve_url);
-    if(curl_code != CURLE_OK) {
+    if (curl_code != CURLE_OK) {
         stringstream msg;
         msg << prolog << "Unable to determine CURLINFO_EFFECTIVE_URL! Requested URL: " << requested_url;
         BESDEBUG(MODULE, msg.str() << endl);

--- a/http/CurlUtils.h
+++ b/http/CurlUtils.h
@@ -38,79 +38,72 @@
 
 namespace curl {
 
+void http_get_and_write_resource(const std::string &url,
+                                 const int fd,
+                                 std::vector<std::string> *http_response_headers);
 
-    void http_get_and_write_resource(const std::string &url,
-                                     const int fd,
-                                     std::vector<std::string> *http_response_headers);
+void http_get(const std::string &url, char *response_buf);
 
-    void http_get(const std::string &url, char *response_buf);
+std::string http_get_as_string(const std::string &url);
 
-    std::string http_get_as_string(const std::string &url);
+rapidjson::Document http_get_as_json(const std::string &target_url);
 
-    rapidjson::Document http_get_as_json(const std::string &target_url);
+void retrieve_effective_url(const std::string &url, std::string &last_accessed_url);
 
-    void retrieve_effective_url(const std::string &url, std::string &last_accessed_url);
+std::string get_netrc_filename();
 
+std::string get_cookie_filename();
 
-    std::string get_netrc_filename();
-    std::string get_cookie_filename();
+bool is_retryable(std::string url);
 
-    bool is_retryable(std::string url);
-    unsigned long max_redirects();
+unsigned long max_redirects();
 
-    std::string hyrax_user_agent();
+std::string hyrax_user_agent();
 
-    CURL *init(const std::string &target_url,
-               const struct curl_slist *http_request_headers,
-               std::vector<std::string> *resp_hdrs );
+CURL *init(const std::string &target_url,
+           const struct curl_slist *http_request_headers,
+           std::vector<std::string> *resp_hdrs);
 
-    CURL *init(CURL *ceh,
-               const std::string &target_url,
-               const struct curl_slist *http_request_headers,
-               std::vector<std::string> *http_response_hdrs
-    );
+CURL *init(CURL *ceh,
+           const std::string &target_url,
+           const struct curl_slist *http_request_headers,
+           std::vector<std::string> *http_response_hdrs);
 
-    bool configure_curl_handle_for_proxy(CURL *ceh, const std::string &url);
+bool configure_curl_handle_for_proxy(CURL *ceh, const std::string &url);
 
-    void set_error_buffer(CURL *ceh, char *error_buffer);
+void set_error_buffer(CURL *ceh, char *error_buffer);
 
-    void unset_error_buffer(CURL *ceh);
+void unset_error_buffer(CURL *ceh);
 
-    void eval_curl_easy_setopt_result(
-            CURLcode result,
-            std::string msg_base,
-            std::string opt_name,
-            char *ebuf, std::string file,
-            unsigned int line );
+void eval_curl_easy_setopt_result(CURLcode result,
+                                  std::string msg_base,
+                                  std::string opt_name,
+                                  char *ebuf, std::string file,
+                                  unsigned int line);
 
+bool eval_curl_easy_perform_code(CURL *ceh,
+                                 std::string url,
+                                 CURLcode curl_code,
+                                 char *error_buffer,
+                                 unsigned int attempt);
 
-    bool eval_curl_easy_perform_code(
-            CURL *ceh,
-            std::string url,
-            CURLcode curl_code,
-            char *error_buffer,
-            unsigned int attempt );
+bool eval_http_get_response(CURL *ceh, char *error_buffer, const std::string &requested_url);
 
-    bool eval_http_get_response(CURL *ceh, char *error_buffer, const std::string &requested_url);
+void super_easy_perform(CURL *ceh);
 
-    void super_easy_perform(CURL *ceh);
+std::string get_effective_url(CURL *ceh, std::string requested_url);
 
-    std::string get_effective_url(CURL *ceh, std::string requested_url);
+std::string get_range_arg_string(const unsigned long long &offset, const unsigned long long &size);
 
-    std::string get_range_arg_string(const unsigned long long &offset, const unsigned long long &size);
+std::string http_status_to_string(int status);
 
-    std::string http_status_to_string(int status);
+std::string error_message(CURLcode response_code, char *error_buf);
 
-    std::string error_message(CURLcode response_code, char *error_buf);
+size_t c_write_data(void *buffer, size_t size, size_t nmemb, void *data);
 
-    size_t c_write_data(void *buffer, size_t size, size_t nmemb, void *data);
+void read_data(CURL *c_handle);
 
-
-    void read_data(CURL *c_handle);
-
-    curl_slist *add_auth_headers(struct curl_slist *request_headers);
-
-
+curl_slist *add_auth_headers(struct curl_slist *request_headers);
 } // namespace curl
 
 #endif /*  _bes_http_CURL_UTILS_H_ */

--- a/modules/dmrpp_module/Chunk.cc
+++ b/modules/dmrpp_module/Chunk.cc
@@ -71,8 +71,7 @@ const std::string Chunk::tracking_context = "cloudydap";
  * @param data Pointer to the user data, configured using
  * @return The number of bytes read
  */
-size_t chunk_header_callback(char *buffer, size_t /*size*/, size_t nitems, void *data)
-{
+size_t chunk_header_callback(char *buffer, size_t /*size*/, size_t nitems, void *data) {
     // received header is nitems * size long in 'buffer' NOT ZERO TERMINATED
     // 'userdata' is set with CURLOPT_HEADERDATA
     // 'size' is always 1
@@ -84,8 +83,8 @@ size_t chunk_header_callback(char *buffer, size_t /*size*/, size_t nitems, void 
     string::size_type pos;
     if ((pos = header.find("Content-Type")) != string::npos) {
         // Header format 'Content-Type: <value>'
-        Chunk *c_ptr = reinterpret_cast<Chunk*>(data);
-        c_ptr->set_response_content_type(header.substr(header.find_last_of(' ')+1));
+        Chunk *c_ptr = reinterpret_cast<Chunk *>(data);
+        c_ptr->set_response_content_type(header.substr(header.find_last_of(' ') + 1));
     }
 
     return nitems;
@@ -104,12 +103,12 @@ size_t chunk_header_callback(char *buffer, size_t /*size*/, size_t nitems, void 
  * @param data Pointer to this
  * @return The number of bytes read
  */
-size_t chunk_write_data(void *buffer, size_t size, size_t nmemb, void *data)
-{
+size_t chunk_write_data(void *buffer, size_t size, size_t nmemb, void *data) {
     size_t nbytes = size * nmemb;
-    Chunk *chunk = reinterpret_cast<Chunk*>(data);
+    Chunk *chunk = reinterpret_cast<Chunk *>(data);
 
-    BESDEBUG(MODULE, prolog << "BEGIN chunk->get_response_content_type():" << chunk->get_response_content_type() << " chunk->get_data_url(): " << chunk->get_data_url() << endl);
+    BESDEBUG(MODULE, prolog << "BEGIN chunk->get_response_content_type():" << chunk->get_response_content_type()
+                            << " chunk->get_data_url(): " << chunk->get_data_url() << endl);
 
     // When Content-Type is 'application/xml,' that's an error. jhrg 6/9/20
     if (chunk->get_response_content_type().find("application/xml") != string::npos) {
@@ -124,7 +123,7 @@ size_t chunk_write_data(void *buffer, size_t size, size_t nmemb, void *data)
             string json_message = xml2json(xml_message.c_str());
             stringstream aws_msg;
             aws_msg << prolog << "AWS S3 Access Error:" << json_message;
-            BESDEBUG(MODULE,aws_msg.str() << endl);
+            BESDEBUG(MODULE, aws_msg.str() << endl);
             VERBOSE(aws_msg.str() << endl);
 
             rapidjson::Document d;
@@ -136,13 +135,13 @@ size_t chunk_write_data(void *buffer, size_t size, size_t nmemb, void *data)
             // are not good enough. But the "Code" is not really suitable for normal humans...
             // jhrg 12/31/19
             stringstream msg;
-            msg << prolog << "Error accessing object store data. (Tried: " << chunk->get_data_url().append(")") <<
+            msg << prolog << "Error accessing object store data. (Tried: " << chunk->get_data_url() << ")" <<
                 " Message " << message.GetString();
-            BESDEBUG(MODULE,msg.str() << endl);
-            if (string(code.GetString()) == "AccessDenied"){
+            BESDEBUG(MODULE, msg.str() << endl);
+            if (string(code.GetString()) == "AccessDenied") {
                 throw BESForbiddenError(msg.str(), __FILE__, __LINE__);
             }
-            else{
+            else {
                 throw BESInternalError(msg.str(), __FILE__, __LINE__);
             }
         }
@@ -151,11 +150,11 @@ size_t chunk_write_data(void *buffer, size_t size, size_t nmemb, void *data)
             // of std::exception as it should be. jhrg 12/30/19
             throw;
         }
-        catch(std::exception &e) {
+        catch (std::exception &e) {
             stringstream msg;
-            msg << prolog << "Error accessing object store data. (Tried: " << chunk->get_data_url().append(")") <<
-            " Message " << e.what();
-            BESDEBUG(MODULE,msg.str() << endl);
+            msg << prolog << "Error accessing object store data. (Tried: " << chunk->get_data_url() << ")" <<
+                " Message " << e.what();
+            BESDEBUG(MODULE, msg.str() << endl);
             throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
         }
     }
@@ -173,13 +172,13 @@ size_t chunk_write_data(void *buffer, size_t size, size_t nmemb, void *data)
             << nbytes << " is larger than the target buffer size: " << chunk->get_rbuf_size();
         BESDEBUG(MODULE, msg.str() << endl);
         DmrppRequestHandler::curl_handle_pool->release_all_handles();
-        throw BESInternalError(msg.str(),__FILE__,__LINE__);
+        throw BESInternalError(msg.str(), __FILE__, __LINE__);
     }
 
     memcpy(chunk->get_rbuf() + bytes_read, buffer, nbytes);
     chunk->set_bytes_read(bytes_read + nbytes);
 
-    BESDEBUG(MODULE, prolog << "END" << endl );
+    BESDEBUG(MODULE, prolog << "END" << endl);
 
     return nbytes;
 }
@@ -194,8 +193,7 @@ size_t chunk_write_data(void *buffer, size_t size, size_t nmemb, void *data)
  * @param src Compressed data
  * @param src_len Size of the compressed data
  */
-void inflate(char *dest, unsigned int dest_len, char *src, unsigned int src_len)
-{
+void inflate(char *dest, unsigned int dest_len, char *src, unsigned int src_len) {
     /* Sanity check */
     assert(src_len > 0);
     assert(src);
@@ -236,9 +234,10 @@ void inflate(char *dest, unsigned int dest_len, char *src, unsigned int src_len)
              * this handler, we always know the size of the uncompressed chunk.
              */
             if (0 == z_strm.avail_out) {
-                throw BESError("Data buffer is not big enough for uncompressed data.", BES_INTERNAL_ERROR, __FILE__, __LINE__);
+                throw BESError("Data buffer is not big enough for uncompressed data.", BES_INTERNAL_ERROR, __FILE__,
+                               __LINE__);
 #if 0
-                /* Here's how to extend the buffer if needed. This might be useful someday... */
+                /* Here's how to extend the buffer if needed. This might be useful some day... */
                 void *new_outbuf; /* Pointer to new output buffer */
 
                 /* Allocate a buffer twice as big */
@@ -288,17 +287,16 @@ void inflate(char *dest, unsigned int dest_len, char *src, unsigned int src_len)
  * @param src_size Number of bytes in both src and dest
  * @param width Number of bytes in an element
  */
-void unshuffle(char *dest, const char *src, unsigned int src_size, unsigned int width)
-{
+void unshuffle(char *dest, const char *src, unsigned int src_size, unsigned int width) {
     unsigned int elems = src_size / width;  // int division rounds down
 
     /* Don't do anything for 1-byte elements, or "fractional" elements */
     if (!(width > 1 && elems > 1)) {
-        memcpy(dest, const_cast<char*>(src), src_size);
+        memcpy(dest, const_cast<char *>(src), src_size);
     }
     else {
         /* Get the pointer to the source buffer (Alias for source buffer) */
-        char *_src = const_cast<char*>(src);
+        char *_src = const_cast<char *>(src);
         char *_dest = 0;   // Alias for destination buffer
 
         /* Input; unshuffle */
@@ -316,30 +314,30 @@ void unshuffle(char *dest, const char *src, unsigned int src_size, unsigned int 
             {
                 size_t duffs_index = (elems + 7) / 8;   /* Counting index for Duff's device */
                 switch (elems % 8) {
-                default:
-                    assert(0 && "This Should never be executed!");
-                    break;
-                case 0:
-                    do {
-                        // This macro saves repeating the same line 8 times
+                    default:
+                        assert(0 && "This Should never be executed!");
+                        break;
+                    case 0:
+                        do {
+                            // This macro saves repeating the same line 8 times
 #define DUFF_GUTS       *_dest = *_src++; _dest += width;
 
-                        DUFF_GUTS
-                        case 7:
-                        DUFF_GUTS
-                        case 6:
-                        DUFF_GUTS
-                        case 5:
-                        DUFF_GUTS
-                        case 4:
-                        DUFF_GUTS
-                        case 3:
-                        DUFF_GUTS
-                        case 2:
-                        DUFF_GUTS
-                        case 1:
-                        DUFF_GUTS
-                    } while (--duffs_index > 0);
+                            DUFF_GUTS
+                            case 7:
+                            DUFF_GUTS
+                            case 6:
+                            DUFF_GUTS
+                            case 5:
+                            DUFF_GUTS
+                            case 4:
+                            DUFF_GUTS
+                            case 3:
+                            DUFF_GUTS
+                            case 2:
+                            DUFF_GUTS
+                            case 1:
+                            DUFF_GUTS
+                        } while (--duffs_index > 0);
                 } /* end switch */
             } /* end block */
 #endif /* DUFFS_DEVICE */
@@ -353,7 +351,7 @@ void unshuffle(char *dest, const char *src, unsigned int src_size, unsigned int 
         if (leftover > 0) {
             /* Adjust back to end of shuffled bytes */
             _dest -= (width - 1); /*lint !e794 _dest is initialized */
-            memcpy((void*) _dest, (void*) _src, leftover);
+            memcpy((void *) _dest, (void *) _src, leftover);
         }
     } /* end if width and elems both > 1 */
 }
@@ -371,8 +369,7 @@ void unshuffle(char *dest, const char *src, unsigned int src_size, unsigned int 
  *
  * @param pia The chunk position string. Syntax parsed: "[1,2,3,4]"
  */
-void Chunk::set_position_in_array(const string &pia)
-{
+void Chunk::set_position_in_array(const string &pia) {
     if (pia.empty()) return;
 
     if (d_chunk_position_in_array.size()) d_chunk_position_in_array.clear();
@@ -385,12 +382,12 @@ void Chunk::set_position_in_array(const string &pia)
     if (pia.find_first_not_of("[]1234567890,") != string::npos)
         throw BESInternalError("while parsing a DMR++, chunk position string illegal character(s)", __FILE__, __LINE__);
 
-    // string off []; iss holds x,y,...,z
-    istringstream iss(pia.substr(1, pia.length()-2));
+    // strip off []; iss holds x,y,...,z
+    istringstream iss(pia.substr(1, pia.length() - 2));
 
     char c;
     unsigned int i;
-    while (!iss.eof() ) {
+    while (!iss.eof()) {
         iss >> i; // read an integer
         d_chunk_position_in_array.push_back(i);
         iss >> c; // read a separator (,)
@@ -405,8 +402,7 @@ void Chunk::set_position_in_array(const string &pia)
  * @see Chunk::set_position_in_array(const string &pia)
  * @param pia A vector of unsigned ints.
  */
-void Chunk::set_position_in_array(const std::vector<unsigned int> &pia)
-{
+void Chunk::set_position_in_array(const std::vector<unsigned int> &pia) {
     if (pia.size() == 0) return;
 
     if (d_chunk_position_in_array.size()) d_chunk_position_in_array.clear();
@@ -421,9 +417,8 @@ void Chunk::set_position_in_array(const std::vector<unsigned int> &pia)
  * for this byteStream.
  *
  */
-string Chunk::get_curl_range_arg_string()
-{
-    return curl::get_range_arg_string(d_offset,d_size);
+string Chunk::get_curl_range_arg_string() {
+    return curl::get_range_arg_string(d_offset, d_size);
 }
 
 /**
@@ -437,8 +432,7 @@ string Chunk::get_curl_range_arg_string()
  *
  * @note This is only added to data URLs that reference S3.
  */
-void Chunk::add_tracking_query_param()
-{
+void Chunk::add_tracking_query_param() {
     /** - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
      * Cloudydap test hack where we tag the S3 URLs with a query string for the S3 log
      * in order to track S3 requests. The tag is submitted as a BESContext with the
@@ -507,8 +501,7 @@ void *inflate_chunk(void *arg_list)
  * @param chunk_size The _expected_ chunk size, in elements; used to allocate storage
  * @param elem_width The number of bytes per element
  */
-void Chunk::inflate_chunk(bool deflate, bool shuffle, unsigned int chunk_size, unsigned int elem_width)
-{
+void Chunk::inflate_chunk(bool deflate, bool shuffle, unsigned int chunk_size, unsigned int elem_width) {
     // This code is pretty naive - there are apparently a number of
     // different ways HDF5 can compress data, and it does also use a scheme
     // where several algorithms can be applied in sequence. For now, get
@@ -576,8 +569,7 @@ void Chunk::inflate_chunk(bool deflate, bool shuffle, unsigned int chunk_size, u
  * @param chunk_size
  * @param elem_width
  */
-void Chunk::read_chunk()
-{
+void Chunk::read_chunk() {
     if (d_is_read) {
         BESDEBUG(MODULE, prolog << "Already been read! Returning." << endl);
         return;
@@ -612,10 +604,9 @@ void Chunk::read_chunk()
  *  std::vector<unsigned int> d_chunk_position_in_array;
  *
  */
-void Chunk::dump(ostream &oss) const
-{
+void Chunk::dump(ostream &oss) const {
     oss << "Chunk";
-    oss << "[ptr='" << (void *)this << "']";
+    oss << "[ptr='" << (void *) this << "']";
     oss << "[data_url='" << d_data_url << "']";
     oss << "[offset=" << d_offset << "]";
     oss << "[size=" << d_size << "]";
@@ -629,22 +620,20 @@ void Chunk::dump(ostream &oss) const
     oss << "[is_inflated=" << d_is_inflated << "]";
 }
 
-string Chunk::to_string() const
-{
+string Chunk::to_string() const {
     std::ostringstream oss;
     dump(oss);
     return oss.str();
 }
 
 
-std::string Chunk::get_data_url() const
-{
+std::string Chunk::get_data_url() const {
     string data_url = d_data_url;
 
     http::url *effective_url = EffectiveUrlCache::TheCache()->get_effective_url(d_data_url);
-    BESDEBUG(MODULE, prolog << "The EffectiveUrlCache" << (effective_url?" contains ":" does not contain ") <<
-    "the d_data_url: " << d_data_url << endl);
-    if(effective_url){
+    BESDEBUG(MODULE, prolog << "The EffectiveUrlCache" << (effective_url ? " contains " : " does not contain ") <<
+                            "the d_data_url: " << d_data_url << endl);
+    if (effective_url) {
         data_url = effective_url->str();
     }
     BESDEBUG(MODULE, prolog << "Using data_url: " << data_url << endl);
@@ -668,7 +657,6 @@ std::string Chunk::get_data_url() const
 
     }
     BESDEBUG(MODULE, prolog << "Using data_url: " << data_url << endl);
-
 #endif
 
     // A conditional call to void Chunk::add_tracking_query_param()
@@ -679,7 +667,6 @@ std::string Chunk::get_data_url() const
 
     return data_url;
 }
-
 
 } // namespace dmrpp
 

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -32,10 +32,6 @@
 
 #include <curl/curl.h>
 
-#if HAVE_CURL_MULTI_H
-#include <curl/multi.h>
-#endif
-
 #include "CurlUtils.h"
 
 #include <time.h>
@@ -46,7 +42,6 @@
 #include "BESDebug.h"
 #include "BESInternalError.h"
 #include "BESForbiddenError.h"
-// #include "TheBESKeys.h"
 #include "AllowedHosts.h"
 
 #include "DmrppRequestHandler.h"
@@ -70,11 +65,7 @@ static const unsigned int retry_limit = 10; // Amazon's suggestion
 static const useconds_t uone_second = 1000 * 1000; // one second, in microseconds
 
 namespace dmrpp {
-#if HAVE_CURL_MULTI_API
-const bool have_curl_multi_api = true;
-#else
 const bool have_curl_multi_api = false;
-#endif
 }
 
 using namespace dmrpp;
@@ -182,21 +173,12 @@ int curl_trace(CURL */*handle*/, curl_infotype type, char *data, size_t /*size*/
         case CURLINFO_HEADER_IN:
             LOG("libcurl == Recv header: " << text << endl);
             break;
-#if 0
+
         // Only print these if we're desperate and the above code has been hacked to match
         case CURLINFO_DATA_OUT:
-            LOG("libcurl == Send data" << text << endl);
-            break;
         case CURLINFO_SSL_DATA_OUT:
-            LOG("libcurl == Send SSL data" << text << endl);
-            break;
         case CURLINFO_DATA_IN:
-            LOG("libcurl == Recv data" << text << endl);
-            break;
         case CURLINFO_SSL_DATA_IN:
-            LOG("libcurl == Recv SSL data" << text << endl);
-            break;
-#endif
         default:
             break;
      }
@@ -204,64 +186,6 @@ int curl_trace(CURL */*handle*/, curl_infotype type, char *data, size_t /*size*/
      return 0;
 }
 #endif
-
-
-#if 0
-dmrpp_easy_handle::dmrpp_easy_handle() : d_request_headers(0) {
-    vector<string> d_response_headers;
-    string target_url="foo";
-
-    d_handle = curl::init();
-
-    if (!d_handle) throw BESInternalError("Could not allocate CURL handle", __FILE__, __LINE__);
-
-    CURLcode res;
-
-    curl::set_error_buffer(d_handle, d_errbuf);
-
-#if CURL_VERBOSE
-    res = curl_easy_setopt(d_handle, CURLOPT_DEBUGFUNCTION, curl_trace);
-     curl::eval_curl_easy_setopt_result(res, prolog, "CURLOPT_DEBUGFUNCTION", d_errbuf, __FILE__, __LINE__);
-    // Many tests fail with this option, but it's still useful to see how connections
-    // are treated. jhrg 10/2/18
-    res = curl_easy_setopt(d_handle, CURLOPT_VERBOSE, 1L);
-    curl::eval_curl_easy_setopt_result(res, prolog, "CURLOPT_VERBOSE", d_errbuf, __FILE__, __LINE__);
-#endif
-
-    res = curl_easy_setopt(d_handle, CURLOPT_HEADERFUNCTION, chunk_header_callback);
-    curl::eval_curl_easy_setopt_result(res, prolog, "CURLOPT_HEADERFUNCTION", d_errbuf, __FILE__, __LINE__);
-
-    // Pass all data to the 'write_data' function
-    res = curl_easy_setopt(d_handle, CURLOPT_WRITEFUNCTION, chunk_write_data);
-    curl::eval_curl_easy_setopt_result(res, prolog, "CURLOPT_WRITEFUNCTION", d_errbuf, __FILE__, __LINE__);
-
-#ifdef CURLOPT_TCP_KEEPALIVE
-    /* enable TCP keep-alive for this transfer */
-    res = curl_easy_setopt(d_handle, CURLOPT_TCP_KEEPALIVE, 1L);
-    curl::eval_curl_easy_setopt_result(res, prolog, "CURLOPT_TCP_KEEPALIVE", d_errbuf, __FILE__, __LINE__);
-#endif
-
-#ifdef CURLOPT_TCP_KEEPIDLE
-    /* keep-alive idle time to 120 seconds */
-     res = curl_easy_setopt(d_handle, CURLOPT_TCP_KEEPIDLE, 120L);
-    curl::eval_curl_easy_setopt_result(res, prolog, "CURLOPT_TCP_KEEPIDLE", d_errbuf, __FILE__, __LINE__);
-#endif
-
-#ifdef CURLOPT_TCP_KEEPINTVL
-    /* interval time between keep-alive probes: 120 seconds */
-    res = curl_easy_setopt(d_handle, CURLOPT_TCP_KEEPINTVL, 120L)
-    curl::eval_curl_easy_setopt_result(res, prolog, "CURLOPT_TCP_KEEPINTVL", d_errbuf, __FILE__, __LINE__);
-#endif
-
-    d_in_use = false;
-    d_url = "";
-    d_chunk = 0;
-
-    curl::unset_error_buffer(d_handle);
-
-}
-
-#else
 
 dmrpp_easy_handle::dmrpp_easy_handle() : d_request_headers(0) {
     d_handle = curl_easy_init();
@@ -272,12 +196,12 @@ dmrpp_easy_handle::dmrpp_easy_handle() : d_request_headers(0) {
     curl::set_error_buffer(d_handle, d_errbuf);
 
 #if CURL_VERBOSE
-     res = curl_easy_setopt(d_handle, CURLOPT_DEBUGFUNCTION, curl_trace);
-     curl::check_setopt_result(res, prolog, "CURLOPT_DEBUGFUNCTION", d_errbuf, __FILE__, __LINE__);
-    // Many tests fail with this option, but it's still useful to see how connections
-    // are treated. jhrg 10/2/18
-    res = curl_easy_setopt(d_handle, CURLOPT_VERBOSE, 1L);
-    curl::check_setopt_result(res, prolog, "CURLOPT_VERBOSE", d_errbuf, __FILE__, __LINE__);
+    res = curl_easy_setopt(d_handle, CURLOPT_DEBUGFUNCTION, curl_trace);
+    curl::check_setopt_result(res, prolog, "CURLOPT_DEBUGFUNCTION", d_errbuf, __FILE__, __LINE__);
+   // Many tests fail with this option, but it's still useful to see how connections
+   // are treated. jhrg 10/2/18
+   res = curl_easy_setopt(d_handle, CURLOPT_VERBOSE, 1L);
+   curl::check_setopt_result(res, prolog, "CURLOPT_VERBOSE", d_errbuf, __FILE__, __LINE__);
 #endif
 
     res = curl_easy_setopt(d_handle, CURLOPT_HEADERFUNCTION, chunk_header_callback);
@@ -309,7 +233,6 @@ dmrpp_easy_handle::dmrpp_easy_handle() : d_request_headers(0) {
     d_url = "";
     d_chunk = 0;
 }
-#endif
 
 dmrpp_easy_handle::~dmrpp_easy_handle() {
     if (d_handle) curl_easy_cleanup(d_handle);
@@ -317,6 +240,7 @@ dmrpp_easy_handle::~dmrpp_easy_handle() {
 }
 
 #if NEW_WAY
+
 /**
  * @brief This is the read_data() method for serial transfers.
  *
@@ -326,22 +250,16 @@ dmrpp_easy_handle::~dmrpp_easy_handle() {
 void dmrpp_easy_handle::read_data() {
     // Treat HTTP/S requests specially; retry some kinds of failures.
     if (d_url.find("https://") == 0 || d_url.find("http://") == 0) {
-
         curl::super_easy_perform(d_handle);
-
-        // FIXME I think this should only happen in the destructor in order
-        //  to insure that retrying the dmrpp_easy_handle doesn't meet with the troubles.
-        //curl_slist_free_all(d_request_headers);
-        //d_request_headers = 0;
     }
     else {
         CURLcode curl_code = curl_easy_perform(d_handle);
         if (CURLE_OK != curl_code) {
             string msg = prolog + "ERROR - Data transfer error: ";
-            throw BESInternalError(msg.append(curl::error_message(curl_code, d_errbuf)),
-                                   __FILE__, __LINE__);
+            throw BESInternalError(msg.append(curl::error_message(curl_code, d_errbuf)), __FILE__, __LINE__);
         }
     }
+
     d_chunk->set_is_read(true);
 }
 
@@ -409,66 +327,7 @@ void dmrpp_easy_handle::read_data() {
 }
 #endif
 
-/**
- * The implementation of the dmrpp_multi_handle field. It can be either
- * a CURLM* or a vector of dmrpp_easy_handle*, depending on whether libcurl
- * has the CULRM* interface.
- *
- * @note This uses the pimpl pattern.
- */
-struct dmrpp_multi_handle::multi_handle {
-#if HAVE_CURL_MULTI_API
-    CURLM *curlm;
-#else
-    std::vector<dmrpp_easy_handle *> ehandles;
-#endif
-};
-
-dmrpp_multi_handle::dmrpp_multi_handle() {
-    p_impl = new multi_handle;
-#if HAVE_CURL_MULTI_API
-    p_impl->curlm = curl_multi_init();
-#endif
-}
-
-dmrpp_multi_handle::~dmrpp_multi_handle() {
-#if HAVE_CURL_MULTI_API
-    curl_multi_cleanup(p_impl->curlm);
-#endif
-    delete p_impl;
-}
-
-/**
- * @brief Add an Easy Handle to a Multi Handle object.
- *
- * @note It is the responsibility of the caller to make sure there are not
- * too many handles added to the 'multi handle' object.
- *
- * @param eh The CURL easy handle to add
- */
-void dmrpp_multi_handle::add_easy_handle(dmrpp_easy_handle *eh) {
-#if HAVE_CURL_MULTI_API
-    curl_multi_add_handle(p_impl->curlm, eh->d_handle);
-#else
-    p_impl->ehandles.push_back(eh);
-#endif
-}
-
-void dmrpp_multi_handle::remove_easy_handle(dmrpp_easy_handle *eh) {
-#if HAVE_CURL_MULTI_API
-    CURLMcode mres = curl_multi_remove_handle(p_impl->curlm, eh);
-    if (mres != CURLM_OK)
-        LOG("While cleaning up CURL multihandle during a parallel data request, could not remove a CURL handle.");
-#else
-    for (vector<dmrpp_easy_handle *>::iterator i = p_impl->ehandles.begin(), e = p_impl->ehandles.end(); i != e; ++i) {
-        if (eh == *i) {
-            p_impl->ehandles.erase(i);
-            break;
-        }
-    }
-#endif
-}
-
+#if 0
 // This is only used if we don't have the Multi API and have to use pthreads.
 // It is a callback used in dmrpp_multi_handle::read_data() below.
 // jhrg 8/27/18
@@ -488,166 +347,10 @@ static void *easy_handle_read_data(void *handle) {
 }
 
 #endif
-
-/**
- * @brief The read_data() method for parallel transfers
- *
- * This uses either the CURL Multi API or pthreads to read N
- * dmrpp_easy_handle instances in parallel.
- *
- * @todo This has to be fixed to restart 500 HTTP errors and to clean up
- * after threads if there's an exception.
- *
- * @note It's the responsibility of the caller to make sure that no more than
- * d_max_parallel_transfers are added to the 'multi' handle.
- */
-void dmrpp_multi_handle::read_data() {
-#if HAVE_CURL_MULTI_API
-    useconds_t retry_time = uone_second/4;
-    // Use the libcurl Multi API here. Alternate version follows...
-    try {
-        int still_running = 0;
-        CURLMcode mres = curl_multi_perform(p_impl->curlm, &still_running);
-        if (mres != CURLM_OK)
-            throw BESInternalError(string("ERROR - Could not initiate data read: ").append(curl_multi_strerror(mres)), __FILE__,
-                __LINE__);
-
-        do {
-            int numfds = 0;
-            mres = curl_multi_wait(p_impl->curlm, NULL, 0, MAX_WAIT_MSECS, &numfds);
-            if (mres != CURLM_OK)
-                throw BESInternalError(string("ERROR - Could not wait on data read: ").append(curl_multi_strerror(mres)), __FILE__,
-                    __LINE__);
-
-            mres = curl_multi_perform(p_impl->curlm, &still_running);
-            if (mres != CURLM_OK)
-                throw BESInternalError(string("ERROR - Could not iterate data read: ").append(curl_multi_strerror(mres)), __FILE__,
-                    __LINE__);
-
-        } while (still_running);
-
-        CURLcode res;
-        CURLMsg *msg = 0;
-        int msgs_left = 0;
-        char empty[1]; // TODO Replace this with the actual error buffer that's in use in the CURL handle msg->easy_handle
-        empty[0] = 0;
-        while ((msg = curl_multi_info_read(p_impl->curlm, &msgs_left))) {
-            if (msg->msg == CURLMSG_DONE) {
-                CURL *eh = msg->easy_handle;
-
-                // Note: 'eh' is the easy handle returned by curl_multi_info_read(),
-                // but in it's private field is our dmrpp_easy_handle object. We need
-                // both to mark this data read operation as complete.
-                dmrpp_easy_handle *deh = 0;
-                res = curl_easy_getinfo(eh, CURLINFO_PRIVATE, &deh);
-                if (res != CURLE_OK)
-                    throw BESInternalError(string(prolog + "ERROR - Could not access easy handle: ").append(curl::error_message(res,empty)), __FILE__, __LINE__);
-
-                res = msg->data.result;
-                if (res != CURLE_OK)
-                    throw BESInternalError(string(prolog + "ERROR - cURL request failed. Message: ").append(curl::error_message(res,deh->d_errbuf)), __FILE__, __LINE__);
-
-
-                // This code has to work with both http/s: and file: protocols. Here we check the
-                // HTTP status code. If the protocol is not HTTP, we assume since msg->data.result
-                // returned CURLE_OK, that the transfer worked. jhrg 5/1/18
-                if (deh->d_url.find("http://") == 0 || deh->d_url.find("https://") == 0) {
-                    bool success;
-                    success = curl::eval_http_get_response(eh, deh->d_errbuf, deh->d_url);
-                    if (!success) {
-                        stringstream msg;
-                        msg <<  prolog << "ERROR - Data transfer error: " << curl::error_message(res,deh->d_errbuf) << endl;
-                        LOG(msg.str());
-                        throw BESInternalError(msg.str(), __FILE__, __LINE__);
-                    }
-                }
-
-                // If we are here, the request was successful.
-                deh->d_chunk->set_is_read(true);  // Set the is_read() property for chunk here.
-
-                // NB: Remove the handle from the CURLM* and _then_ call release_handle()
-                // so that the KEEP_ALIVE 0 (off) works. Calling delete on the dmrpp_easy_handle
-                // will invalidate 'eh', so call that after removing 'eh'.
-                mres = curl_multi_remove_handle(p_impl->curlm, eh);
-                if (mres != CURLM_OK)
-                    throw BESInternalError(string("ERROR - Could not remove libcurl handle: ").append(curl_multi_strerror(mres)),  __FILE__, __LINE__);
-
-                DmrppRequestHandler::curl_handle_pool->release_handle(deh);
-            }
-            else {  // != CURLMSG_DONE
-                throw BESInternalError("ERROR - getting HTTP or FILE responses.", __FILE__, __LINE__);
-            }
-        }
-    }
-    catch (...) {
-        // If we throw here, remove all of the easy handles from this multihandle
-        // That will prevent old URLs part that were part of a failed request from
-        // being part of a subsequent request.
-        // With C++11 this could be for (auto &i: DmrppRequestHandler::curl_handle_pool->d_easy_handles) { ... }
-        for (std::vector<dmrpp_easy_handle *>::iterator i = DmrppRequestHandler::curl_handle_pool->d_easy_handles.begin(),
-                e = DmrppRequestHandler::curl_handle_pool->d_easy_handles.end(); i != e; ++i) {
-            CURLMcode mres = curl_multi_remove_handle(p_impl->curlm, (*i)->d_handle);
-            if (mres != CURLM_OK)
-                LOG("ERROR - While cleaning up from an error during a parallel data request, could not remove a CURL handle." << endl);
-            DmrppRequestHandler::curl_handle_pool->release_handle(*i);
-        }
-
-        throw;  // re-throw the exception
-    }
-#else
-    // Start the processing pipelines using pthreads - there is no Multi API
-
-    pthread_t threads[p_impl->ehandles.size()];
-    unsigned int num_threads = 0;
-    try {
-        for (unsigned int i = 0; i < p_impl->ehandles.size(); ++i) {
-            int status = pthread_create(&threads[i], NULL, easy_handle_read_data, (void *) p_impl->ehandles[i]);
-            if (status == 0) {
-                ++num_threads;
-            }
-            else {
-                ostringstream oss("Could not start process_one_chunk_unconstrained thread for chunk ", std::ios::ate);
-                oss << i << ": " << strerror(status);
-                throw BESInternalError(oss.str(), __FILE__, __LINE__);
-            }
-        }
-
-        // Now join the child threads.
-        for (unsigned int i = 0; i < num_threads; ++i) {
-            string *error;
-            int status = pthread_join(threads[i], (void **) &error);
-            if (status != 0) {
-                ostringstream oss("Could not join process_one_chunk_unconstrained thread for chunk ", std::ios::ate);
-                oss << i << ": " << strerror(status);
-                throw BESInternalError(oss.str(), __FILE__, __LINE__);
-            }
-            else if (error != 0) {
-                BESInternalError e(*error, __FILE__, __LINE__);
-                delete error;
-                throw e;
-            }
-        }
-        // Now remove the easy_handles, mimicking the behavior when using the real Multi API
-        p_impl->ehandles.clear();
-    }
-    catch (...) {
-        // Returning all the easy handles to the pool is handled for the 'no HAVE_CURL_MULTI_API
-        // case in Chunk's chunk_write_data() libcurl callback.
-        DmrppRequestHandler::curl_handle_pool->release_all_handles();
-
-        // Now remove the easy_handles, mimicking the behavior when using the real Multi API
-        p_impl->ehandles.clear();
-
-        join_threads(threads, num_threads);
-
-        throw;
-    }
 #endif
-}
 
-CurlHandlePool::CurlHandlePool() : d_multi_handle(0) {
+CurlHandlePool::CurlHandlePool() {
     d_max_easy_handles = DmrppRequestHandler::d_max_parallel_transfers;
-    d_multi_handle = new dmrpp_multi_handle();
 
     for (unsigned int i = 0; i < d_max_easy_handles; ++i) {
         d_easy_handles.push_back(new dmrpp_easy_handle());
@@ -743,7 +446,7 @@ CurlHandlePool::get_easy_handle(Chunk *chunk) {
         res = curl_easy_setopt(handle->d_handle, CURLOPT_COOKIEFILE, curl::get_cookie_filename().c_str());
         curl::eval_curl_easy_setopt_result(res, prolog, "CURLOPT_COOKIEFILE", handle->d_errbuf, __FILE__, __LINE__);
 
-        res  = curl_easy_setopt(handle->d_handle, CURLOPT_COOKIEJAR, curl::get_cookie_filename().c_str());
+        res = curl_easy_setopt(handle->d_handle, CURLOPT_COOKIEJAR, curl::get_cookie_filename().c_str());
         curl::eval_curl_easy_setopt_result(res, prolog, "CURLOPT_COOKIEJAR", handle->d_errbuf, __FILE__, __LINE__);
 
         // Follow 302 (redirect) responses

--- a/modules/dmrpp_module/CurlHandlePool.h
+++ b/modules/dmrpp_module/CurlHandlePool.h
@@ -129,17 +129,17 @@ public:
  * parallel transfer fails and an exception is thrown taking the flow of
  * control out of the handler to the command processor loop.
  */
-class SwinLane {
+class SwimLane {
     CurlHandlePool &d_pool;
     std::vector<dmrpp_easy_handle *> d_handles;
 public:
-    SwinLane(CurlHandlePool &pool) : d_pool(pool) {}
+    SwimLane(CurlHandlePool &pool) : d_pool(pool) {}
 
-    SwinLane(CurlHandlePool &pool, dmrpp_easy_handle *h) : d_pool(pool) {
+    SwimLane(CurlHandlePool &pool, dmrpp_easy_handle *h) : d_pool(pool) {
         d_handles.push_back(h);
     }
 
-    virtual ~SwinLane() {
+    virtual ~SwimLane() {
         for(auto i = d_handles.begin(), e = d_handles.end(); i != e; ++i) {
             d_pool.release_handle(*i);
         }

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -1104,15 +1104,6 @@ void DmrppArray::read_chunks()
         }
     }
     else {
-#if 0
-        // temporary version
-        while (chunks_to_read.size() > 0) {
-            Chunk *chunk = chunks_to_read.front();
-            chunks_to_read.pop();
-
-            process_one_chunk(chunk, this, array_shape);
-        }
-#endif
         // Parallel version based on read_chunks_unconstrained(). There is
         // substantial duplication of the code in read_chunks_unconstrained(), but
         // wait to remove that when we move to C++11 which has threads integrated.


### PR DESCRIPTION
This refactor removes the last bits of the curl multi handle API. The parallel access is now always handled by pthreads. The code also contains the start of a RAII class for the dmrpp_easy_handle code. It's not used, but the class will be part of the build - just to see if the compilers barf.