### PR TITLE
Retriever tests

### DIFF
--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -1766,7 +1766,7 @@ curl_slist *append_http_header(curl_slist *slist, const string &header_name, con
     full_header.append(": ").append(value);
 
     BESDEBUG(MODULE, prolog << full_header << endl);
-    std::cerr << prolog << full_header << endl;
+    // std::cerr << prolog << full_header << endl;
 
     struct curl_slist *temp = curl_slist_append(slist, full_header.c_str());
     if (!temp){

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -1759,7 +1759,7 @@ unsigned long max_redirects() {
  * @param value The value
  * @return The modified slist pointer or nullptr if an error occurred.
  */
-struct curl_slist *append_http_header(curl_slist *slist, const string &header_name, const string &value)
+curl_slist *append_http_header(curl_slist *slist, const string &header_name, const string &value)
 {
 
     string full_header = header_name;

--- a/http/CurlUtils.h
+++ b/http/CurlUtils.h
@@ -104,9 +104,9 @@ size_t c_write_data(void *buffer, size_t size, size_t nmemb, void *data);
 
 void read_data(CURL *c_handle);
 
-struct curl_slist *append_http_header(curl_slist *slist, const std::string &header_name, const std::string &value);
+curl_slist *append_http_header(curl_slist *slist, const std::string &header_name, const std::string &value);
 
-curl_slist *add_auth_headers(struct curl_slist *request_headers);
+curl_slist *add_auth_headers(curl_slist *request_headers);
 
 
 } // namespace curl

--- a/modules/dmrpp_module/AccessCredentials.cc
+++ b/modules/dmrpp_module/AccessCredentials.cc
@@ -91,15 +91,15 @@ AccessCredentials::add(const string &key, const string &value) {
  * @return True
  */
 bool AccessCredentials::is_s3_cred() {
-    if (!s3_tested) {
-        is_s3 = get(URL_KEY).length() > 0 &&
+    if (!d_s3_tested) {
+        d_is_s3 = get(URL_KEY).length() > 0 &&
                 get(ID_KEY).length() > 0 &&
                 get(KEY_KEY).length() > 0 &&
                 get(REGION_KEY).length() > 0; //&&
         //get(BUCKET_KEY).length()>0;
-        s3_tested = true;
+        d_s3_tested = true;
     }
-    return is_s3;
+    return d_is_s3;
 }
 
 string AccessCredentials::to_json() {

--- a/modules/dmrpp_module/AccessCredentials.h
+++ b/modules/dmrpp_module/AccessCredentials.h
@@ -26,13 +26,16 @@ public:
 #endif
 private:
     std::map<std::string, std::string> kvp;
-    bool s3_tested, is_s3;
     std::string d_config_name;
+    bool d_s3_tested;
+    bool d_is_s3;
 public:
     AccessCredentials() = default;
 
-    AccessCredentials(const std::string &config_name)
-        :d_config_name(config_name),s3_tested(false), is_s3(false) { }
+    explicit AccessCredentials(const std::string &config_name) :
+        d_config_name(config_name),
+        d_s3_tested(false),
+        d_is_s3(false) { }
 
     AccessCredentials(const AccessCredentials &ac) = default;
 

--- a/modules/dmrpp_module/AccessCredentials.h
+++ b/modules/dmrpp_module/AccessCredentials.h
@@ -32,7 +32,7 @@ public:
     AccessCredentials() = default;
 
     AccessCredentials(const std::string &config_name)
-        :d_config_name(config_name) { }
+        :d_config_name(config_name),s3_tested(false), is_s3(false) { }
 
     AccessCredentials(const AccessCredentials &ac) = default;
 

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -473,8 +473,7 @@ CurlHandlePool::get_easy_handle(Chunk *chunk) {
             handle->d_request_headers = curl::append_http_header((curl_slist *)0, "Authorization", auth_header);
             handle->d_request_headers = curl::append_http_header(handle->d_request_headers, "x-amz-content-sha256",
                                                   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-
-            handle->d_request_headers = curl::append_http_header(handle->d_request_headers, "x-amz-date:", AWSV4::ISO8601_date(request_time));
+            handle->d_request_headers = curl::append_http_header(handle->d_request_headers, "x-amz-date", AWSV4::ISO8601_date(request_time));
 #if 0
 
             // passing nullptr for the first call allocates the curl_slist

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -44,7 +44,6 @@
 #include "BESForbiddenError.h"
 #include "AllowedHosts.h"
 
-#include "DmrppRequestHandler.h"
 #include "DmrppCommon.h"
 #include "DmrppNames.h"
 #include "awsv4.h"
@@ -312,6 +311,17 @@ void dmrpp_easy_handle::read_data() {
     d_chunk->set_is_read(true);
 }
 
+#if 0
+// This implmentation of the default constructor should have:
+// a) Utilized the other constructor:
+//        CurlHandlePool::CurlHandlePool() { CurlHandlePool(DmrppRequestHandler::d_max_parallel_transfers); }
+//    rather than duplicating the logic.
+// b) Skipped because the only code that called it in the first place was DmrppRequestHandler::DmrppRequestHandler()
+//    which is already owns DmrppRequestHandler::d_max_parallel_transfers and can pass it in.
+//
+//
+// Old default constructor. Duplicates logic.
+//
 CurlHandlePool::CurlHandlePool() {
     d_max_easy_handles = DmrppRequestHandler::d_max_parallel_transfers;
 
@@ -322,6 +332,15 @@ CurlHandlePool::CurlHandlePool() {
     if (status != 0)
         throw BESInternalError("Could not initialize mutex in CurlHandlePool. msg: " + pthread_error(status), __FILE__, __LINE__);
 }
+//
+// One alternate would be to do this for the default constructor:
+CurlHandlePool::CurlHandlePool() {
+    CurlHandlePool(8);
+}
+//
+// - ndp 12/02/20
+#endif
+
 
 CurlHandlePool::CurlHandlePool(unsigned int max_handles) : d_max_easy_handles(max_handles) {
     for (unsigned int i = 0; i < d_max_easy_handles; ++i) {

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -344,6 +344,7 @@ CurlHandlePool::CurlHandlePool(unsigned int max_handles) : d_max_easy_handles(ma
  * @param value The value
  * @return The modified slist pointer or nullptr if an error occurred.
  */
+#if 0
 static struct curl_slist *append_http_header(curl_slist *slist, const string &header, const string &value) {
     string full_header = header;
     full_header.append(" ").append(value);
@@ -351,6 +352,8 @@ static struct curl_slist *append_http_header(curl_slist *slist, const string &he
     struct curl_slist *temp = curl_slist_append(slist, full_header.c_str());
     return temp;
 }
+#endif
+
 
 /**
  * Get a CURL easy handle to transfer data from \arg url into the given \arg chunk.
@@ -467,7 +470,7 @@ CurlHandlePool::get_easy_handle(Chunk *chunk) {
                             "s3");
 
 
-            handle->d_request_headers = curl::append_http_header(handle->d_request_headers, "Authorization", auth_header);
+            handle->d_request_headers = curl::append_http_header((curl_slist *)0, "Authorization", auth_header);
             handle->d_request_headers = curl::append_http_header(handle->d_request_headers, "x-amz-content-sha256",
                                                   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -344,8 +344,7 @@ CurlHandlePool::CurlHandlePool(unsigned int max_handles) : d_max_easy_handles(ma
  * @param value The value
  * @return The modified slist pointer or nullptr if an error occurred.
  */
-static struct curl_slist *
-append_http_header(curl_slist *slist, const string &header, const string &value) {
+static struct curl_slist *append_http_header(curl_slist *slist, const string &header, const string &value) {
     string full_header = header;
     full_header.append(" ").append(value);
 
@@ -467,6 +466,14 @@ CurlHandlePool::get_easy_handle(Chunk *chunk) {
                             credentials->get(AccessCredentials::REGION_KEY),
                             "s3");
 
+
+            handle->d_request_headers = curl::append_http_header(handle->d_request_headers, "Authorization", auth_header);
+            handle->d_request_headers = curl::append_http_header(handle->d_request_headers, "x-amz-content-sha256",
+                                                  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+
+            handle->d_request_headers = curl::append_http_header(handle->d_request_headers, "x-amz-date:", AWSV4::ISO8601_date(request_time));
+#if 0
+
             // passing nullptr for the first call allocates the curl_slist
             // The following code builds the slist that holds the headers. This slist is freed
             // once the URL is dereferenced in dmrpp_easy_handle::read_data(). jhrg 11/26/19
@@ -493,6 +500,7 @@ CurlHandlePool::get_easy_handle(Chunk *chunk) {
                                 curl::error_message(res, handle->d_errbuf)),
                         __FILE__, __LINE__);
             handle->d_request_headers = temp;
+#endif
 
             // handle->d_request_headers = curl::add_auth_headers(handle->d_request_headers);
 

--- a/modules/dmrpp_module/CurlHandlePool.h
+++ b/modules/dmrpp_module/CurlHandlePool.h
@@ -96,11 +96,11 @@ private:
     pthread_mutex_t d_get_easy_handle_mutex;
 
     friend class Lock;
-
-public:
     CurlHandlePool();
 
-    CurlHandlePool(unsigned int max_handles);
+public:
+
+    explicit CurlHandlePool(unsigned int max_handles);
 
     ~CurlHandlePool()
     {

--- a/modules/dmrpp_module/CurlHandlePool.h
+++ b/modules/dmrpp_module/CurlHandlePool.h
@@ -65,7 +65,7 @@ class dmrpp_easy_handle {
     Chunk *d_chunk;     ///< This easy_handle reads the data for \arg chunk.
     char d_errbuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
     CURL *d_handle;     ///< The libcurl handle object.
-    struct curl_slist *d_request_headers; ///< Holds the list of authorization headers, if needed.
+    curl_slist *d_request_headers; ///< Holds the list of authorization headers, if needed.
 
     friend class CurlHandlePool;
 

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -653,6 +653,14 @@ void *one_chunk_unconstrained_thread(void *arg_list)
         delete args;
         pthread_exit(new string(msg.str()));
     }
+    catch (...){
+        stringstream  msg;
+        msg << prolog << "ERROR. tid: " << +(args->tid) << " message: " << error.get_verbose_message() << endl;
+        ERROR_LOG(msg.str());
+        write(args->fds[1], &args->tid, sizeof(args->tid));
+        delete args;
+        pthread_exit(new string(msg.str()));
+    }
 
     // tid is a char and thus us written atomically. Writing this tells the parent
     // thread the child is complete and it should call pthread_join(tid, ...)

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -45,6 +45,7 @@
 
 #include "BESInternalError.h"
 #include "BESDebug.h"
+#include "BESLog.h"
 #include "BESStopWatch.h"
 
 #include "byteswap_compat.h"
@@ -647,7 +648,10 @@ void *one_chunk_unconstrained_thread(void *arg_list)
     catch (BESError &error) {
         write(args->fds[1], &args->tid, sizeof(args->tid));
         delete args;
-        pthread_exit(new string(error.get_verbose_message()));
+        stringstream  msg;
+        msg << prolog << error.get_verbose_message() << endl;
+        ERROR_LOG(msg.str());
+        pthread_exit(new string(msg.str()));
     }
 
     // tid is a char and thus us written atomically. Writing this tells the parent

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -649,7 +649,7 @@ void *one_chunk_unconstrained_thread(void *arg_list)
         write(args->fds[1], &args->tid, sizeof(args->tid));
         delete args;
         stringstream  msg;
-        msg << prolog << error.get_verbose_message() << endl;
+        msg << prolog << "ERROR. tid: " << args->tid << " message: " << error.get_verbose_message() << endl;
         ERROR_LOG(msg.str());
         pthread_exit(new string(msg.str()));
     }

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -653,9 +653,20 @@ void *one_chunk_unconstrained_thread(void *arg_list)
         delete args;
         pthread_exit(new string(msg.str()));
     }
+    catch (std::exception &e){
+        stringstream  msg;
+        msg << prolog << "ERROR. tid: " << +(args->tid) << " process_one_chunk_unconstrained() "
+                                                           "failed. Message: " << e.what() << endl;
+        ERROR_LOG(msg.str());
+        write(args->fds[1], &args->tid, sizeof(args->tid));
+        delete args;
+        pthread_exit(new string(msg.str()));
+
+    }
     catch (...){
         stringstream  msg;
-        msg << prolog << "ERROR. tid: " << +(args->tid) << " message: " << error.get_verbose_message() << endl;
+        msg << prolog << "ERROR. tid: " << +(args->tid) << " process_one_chunk_unconstrained() "
+                                                           "failed for an unknown reason." << endl;
         ERROR_LOG(msg.str());
         write(args->fds[1], &args->tid, sizeof(args->tid));
         delete args;

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -647,7 +647,7 @@ void *one_chunk_unconstrained_thread(void *arg_list)
     }
     catch (BESError &error) {
         stringstream  msg;
-        msg << prolog << "ERROR. tid: " << args->tid << " message: " << error.get_verbose_message() << endl;
+        msg << prolog << "ERROR. tid: " << +(args->tid) << " message: " << error.get_verbose_message() << endl;
         ERROR_LOG(msg.str());
         write(args->fds[1], &args->tid, sizeof(args->tid));
         delete args;

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -646,11 +646,11 @@ void *one_chunk_unconstrained_thread(void *arg_list)
         process_one_chunk_unconstrained(args->chunk, args->array, args->array_shape, args->chunk_shape);
     }
     catch (BESError &error) {
-        write(args->fds[1], &args->tid, sizeof(args->tid));
-        delete args;
         stringstream  msg;
         msg << prolog << "ERROR. tid: " << args->tid << " message: " << error.get_verbose_message() << endl;
         ERROR_LOG(msg.str());
+        write(args->fds[1], &args->tid, sizeof(args->tid));
+        delete args;
         pthread_exit(new string(msg.str()));
     }
 

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -497,7 +497,7 @@ void DmrppArray::read_contiguous()
                         throw BESInternalError(oss.str(), __FILE__, __LINE__);
                     }
                     ++num_threads;
-                    BESDEBUG(dmrpp_3, "started thread: " << (unsigned int) tid << ", there are: " << threads << endl);
+                    BESDEBUG(dmrpp_3, "started thread: " << (unsigned int) tid << ", there are: " << num_threads << endl);
                 }
             }
 
@@ -822,7 +822,7 @@ void DmrppArray::read_chunks_unconstrained()
                         throw BESInternalError(oss.str(), __FILE__, __LINE__);
                     }
                     ++num_threads;
-                    BESDEBUG(dmrpp_3, "started thread: " << (unsigned int) tid << ", there are: " << threads << endl);
+                    BESDEBUG(dmrpp_3, "started thread: " << (unsigned int) tid << ", there are: " << num_threads << endl);
                 }
             }
 
@@ -1228,7 +1228,7 @@ void DmrppArray::read_chunks()
                         throw BESInternalError(oss.str(), __FILE__, __LINE__);
                     }
                     ++num_threads;
-                    BESDEBUG(dmrpp_3, "started thread: " << (unsigned int) tid << ", there are: " << threads << endl);
+                    BESDEBUG(dmrpp_3, "started thread: " << (unsigned int) tid << ", there are: " << num_threads << endl);
                 }
             }
 

--- a/modules/dmrpp_module/DmrppCommon.cc
+++ b/modules/dmrpp_module/DmrppCommon.cc
@@ -77,7 +77,7 @@ void join_threads(pthread_t threads[], unsigned int num_threads)
             string *error = NULL;
             if ((status = pthread_join(threads[i], (void **) &error)) < 0) {
                 BESDEBUG(dmrpp_3, "Could not join thread " << i << ", " << strerror(status)<< endl);
-                // ERROR_LOG("Failed to join thread " << i << "during clean up from an exception: " << strerror(status) << endl);
+                // ERROR_LOG("Failed to join thread " << i << " during clean up from an exception: " << strerror(status) << endl);
             }
             else if (error != NULL) {
                 BESDEBUG(dmrpp_3, "Joined thread " << i << ", error exit: " << *error << endl);

--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -143,7 +143,7 @@ DmrppRequestHandler::DmrppRequestHandler(const string &name) :
     CredentialsManager::theCM()->load_credentials();
 
     if (!curl_handle_pool)
-        curl_handle_pool = new CurlHandlePool();
+        curl_handle_pool = new CurlHandlePool(d_max_parallel_transfers);
 
     // This and the matching cleanup function can be called many times as long as
     // they are called in balanced pairs. jhrg 9/3/20

--- a/modules/dmrpp_module/retriever.cc
+++ b/modules/dmrpp_module/retriever.cc
@@ -742,13 +742,19 @@ int main(int argc, char *argv[]) {
 
 
     try {
+        if(pwr2_parallel_reads){
+            unsigned long long int max_threads = 1ULL << pwr2_parallel_reads;
+            dmrpp::DmrppRequestHandler::d_use_parallel_transfers = true;
+            dmrpp::DmrppRequestHandler::d_max_parallel_transfers = max_threads;
+        }
+        else {
+            dmrpp::DmrppRequestHandler::d_use_parallel_transfers = false;
+            dmrpp::DmrppRequestHandler::d_max_parallel_transfers = 1;
+        }
+
         dmrpp::DmrppRequestHandler *dmrppRH = bes_setup(bes_config_file, bes_log_file, bes_debug_log_file,
                                                         bes_debug_keys, http_netrc_file,http_cache_dir);
-
-
-
-
-
+        
         string effectiveUrl = http::EffectiveUrlCache::TheCache()->get_effective_url(target_url);
         if (debug)  cerr << prolog << "curl::retrieve_effective_url() returned:  " << effectiveUrl << endl;
         size_t target_size =  get_max_retrival_size(max_target_size, effectiveUrl);
@@ -757,14 +763,6 @@ int main(int argc, char *argv[]) {
         if (debug)  cerr << prolog << "Dividing target into " << chunks << " chunks." << endl;
 
 
-        if(pwr2_parallel_reads){
-            unsigned long long int max_threads = 1ULL << pwr2_parallel_reads;
-            dmrpp::DmrppRequestHandler::d_use_parallel_transfers = true;
-            dmrpp::DmrppRequestHandler::d_max_parallel_transfers = max_threads;
-        }else {
-            dmrpp::DmrppRequestHandler::d_use_parallel_transfers = false;
-            dmrpp::DmrppRequestHandler::d_max_parallel_transfers = 1;
-        }
 
         array_get(effectiveUrl, target_size, chunks, output_file_base);
 

--- a/modules/dmrpp_module/retriever.cc
+++ b/modules/dmrpp_module/retriever.cc
@@ -751,7 +751,11 @@ int main(int argc, char *argv[]) {
         string effectiveUrl = http::EffectiveUrlCache::TheCache()->get_effective_url(target_url);
         if (debug)  cerr << prolog << "curl::retrieve_effective_url() returned:  " << effectiveUrl << endl;
         size_t target_size =  get_max_retrival_size(max_target_size, effectiveUrl);
-        array_get(effectiveUrl, target_size, pwr2_number_o_chunks, output_file_base);
+
+        unsigned long long int chunks = 1ULL << pwr2_number_o_chunks;
+        if (debug)  cerr << prolog << "Dividing target into " << chunks << " chunks." << endl;
+
+        array_get(effectiveUrl, target_size, chunks, output_file_base);
 
 
 #if 0 // these work but are parked a.t.m.

--- a/modules/dmrpp_module/retriever.cc
+++ b/modules/dmrpp_module/retriever.cc
@@ -583,6 +583,8 @@ int test_plan_01(const string &target_url,
                   const string &output_file_base
                   ) {
     int result = 0;
+    if (debug)
+        cerr << prolog << "BEGIN" << endl;
 
     try {
         string effectiveUrl = http::EffectiveUrlCache::TheCache()->get_effective_url(target_url);
@@ -624,6 +626,7 @@ int test_plan_01(const string &target_url,
              endl;
         result = 2;
     }
+    cerr << prolog << "END" << endl;
     return result;
 }
 
@@ -644,7 +647,7 @@ int main(int argc, char *argv[]) {
     string output_file_base("retriever");
     string http_cache_dir;
     string prefix;
-    size_t pwr2_number_o_chunks = 100;
+    size_t pwr2_number_o_chunks = 18;
     size_t max_target_size = 0;
     string http_netrc_file;
     unsigned int reps=10;
@@ -744,6 +747,14 @@ int main(int argc, char *argv[]) {
 
 
 
+        string effectiveUrl = http::EffectiveUrlCache::TheCache()->get_effective_url(target_url);
+        if (debug)
+            cerr << prolog << "curl::retrieve_effective_url() returned:  " << effectiveUrl << endl;
+        size_t target_size =  get_max_retrival_size(max_target_size, effectiveUrl);
+        array_get(effectiveUrl, target_size, pwr2_number_o_chunks, output_file_base);
+
+
+#if 0 // these work but are parked a.t.m.
         result = test_plan_01(
                 target_url,
                 output_file_base,
@@ -753,8 +764,6 @@ int main(int argc, char *argv[]) {
                 pwr2_parallel_reads,
                 output_file_base) ;
 
-
-#if 0 // these work but are parked a.t.m.
         simple_get(effectiveUrl, output_file_base);
         serial_chunky_get( effectiveUrl,  max_target_size, pwr2_number_o_chunks, output_file_base);
 

--- a/modules/dmrpp_module/retriever.cc
+++ b/modules/dmrpp_module/retriever.cc
@@ -574,6 +574,7 @@ size_t array_get(const string &target_url, const size_t &target_size, const size
 }
 
  */
+#if 0
 int test_plan_01(const string &target_url,
                   const string &output_prefix,
                   const unsigned int reps,
@@ -629,7 +630,7 @@ int test_plan_01(const string &target_url,
     cerr << prolog << "END" << endl;
     return result;
 }
-
+#endif
 
 /**
  *

--- a/modules/dmrpp_module/retriever.cc
+++ b/modules/dmrpp_module/retriever.cc
@@ -174,7 +174,6 @@ curl_slist *aws_sign_request_url(const string &target_url, curl_slist *request_h
         // We pre-compute the sha256 hash of a null message body
         request_headers = curl::append_http_header(request_headers, "x-amz-content-sha256", NULL_BODY_HASH);
         request_headers = curl::append_http_header(request_headers, "x-amz-date", AWSV4::ISO8601_date(request_time));
-
     }
     if (debug) cerr << prolog << "END" << endl;
     return request_headers;

--- a/modules/dmrpp_module/retriever.cc
+++ b/modules/dmrpp_module/retriever.cc
@@ -642,7 +642,7 @@ int main(int argc, char *argv[]) {
     int result = 0;
     string bes_log_file;
     string bes_debug_log_file = "cerr";
-    string bes_debug_keys = "bes,http,curl,dmrpp,dmrpp:4,rr";
+    string bes_debug_keys = "bes,http,curl,dmrpp,dmrpp:3,dmrpp:4,rr";
     string target_url = "https://www.opendap.org/pub/binary/hyrax-1.16/centos-7.x/bes-debuginfo-3.20.7-1.static.el7.x86_64.rpm";
     string output_file_base("retriever");
     string http_cache_dir;

--- a/modules/dmrpp_module/retriever.cc
+++ b/modules/dmrpp_module/retriever.cc
@@ -748,12 +748,24 @@ int main(int argc, char *argv[]) {
 
 
 
+
+
         string effectiveUrl = http::EffectiveUrlCache::TheCache()->get_effective_url(target_url);
         if (debug)  cerr << prolog << "curl::retrieve_effective_url() returned:  " << effectiveUrl << endl;
         size_t target_size =  get_max_retrival_size(max_target_size, effectiveUrl);
 
         unsigned long long int chunks = 1ULL << pwr2_number_o_chunks;
         if (debug)  cerr << prolog << "Dividing target into " << chunks << " chunks." << endl;
+
+
+        if(pwr2_parallel_reads){
+            unsigned long long int max_threads = 1ULL << pwr2_parallel_reads;
+            dmrpp::DmrppRequestHandler::d_use_parallel_transfers = true;
+            dmrpp::DmrppRequestHandler::d_max_parallel_transfers = max_threads;
+        }else {
+            dmrpp::DmrppRequestHandler::d_use_parallel_transfers = false;
+            dmrpp::DmrppRequestHandler::d_max_parallel_transfers = 1;
+        }
 
         array_get(effectiveUrl, target_size, chunks, output_file_base);
 

--- a/modules/dmrpp_module/retriever.cc
+++ b/modules/dmrpp_module/retriever.cc
@@ -748,8 +748,7 @@ int main(int argc, char *argv[]) {
 
 
         string effectiveUrl = http::EffectiveUrlCache::TheCache()->get_effective_url(target_url);
-        if (debug)
-            cerr << prolog << "curl::retrieve_effective_url() returned:  " << effectiveUrl << endl;
+        if (debug)  cerr << prolog << "curl::retrieve_effective_url() returned:  " << effectiveUrl << endl;
         size_t target_size =  get_max_retrival_size(max_target_size, effectiveUrl);
         array_get(effectiveUrl, target_size, pwr2_number_o_chunks, output_file_base);
 

--- a/modules/ngap_module/NgapApi.cc
+++ b/modules/ngap_module/NgapApi.cc
@@ -157,47 +157,58 @@ namespace ngap {
             throw BESSyntaxUserError(msg.str() , __FILE__, __LINE__);
         }
 
-        // Check to make sure all required tokens are present.
+        // Check that the NGAP_PROVIDER_KEY token is present.
         if (tokens[0] != NGAP_PROVIDER_KEY ) {
             stringstream msg;
             msg << prolog << "The specified path '" << restified_path << "'";
-            msg << "does not contain the expected path element '" << NGAP_PROVIDER_KEY << "'";
-            throw BESSyntaxUserError(string("The specified path '") + restified_path +
-                                     "' does not contain the expected .", __FILE__, __LINE__);
+            msg << "does not contain the required path element '" << NGAP_PROVIDER_KEY << "'";
+            throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
         }
-        // Check to make sure all required tokens are present.
+        // Check that the NGAP_COLLECTIONS_KEY or  NGAP_CONCEPTS_KEY token is present.
         if ((tokens[2] != NGAP_COLLECTIONS_KEY && tokens[2] != NGAP_CONCEPTS_KEY)) {
-            throw BESSyntaxUserError(string("The specified path '") + restified_path +
-                                     "' does not conform to the NGAP request interface API.", __FILE__, __LINE__);
+            stringstream msg;
+            msg << prolog << "The specified path '" << restified_path << "'";
+            msg << "does not contain the expected path element '" << NGAP_COLLECTIONS_KEY << "' or it's alternate, '";
+            msg << NGAP_CONCEPTS_KEY << "'. One of these is required";
+            throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
         }
-        // Check to make sure all required tokens are present.
+        // Check that the NGAP_GRANULES_KEY token is present.
         if (tokens[4] != NGAP_GRANULES_KEY) {
-            throw BESSyntaxUserError(string("The specified path '") + restified_path +
-                                     "' does not conform to the NGAP request interface API.", __FILE__, __LINE__);
+            stringstream msg;
+            msg << prolog << "The specified path '" << restified_path << "'";
+            msg << "does not contain the required path element '" << NGAP_GRANULES_KEY << "'.";
+            throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
         }
-        // Pick up the values of said tokens.
-        string cmr_url = get_cmr_search_endpoint_url() + "?";
 
+        // Build the CMR query URL for the dataset
+        string cmr_url = get_cmr_search_endpoint_url() + "?";
         {
             // This easy handle is only created so we can use the curl_easy_escape() on the tokens
             CURL *ceh = curl_easy_init();
             char *esc_url_content;
 
+            // Add provider
             esc_url_content = curl_easy_escape(ceh, tokens[1].c_str(), tokens[1].size());
             cmr_url += CMR_PROVIDER + "=" + esc_url_content + "&";
             curl_free(esc_url_content);
 
             esc_url_content = curl_easy_escape(ceh, tokens[3].c_str(), tokens[3].size());
             if (tokens[2] == NGAP_COLLECTIONS_KEY) {
+                // Add entry_title
                 cmr_url += CMR_ENTRY_TITLE + "=" + esc_url_content + "&";
             }
             else if(tokens[2] == NGAP_CONCEPTS_KEY){
+                // Add collection_concept_id
                 cmr_url += CMR_COLLECTION_CONCEPT_ID + "=" + esc_url_content + "&";
             }
             else {
+                // Bad inputs throw an exception.
                 curl_free(esc_url_content);
-                throw BESSyntaxUserError(string("The specified path '") + restified_path +
-                                         "' does not conform to the NGAP request interface API.", __FILE__, __LINE__);
+                stringstream msg;
+                msg << prolog << "The specified path '" << restified_path << "'";
+                msg << "does not contain the expected path element '" << NGAP_COLLECTIONS_KEY << "' or it's alternate '";
+                msg << NGAP_CONCEPTS_KEY << "'. One of these is required";
+                throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
             }
             curl_free(esc_url_content);
 

--- a/modules/ngap_module/NgapApi.cc
+++ b/modules/ngap_module/NgapApi.cc
@@ -147,14 +147,31 @@ namespace ngap {
         vector<string> tokens;
         BESUtil::tokenize(restified_path, tokens);
         if (tokens.empty()) {
-            throw BESSyntaxUserError(string("The specified path '") + restified_path +
-                                     "' does not conform to the NGAP request interface API.", __FILE__, __LINE__);
+            throw BESSyntaxUserError(string("The specified NGAP API path '") + restified_path +
+                                     "' failed to tokenize: No tokens were returned.", __FILE__, __LINE__);
+        }
+        if(tokens.size()!=6){
+            stringstream msg;
+            msg << prolog << "The specified NGAP API path '" << restified_path << "' was tokenized, but ";
+            msg << tokens.size() << " token(s) were found where 6 are required.";
+            throw BESSyntaxUserError(msg.str() , __FILE__, __LINE__);
         }
 
         // Check to make sure all required tokens are present.
-        if (tokens[0] != NGAP_PROVIDER_KEY ||
-            (tokens[2] != NGAP_COLLECTIONS_KEY && tokens[2] != NGAP_CONCEPTS_KEY) ||
-            tokens[4] != NGAP_GRANULES_KEY) {
+        if (tokens[0] != NGAP_PROVIDER_KEY ) {
+            stringstream msg;
+            msg << prolog << "The specified path '" << restified_path << "'";
+            msg << "does not contain the expected path element '" << NGAP_PROVIDER_KEY << "'";
+            throw BESSyntaxUserError(string("The specified path '") + restified_path +
+                                     "' does not contain the expected .", __FILE__, __LINE__);
+        }
+        // Check to make sure all required tokens are present.
+        if ((tokens[2] != NGAP_COLLECTIONS_KEY && tokens[2] != NGAP_CONCEPTS_KEY)) {
+            throw BESSyntaxUserError(string("The specified path '") + restified_path +
+                                     "' does not conform to the NGAP request interface API.", __FILE__, __LINE__);
+        }
+        // Check to make sure all required tokens are present.
+        if (tokens[4] != NGAP_GRANULES_KEY) {
             throw BESSyntaxUserError(string("The specified path '") + restified_path +
                                      "' does not conform to the NGAP request interface API.", __FILE__, __LINE__);
         }


### PR DESCRIPTION
Adds:
* Bug fixes to retriever.cc that enable higher number of child threads.
* Debugging and error handling to the `DmrppArray::one_chunk_unconstrained_thread()` function.
* Removed leak to stderr in `CurlUtils`
* Fixed bad declarations of instances of the `curl_slist` type in `CurlHandlePool.h` and elsewhere.