### PR TITLE
check version of hdfeos2 library in configure to ensure it is not 2.20

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -738,7 +738,6 @@ if test  -n "$HDFEOS2_DIR"; then
       choke me
 #endif
   ]])], [AC_MSG_ERROR([HDFEOS2 library must be version 2.19, not version 2.20.])], [])
-  AC_MSG_RESULT([$hdfeos2_20])
   CPPFLAGS=$OLD_CPPFLAGS  
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AC_ARG_ENABLE([developer],
 )
 AM_CONDITIONAL([BES_DEVELOPER], [test "x$enable_developer" = "xyes"])
 AM_COND_IF([BES_DEVELOPER],
-    [cxx_debug_flags="-g3 -O0  -Wall -W -Wcast-align $CXXFLAGS"
+    [cxx_debug_flags="-g3 -O0  -Wall -W -Wcast-align"
       AC_MSG_NOTICE([Developer Mode is enabled.]) ],
     [AC_DEFINE([NDEBUG], [1], [Define this to suppress assert() statements.])
       AC_MSG_NOTICE([Developer Mode is disabled.])]

--- a/configure.ac
+++ b/configure.ac
@@ -724,6 +724,24 @@ AC_SUBST([HDFEOS2_LDFLAGS])
 AC_SUBST([HDFEOS2_LIBS])
 AC_SUBST([HDFEOS2_DIR])
 
+# Ensure that we have version 2.19 of HDFEOS2, not 2.20, which will
+# not work, due to adding const to some paramters of some functions.
+if test  -n "$HDFEOS2_DIR"; then
+  OLD_CPPFLAGS=$CPPFLAGS
+  CPPFLAGS="$CPPFLAGS $HDFEOS2_CPPFLAGS $HDF4_CFLAGS"
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <mfhdf.h>
+#include <hdf.h>
+#include <HdfEosDef.h>
+]], [[
+#ifndef ICHECKNAME 
+      choke me
+#endif
+  ]])], [AC_MSG_ERROR([HDFEOS2 library must be version 2.19, not version 2.20.])], [])
+  AC_MSG_RESULT([$hdfeos2_20])
+  CPPFLAGS=$OLD_CPPFLAGS  
+fi
+
 dnl HDF5 tests; We pass null for the tird argument - the interface number
 AC_CHECK_HDF5(
   [AM_CONDITIONAL([BUILD_HDF5],[true])

--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AC_ARG_ENABLE([developer],
 )
 AM_CONDITIONAL([BES_DEVELOPER], [test "x$enable_developer" = "xyes"])
 AM_COND_IF([BES_DEVELOPER],
-    [cxx_debug_flags="-g3 -O0  -Wall -W -Wcast-align"
+    [cxx_debug_flags="-g3 -O0  -Wall -W -Wcast-align $CXXFLAGS"
       AC_MSG_NOTICE([Developer Mode is enabled.]) ],
     [AC_DEFINE([NDEBUG], [1], [Define this to suppress assert() statements.])
       AC_MSG_NOTICE([Developer Mode is disabled.])]


### PR DESCRIPTION
Fixes #447 

As noted in issue #447 only HDFEOS2-2.19 can be used. 2.20 should not be used and will cause compile errors.

In this PR I add a check in configure.ac to ensure that 2.20 is not being used.