### PR TITLE
Hyrax 388

### DIFF
--- a/modules/fileout_netcdf/FONcArray.cc
+++ b/modules/fileout_netcdf/FONcArray.cc
@@ -394,6 +394,7 @@ void FONcArray::define(int ncid)
             FONcUtils::handle_error(stax, err, __FILE__, __LINE__);
         }
 
+        BESDEBUG("fonc", "FONcArray::define() netcdf-4 version is " << _ncVersion << endl);
         if (isNetCDF4()) {
             BESDEBUG("fonc", "FONcArray::define() Working netcdf-4 branch " << endl);
            if (FONcRequestHandler::chunk_size == 0)

--- a/modules/fileout_netcdf/FONcGrid.cc
+++ b/modules/fileout_netcdf/FONcGrid.cc
@@ -143,6 +143,7 @@ void FONcGrid::convert(vector<string> embed,bool is_dap4_group)
 {
     FONcGrid::InGrid = true;
     FONcBaseType::convert(embed,is_dap4_group);
+    BESDEBUG("fonc", "FONcGrid:: version: '" << _ncVersion << "'" << endl);
     _varname = FONcUtils::gen_name(embed, _varname, _orig_varname);
     BESDEBUG("fonc", "FONcGrid::convert - converting grid " << _varname << endl);
 
@@ -172,6 +173,8 @@ void FONcGrid::convert(vector<string> embed,bool is_dap4_group)
         // FONcMap to the FONcGrid.
         if (!map_found) {
             FONcArray *fa = new FONcArray(map);
+            fa->setVersion(_ncVersion);
+            fa->setNC4DataModel(_nc4_datamodel);
             fa->convert(map_embed,is_dap4_group);
             map_found = new FONcMap(fa, true);
             FONcGrid::Maps.push_back(map_found);
@@ -193,6 +196,9 @@ void FONcGrid::convert(vector<string> embed,bool is_dap4_group)
     // jhrg 11/3/16
     if (_grid->get_array()->send_p()) {
         _arr = new FONcArray(_grid->get_array());
+        _arr->setVersion(_ncVersion);
+        _arr->setNC4DataModel(_nc4_datamodel);
+        
         _arr->convert(_embed,is_dap4_group);
     }
 

--- a/modules/fileout_netcdf/FONcTransform.cc
+++ b/modules/fileout_netcdf/FONcTransform.cc
@@ -212,7 +212,6 @@ void FONcTransform::transform()
             }
 #endif
             _fonc_vars.push_back(fb);
-
             vector<string> embed;
             fb->convert(embed);
         }

--- a/modules/fileout_netcdf/tests/bescmd/gridT.3.compression.bescmd
+++ b/modules/fileout_netcdf/tests/bescmd/gridT.3.compression.bescmd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<request reqID="some_unique_value" >
+    <setContext name="dap_format">dap2</setContext>
+    <setContainer name="c" space="catalog">/data/gridT.dods</setContainer>
+    <define name="d">
+	   <container name="c" />
+    </define>
+    <get type="dods" definition="d" returnAs="netcdf-4"/>
+</request>

--- a/modules/fileout_netcdf/tests/bescmd/gridT.3.compression.bescmd.baseline.comp
+++ b/modules/fileout_netcdf/tests/bescmd/gridT.3.compression.bescmd.baseline.comp
@@ -1,0 +1,1 @@
+		i:_DeflateLevel = 4 ;

--- a/modules/fileout_netcdf/tests/local_handler_tests_macros.m4
+++ b/modules/fileout_netcdf/tests/local_handler_tests_macros.m4
@@ -89,7 +89,7 @@ m4_define([AT_BESCMD_BINARY_DAP4_RESPONSE_TEST_NC4_ENHANCED],  [dnl
 ])
 
 dnl This is similar to the "binary data" macro above, but instead assumes the
-dnl output of besstandalone is a netcdf3 file. The binary stream is read using
+dnl output of besstandalone is a netcdf4 file. The binary stream is read using
 dnl ncdump and the output of that is compared to a baseline. Of course, this
 dnl requires ncdump be accessible.
 
@@ -228,9 +228,9 @@ m4_define([AT_BESCMD_BINARY_DAP4_RESPONSE_TEST_NC4_ENHANCED_GRP],  [dnl
 ])
 
 dnl This is similar to the "binary data" macro above, but instead assumes the
-dnl output of besstandalone is a netcdf3 file. The binary stream is read using
+dnl output of besstandalone is a netcdf4 file. The binary stream is read using
 dnl ncdump and the output of that is compared to a baseline. Of course, this
-dnl requires ncdump be accessible.
+dnl requires ncdump be accessible. The netcdf4 file is in netCDF-4 enhanced model.
 
 m4_define([AT_BESCMD_NETCDF_RESPONSE_TEST_NC4_ENHANCED_GRP],  [dnl
 
@@ -278,9 +278,9 @@ m4_define([AT_BESCMD_NETCDF_RESPONSE_TEST_NC4_ENHANCED_GRP],  [dnl
 ])
 
 dnl This is similar to the "binary data" macro above, but instead assumes the
-dnl output of besstandalone is a netcdf3 file. The binary stream is read using
+dnl output of besstandalone is a netcdf4 file. The binary stream is read using
 dnl ncdump and the output of that is compared to a baseline. Of course, this
-dnl requires ncdump be accessible.
+dnl requires ncdump be accessible. This one only checks the header of ncdump.
 
 m4_define([AT_BESCMD_NETCDF_RESPONSE_TEST_NC4_ENHANCED_GRP_HDR],  [dnl
 
@@ -300,26 +300,57 @@ m4_define([AT_BESCMD_NETCDF_RESPONSE_TEST_NC4_ENHANCED_GRP_HDR],  [dnl
          [
          AT_CHECK([besstandalone -c $abs_builddir/bes.nc4.grp.conf -i $input > test.nc])
 
-         dnl first get the version number, then the header, then the data
-         dnl AT_CHECK([ncdump -k test.nc > $baseline.ver.tmp])
+         dnl the header
          AT_CHECK([ncdump -h test.nc > $baseline.header.tmp])
          dnl REMOVE_DATE_TIME([$baseline.header.tmp])
          ],
          [
          AT_CHECK([besstandalone -c $abs_builddir/bes.nc4.grp.conf -i $input > test.nc])
-        
-         dnl AT_CHECK([ncdump -k test.nc > tmp])
-         dnl AT_CHECK([diff -b -B $baseline.ver tmp])
-        
          AT_CHECK([ncdump -h test.nc > tmp])
          dnl REMOVE_DATE_TIME([tmp])
          AT_CHECK([diff -b -B $baseline.header tmp])
-        
+         AT_XFAIL_IF([test z$2 = zxfail])
+         ])
+
+    AT_CLEANUP
+])
+
+dnl Only check if the netcdf-4 file is compressed.
+
+m4_define([AT_BESCMD_NETCDF_RESPONSE_TEST_NC4_COMPRESSION],  [dnl
+    AT_SETUP([$1])
+    AT_KEYWORDS([nc4 enhanced binary ncdump])
+
+    input=$abs_srcdir/$1
+    baseline=$abs_srcdir/$1.baseline
+    pass=$2
+    repeat=$3
+    compression="Deflate"
+
+    AS_IF([test -n "$repeat" -a x$repeat = xrepeat -o x$repeat = xcached], [repeat="-r 3"])
+
+    AS_IF([test -z "$at_verbose"], [echo "COMMAND: besstandalone $repeat -c $bes_conf -i $1"])
+
+    AS_IF([test -n "$baselines" -a x$baselines = xyes],
+         [
+         AT_CHECK([besstandalone -c $abs_builddir/bes.conf -i $input > test.nc])
+
+         AT_CHECK([ncdump -sh test.nc > tmp])
+         AT_CHECK([grep -m 1 $compression tmp >$baseline.comp.tmp]) 
+ 
+         ],
+         [
+         AT_CHECK([besstandalone -c $abs_builddir/bes.conf -i $input > test.nc])
+         AT_CHECK([ncdump -sh test.nc > tmp])
+         dnl only need to check if the deflate compression appears.
+         AT_CHECK([grep -m 1 $compression tmp >tmp2]) 
+         AT_CHECK([diff -b -B $baseline.comp tmp2])
         
          AT_XFAIL_IF([test z$2 = zxfail])
          ])
 
     AT_CLEANUP
+
 ])
 
 

--- a/modules/fileout_netcdf/tests/testsuite.at
+++ b/modules/fileout_netcdf/tests/testsuite.at
@@ -168,3 +168,6 @@ dnl The whole file is supposed to convert to netCDF
 AT_BESCMD_NETCDF_RESPONSE_TEST_NC4_ENHANCED(bescmd/grid_1_2d_dap2_ce_empty.h5.2.bescmd)
 AT_BESCMD_NETCDF_RESPONSE_TEST_NC4_ENHANCED(bescmd/grid_1_2d_dap2_to_4_ce_empty.h5.2.bescmd)
 AT_BESCMD_NETCDF_RESPONSE_TEST_NC4_ENHANCED_GRP(bescmd/d_group_dap4_ce_empty.h5.2.bescmd)
+
+dnl Add a test to check if the compression is turned on for netCDF-4 
+AT_BESCMD_NETCDF_RESPONSE_TEST_NC4_COMPRESSION(bescmd/gridT.3.compression.bescmd)


### PR DESCRIPTION
Fix the bug that the in-memory compression is not turned on when an netCDF-4 file output is requested for a DAP2 Grid.