### PR TITLE
fixed missing return code in test ppt/unit-tests/extT.cc

### DIFF
--- a/ppt/unit-tests/extT.cc
+++ b/ppt/unit-tests/extT.cc
@@ -103,6 +103,7 @@ CPPUNIT_TEST_SUITE( extT );
             cout << "var " << var << " = " << (*f).second << ", should be " << val << endl;
             CPPUNIT_ASSERT( (*f).second == val );
         }
+	return 0;
     }
 
     void do_try_list()


### PR DESCRIPTION
Fixes #438 

Added missing return code to clear warning and cause test to pass.