### PR TITLE
Adds new restified path parsing implementation and

### DIFF
--- a/modules/ngap_module/Makefile.am
+++ b/modules/ngap_module/Makefile.am
@@ -2,7 +2,6 @@
 #
 # 07/25/18
 #
-
 AUTOMAKE_OPTIONS = foreign
 
 ACLOCAL_AMFLAGS = -I conf

--- a/modules/ngap_module/NgapApi.cc
+++ b/modules/ngap_module/NgapApi.cc
@@ -119,7 +119,7 @@ namespace ngap {
 #if 0
     // OLD WAY (tokenization on '/' delimiter)
     std::string
-    NgapApi::convert_restified_path_to_cmr_query_url(const std::string &restified_path) {
+    NgapApi::build_cmr_query_url(const std::string &restified_path) {
         string data_access_url("");
 
         vector<string> tokens;
@@ -206,7 +206,7 @@ namespace ngap {
  * @return The CMR query URL that will return the granules.umm_json_v1_4 from CMR for the
  * granule specified in the restified path.
  */
-std::string NgapApi::convert_restified_path_to_cmr_query_url(const std::string &restified_path) {
+std::string NgapApi::build_cmr_query_url(const std::string &restified_path) {
     string PROVIDERS_KEY("/providers/");
     string COLLECTIONS_KEY("/collections/");
     string CONCEPTS_KEY("/concepts/");
@@ -317,11 +317,11 @@ std::string NgapApi::convert_restified_path_to_cmr_query_url(const std::string &
  * A single granule query is built by convert_restified_path_to_cmr_query_url() from the
  * NGAP API restified path. This method will parse the CMR response to the query and extract the
  * granule's "GET DATA" URL and return it.
- * @param restified_path
- * @param cmr_granules
- * @return
+ * @param restified_path THe restified path used to form the CMR query
+ * @param cmr_granules The CMR response (granules.umm_json_v1_4) to evaluate
+ * @return  The "GET DATA" URL for the granule.
  */
-std::string NgapApi::get_data_access_url_from_cmr_json(const std::string &restified_path, rapidjson::Document &cmr_granule_response)
+std::string NgapApi::find_get_data_url_in_granules_umm_json_v1_4(const std::string &restified_path, rapidjson::Document &cmr_granule_response)
 {
 
     string data_access_url("");
@@ -435,6 +435,7 @@ std::string NgapApi::get_data_access_url_from_cmr_json(const std::string &restif
             const std::string &restified_path,
             const std::string &uid
             ) {
+        BESDEBUG(MODULE, prolog << "BEGIN" << endl);
         string data_access_url("");
 
         string cmr_query_url = build_cmr_query_url(restified_path);
@@ -452,9 +453,9 @@ std::string NgapApi::get_data_access_url_from_cmr_json(const std::string &restif
         }
         rapidjson::Document cmr_response = cmr_query.get_as_json();
 
-        data_access_url = get_data_access_url_from_cmr_json(restified_path, cmr_response);
+        data_access_url = find_get_data_url_in_granules_umm_json_v1_4(restified_path, cmr_response);
 
-        BESDEBUG(MODULE, prolog << "Following data_access_url redirects..." << endl);
+        BESDEBUG(MODULE, prolog << "END (data_access_url: "<< data_access_url << ")" << endl);
 
         return data_access_url;
     }

--- a/modules/ngap_module/NgapApi.cc
+++ b/modules/ngap_module/NgapApi.cc
@@ -115,33 +115,11 @@ namespace ngap {
         return BESUtil::assemblePath(d_cmr_hostname , d_cmr_search_endpoint_path);
     }
 
-    /**
-     * @brief Converts an NGAP restified granule path into a CMR metadata query for the granule.
-     *
-     * The NGAP module's "restified" interface utilizes a google-esque set of
-     * ordered key value pairs using the "/" character as field seperatror.
-     *
-     * The NGAP container the "restified_path" will follow the template:
-     *
-     *   provider/daac_name/datasets/collection_name/granules/granule_name(s?)
-     *
-     * Where "provider", "datasets", and "granules" are NGAP keys and
-     * "ddac_name", "collection_name", and "granule_name" the their respective values.
-     *
-     * For example, "provider/GHRC_CLOUD/datasets/ACES_CONTINUOUS_DATA_V1/granules/aces1cont.nc"
-     *
-     * https://cmr.earthdata.nasa.gov/search/granules.umm_json_v1_4?
-     *   provider=GHRC_CLOUD &entry_title=ACES_CONTINUOUS_DATA_V1 &native_id=aces1cont.nc
-     *   provider=GHRC_CLOUD &entry_title=ACES CONTINUOUS DATA V1 &native_id=aces1cont_2002.191_v2.50.tar
-     *   provider=GHRC_CLOUD &native_id=olslit77.nov_analog.hdf &pretty=true
-     *
-     * @param restified_path The name to decompose.
-     */
-    string NgapApi::convert_ngap_resty_path_to_data_access_url(
-            const std::string &restified_path,
-            const std::string &uid
-            ) {
 
+#if 0
+    // OLD WAY (tokenization on '/' delimiter)
+    std::string
+    NgapApi::convert_restified_path_to_cmr_query_url(const std::string &restified_path) {
         string data_access_url("");
 
         vector<string> tokens;
@@ -217,15 +195,157 @@ namespace ngap {
             curl_free(esc_url_content);
             curl_easy_cleanup(ceh);
         }
+        return cmr_url;
+    }
+#else
 
-        BESDEBUG(MODULE, prolog << "CMR Request URL: " << cmr_url << endl);
+
+    std::string
+    NgapApi::convert_restified_path_to_cmr_query_url(const std::string &restified_path) {
+        string PROVIDERS_KEY("/providers/");
+        string COLLECTIONS_KEY("/collections/");
+        string CONCEPTS_KEY("/concepts/");
+        string GRANULES_KEY("/granules/");
+
+        string r_path = (restified_path[0]!='/'?"/":"") + restified_path;
+
+        size_t provider_index  = r_path.find(PROVIDERS_KEY);
+        if(provider_index == string::npos){
+            stringstream msg;
+            msg << prolog << "The specified path '" << r_path << "'";
+            msg << " does not contain the required path element '" << NGAP_PROVIDER_KEY << "'";
+            throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
+        }
+        if(provider_index != 0){
+            stringstream msg;
+            msg << prolog << "The specified path '" << r_path << "'";
+            msg << " has the path element '" << NGAP_PROVIDER_KEY << "' located in the incorrect position (";
+            msg << provider_index << ") expected 0.";
+            throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
+        }
+        provider_index += PROVIDERS_KEY.length();
+
+        bool use_collection_concept_id = false;
+        size_t collection_index  = r_path.find(COLLECTIONS_KEY);
+        if(collection_index == string::npos) {
+            collection_index = r_path.find(CONCEPTS_KEY);
+            if (collection_index == string::npos) {
+                stringstream msg;
+                msg << prolog << "The specified path '" << r_path << "'";
+                msg << " does not contain the required path element '" << CONCEPTS_KEY << "'";
+                throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
+            }
+            if(collection_index <= provider_index+1){
+                stringstream msg;
+                msg << prolog << "The specified path '" << r_path << "'";
+                msg << " has the path element '" << CONCEPTS_KEY << "' located in the incorrect position (";
+                msg << collection_index << ") expected at least " << provider_index+1;
+                throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
+            }
+            use_collection_concept_id = true;
+        }
+        if(collection_index <= provider_index+1){
+            stringstream msg;
+            msg << prolog << "The specified path '" << r_path << "'";
+            msg << " has the path element '" << COLLECTIONS_KEY << "' located in the incorrect position (";
+            msg << collection_index << ") expected at least " << provider_index+1;
+            throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
+        }
+        string provider = r_path.substr(provider_index,collection_index - provider_index);
+        collection_index += use_collection_concept_id?CONCEPTS_KEY.length():COLLECTIONS_KEY.length();
+
+
+        size_t granule_index  = r_path.find(GRANULES_KEY);
+        if(granule_index == string::npos){
+            stringstream msg;
+            msg << prolog << "The specified path '" << r_path << "'";
+            msg << " does not contain the required path element '" << GRANULES_KEY << "'";
+            throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
+        }
+        if(granule_index <= collection_index+1){
+            stringstream msg;
+            msg << prolog << "The specified path '" << r_path << "'";
+            msg << " has the path element '" << GRANULES_KEY << "' located in the incorrect position (";
+            msg << granule_index << ") expected at least " << collection_index+1;
+            throw BESSyntaxUserError(msg.str(), __FILE__, __LINE__);
+        }
+        string collection = r_path.substr(collection_index,granule_index - collection_index);
+        granule_index += GRANULES_KEY.length();
+
+        string granule = r_path.substr(granule_index);
+
+        // Build the CMR query URL for the dataset
+        string cmr_url = get_cmr_search_endpoint_url() + "?";
+        {
+            // This easy handle is only created so we can use the curl_easy_escape() on the tokens
+            CURL *ceh = curl_easy_init();
+            char *esc_url_content;
+
+            // Add provider
+            esc_url_content = curl_easy_escape(ceh, provider.c_str(), provider.size());
+            cmr_url += CMR_PROVIDER + "=" + esc_url_content + "&";
+            curl_free(esc_url_content);
+
+            esc_url_content = curl_easy_escape(ceh, collection.c_str(), collection.size());
+            if(use_collection_concept_id){
+                // Add collection_concept_id
+                cmr_url += CMR_COLLECTION_CONCEPT_ID + "=" + esc_url_content + "&";
+            }
+            else {
+                // Add entry_title
+                cmr_url += CMR_ENTRY_TITLE + "=" + esc_url_content + "&";
+
+            }
+            curl_free(esc_url_content);
+
+            esc_url_content = curl_easy_escape(ceh, granule.c_str(), granule.size());
+            cmr_url += CMR_GRANULE_UR + "=" + esc_url_content;
+            curl_free(esc_url_content);
+
+            curl_easy_cleanup(ceh);
+        }
+        return cmr_url;
+    }
+#endif
+
+    /**
+     * @brief Converts an NGAP restified granule path into a CMR metadata query for the granule.
+     *
+     * The NGAP module's "restified" interface utilizes a google-esque set of
+     * ordered key value pairs using the "/" character as field seperatror.
+     *
+     * The NGAP container the "restified_path" will follow the template:
+     *
+     *   provider/daac_name/datasets/collection_name/granules/granule_name(s?)
+     *
+     * Where "provider", "datasets", and "granules" are NGAP keys and
+     * "ddac_name", "collection_name", and "granule_name" the their respective values.
+     *
+     * For example, "provider/GHRC_CLOUD/datasets/ACES_CONTINUOUS_DATA_V1/granules/aces1cont.nc"
+     *
+     * https://cmr.earthdata.nasa.gov/search/granules.umm_json_v1_4?
+     *   provider=GHRC_CLOUD &entry_title=ACES_CONTINUOUS_DATA_V1 &native_id=aces1cont.nc
+     *   provider=GHRC_CLOUD &entry_title=ACES CONTINUOUS DATA V1 &native_id=aces1cont_2002.191_v2.50.tar
+     *   provider=GHRC_CLOUD &native_id=olslit77.nov_analog.hdf &pretty=true
+     *
+     * @param restified_path The name to decompose.
+     */
+    string NgapApi::convert_ngap_resty_path_to_data_access_url(
+            const std::string &restified_path,
+            const std::string &uid
+            ) {
+        string data_access_url("");
+
+        string cmr_query_url = convert_restified_path_to_cmr_query_url(restified_path);
+
+        BESDEBUG(MODULE, prolog << "CMR Request URL: " << cmr_query_url << endl);
 #if 1
         BESDEBUG(MODULE, prolog << "Building new RemoteResource." << endl);
-        http::RemoteResource cmr_query(cmr_url, uid);
+        http::RemoteResource cmr_query(cmr_query_url, uid);
         {
             BESStopWatch besTimer;
             if (BESISDEBUG(MODULE) || BESDebug::IsSet(TIMING_LOG_KEY) || BESLog::TheLog()->is_verbose()){
-                besTimer.start("CMR Query: " + cmr_url);
+                besTimer.start("CMR Query: " + cmr_query_url);
             }
             cmr_query.retrieveResource();
         }

--- a/modules/ngap_module/NgapApi.h
+++ b/modules/ngap_module/NgapApi.h
@@ -52,14 +52,19 @@ private:
     std::string d_cmr_search_endpoint_path;
 
     std::string get_cmr_search_endpoint_url();
+
+
+
 public:
 
     NgapApi();
+
 
     std::string convert_ngap_resty_path_to_data_access_url(
             const std::string &restified_path,
             const std::string &uid="");
 
+    std::string convert_restified_path_to_cmr_query_url(const std::string &restified_path);
     static bool signed_url_is_expired(const http::url &signed_url) ;
 
 #if 0

--- a/modules/ngap_module/NgapApi.h
+++ b/modules/ngap_module/NgapApi.h
@@ -55,6 +55,7 @@ private:
     std::string find_get_data_url_in_granules_umm_json_v1_4(const std::string &restified_path, rapidjson::Document &cmr_granule_response);
     std::string build_cmr_query_url(const std::string &restified_path);
 
+    friend class NgapApiTest;
 
 public:
 

--- a/modules/ngap_module/NgapApi.h
+++ b/modules/ngap_module/NgapApi.h
@@ -52,14 +52,13 @@ private:
     std::string d_cmr_search_endpoint_path;
 
     std::string get_cmr_search_endpoint_url();
-    std::string get_data_access_url_from_cmr_json(const std::string &restified_path, rapidjson::Document &cmr_granules);
+    std::string find_get_data_url_in_granules_umm_json_v1_4(const std::string &restified_path, rapidjson::Document &cmr_granule_response);
     std::string build_cmr_query_url(const std::string &restified_path);
 
 
 public:
 
     NgapApi();
-
 
     std::string convert_ngap_resty_path_to_data_access_url(
             const std::string &restified_path,

--- a/modules/ngap_module/NgapApi.h
+++ b/modules/ngap_module/NgapApi.h
@@ -52,7 +52,8 @@ private:
     std::string d_cmr_search_endpoint_path;
 
     std::string get_cmr_search_endpoint_url();
-
+    std::string get_data_access_url_from_cmr_json(const std::string &restified_path, rapidjson::Document &cmr_granules);
+    std::string build_cmr_query_url(const std::string &restified_path);
 
 
 public:
@@ -64,7 +65,6 @@ public:
             const std::string &restified_path,
             const std::string &uid="");
 
-    std::string convert_restified_path_to_cmr_query_url(const std::string &restified_path);
     static bool signed_url_is_expired(const http::url &signed_url) ;
 
 #if 0

--- a/modules/ngap_module/unit-tests/NgapApiTest.cc
+++ b/modules/ngap_module/unit-tests/NgapApiTest.cc
@@ -163,7 +163,7 @@ public:
             );
         try {
             string cmr_query_url;
-            cmr_query_url = ngapi.convert_restified_path_to_cmr_query_url(resty_path);
+            cmr_query_url = ngapi.build_cmr_query_url(resty_path);
             if(debug) cerr << prolog << "expected_cmr_url: " << expected_cmr_url << endl;
             if(debug) cerr << prolog << "   cmr_query_url: " << cmr_query_url << endl;
             CPPUNIT_ASSERT( cmr_query_url == expected_cmr_url );


### PR DESCRIPTION
This PR drops the original parsing schema for the restified path (tokenizing using the '/' character as the delimiter) in favor of an implementation that searches the restified path for the keys and their surrounding delimiters` /<key_name>/` 
While not entirely impervious to the values of the fields this is a significant improvement and resolves the issue where '/' characters in the values was breaking the parser.