### PR TITLE
First pass at loading modules and stuff after UID switch.

### DIFF
--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -146,7 +146,7 @@ DmrppRequestHandler::DmrppRequestHandler(const string &name) :
         msg << "Disabled." << endl;
     }
     // BESDEBUG(MODULE, msg.str());
-    // INFO_LOG(msg.str() );
+    INFO_LOG(msg.str() );
     msg.str(std::string());
 
     read_key_value(DMRPP_USE_COMPUTE_THREADS_KEY, d_use_compute_threads);
@@ -159,7 +159,7 @@ DmrppRequestHandler::DmrppRequestHandler(const string &name) :
         msg << "Disabled." << endl;
     }
     // BESDEBUG(MODULE, msg.str());
-    // INFO_LOG(msg.str() );
+    INFO_LOG(msg.str() );
     msg.str(std::string());
 
 

--- a/server/daemon.cc
+++ b/server/daemon.cc
@@ -1116,6 +1116,17 @@ int main(int argc, char *argv[])
 
         store_daemon_id(getpid());
 
+        if (curr_euid == 0) {
+#ifdef BES_DEVELOPER
+            cerr << "Developer Mode: Running as root - setting group and user ids" << endl;
+#endif
+            set_group_id();
+            set_user_id();
+        }
+        else {
+            cerr << "Developer Mode: Not setting group or user ids" << endl;
+        }
+
         register_signal_handlers();
 
         // Load the modules in the conf file(s) so that the debug (log) contexts
@@ -1132,16 +1143,6 @@ int main(int argc, char *argv[])
         BESDebug::Register("server");
         BESDebug::Register("ppt");
 
-        if (curr_euid == 0) {
-#ifdef BES_DEVELOPER
-            cerr << "Developer Mode: Running as root - setting group and user ids" << endl;
-#endif
-            set_group_id();
-            set_user_id();
-        }
-        else {
-            cerr << "Developer Mode: Not setting group or user ids" << endl;
-        }
 
         // The stuff in global_args is used whenever a call to start_master_beslistener()
         // is made, so any time the BESDebug contexts are changed, a change to the


### PR DESCRIPTION
When I added code to the `DmrppRequestHandler` that wrote to the `bes.log` during initialization we discovered that this broke the server because the log lines were being written into the log file BEFORE the server switched users from `root` to `bes`. This caused the server to be unable to start because the resulting `bes.log` file was owned by `root` and the `bes_listener` processes are all running as `bes`, unable to write to the `root` owned log file.

In this PR I have reorganized the code in `daemon.cc` to load the modules and signal handlers after the UID switch.