### PR TITLE
Trusted logging

### DIFF
--- a/http/AllowedHosts.cc
+++ b/http/AllowedHosts.cc
@@ -183,16 +183,10 @@ bool AllowedHosts::is_allowed(shared_ptr<http::url> candidate_url) {
         BESDEBUG(MODULE, prolog << "File Access Allowed: " << (isAllowed ? "true " : "false ") << endl);
     } else if(candidate_url->protocol() == HTTPS_PROTOCOL || candidate_url->protocol() == HTTP_PROTOCOL ){
 
-        // Always run this check so we can track which URLs are
-        // being "trusted" and but are technically "not allowed"
-        isAllowed = check(candidate_url->str());
+        isAllowed = candidate_url->is_trusted() || check(candidate_url->str());
 
-        // If the URL does not pass check, we see is it's marked trusted.
-        if (!isAllowed && candidate_url->is_trusted()) {
-            // It's not allowed but is trusted, so log that
-            INFO_LOG(prolog << "Candidate URL failed check() but is marked trusted. url: " << candidate_url->str() <<  endl);
-            // And mark it allowed.
-            isAllowed = true;
+        if (candidate_url->is_trusted()) {
+            INFO_LOG(prolog << "Candidate URL is marked trusted, allowing. url: " << candidate_url->str() <<  endl);
         }
         BESDEBUG(MODULE, prolog << "HTTP Access Allowed: " << (isAllowed ? "true " : "false ") << endl);
     }

--- a/http/AllowedHosts.h
+++ b/http/AllowedHosts.h
@@ -61,6 +61,8 @@ private:
 
     AllowedHosts();
 
+    bool check(const std::string &url);
+
 public:
     virtual ~AllowedHosts() {}
 

--- a/http/unit-tests/allowed_hosts_test.ini
+++ b/http/unit-tests/allowed_hosts_test.ini
@@ -26,3 +26,4 @@ BES.Catalog.catalog.RootDirectory=/tmp
 BES.Catalog.catalog.TypeMatch=something:regex;
 
 BES.LogName=/tmp/bes.log
+

--- a/http/unit-tests/allowed_hosts_test.ini
+++ b/http/unit-tests/allowed_hosts_test.ini
@@ -24,3 +24,5 @@ BES.Catalog.catalog.RootDirectory=/tmp
 # The TypeMatch is required, but since these tests don't actually use the value,
 # it can be anything that matches the form of '<thing>:<regex>;' jhrg 7/6/18
 BES.Catalog.catalog.TypeMatch=something:regex;
+
+BES.LogName=/tmp/bes.log


### PR DESCRIPTION
This change adds a call to INFO_LOG() everytime AllowedHosts allows a URL that is marked trusted but that does not pass the normative test `AllowedHosts::check()`