### PR TITLE
When --enable-developer is used, don't override command line CXXFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AC_ARG_ENABLE([developer],
 )
 AM_CONDITIONAL([BES_DEVELOPER], [test "x$enable_developer" = "xyes"])
 AM_COND_IF([BES_DEVELOPER],
-    [cxx_debug_flags="-g3 -O0  -Wall -W -Wcast-align $CXXFLAGS"
+    [cxx_debug_flags="-g3 -O0  -Wall -W -Wcast-align"
       AC_MSG_NOTICE([Developer Mode is enabled.]) ],
     [AC_DEFINE([NDEBUG], [1], [Define this to suppress assert() statements.])
       AC_MSG_NOTICE([Developer Mode is disabled.])]

--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AC_ARG_ENABLE([developer],
 )
 AM_CONDITIONAL([BES_DEVELOPER], [test "x$enable_developer" = "xyes"])
 AM_COND_IF([BES_DEVELOPER],
-    [cxx_debug_flags="-g3 -O0  -Wall -W -Wcast-align"
+    [cxx_debug_flags="-g3 -O0  -Wall -W -Wcast-align $CXXFLAGS"
       AC_MSG_NOTICE([Developer Mode is enabled.]) ],
     [AC_DEFINE([NDEBUG], [1], [Define this to suppress assert() statements.])
       AC_MSG_NOTICE([Developer Mode is disabled.])]


### PR DESCRIPTION
Fixes #443 

This fixes the --enable-developer option so that command line CXXFLAGS settings are not overridden.