### PR TITLE
Added new dmr++ metadata including bes and libdap version

### DIFF
--- a/dispatch/TheBESKeys.cc
+++ b/dispatch/TheBESKeys.cc
@@ -523,6 +523,30 @@ string TheBESKeys::dump() const
 }
 
 
+string TheBESKeys::get_as_config() const
+{
+    stringstream ss;
+    ss << endl;
+    ss << "# TheBESKeys::get_as_config()" << endl;
+    if (d_the_keys && d_the_keys->size()) {
+        Keys_citer i = d_the_keys->begin();
+        Keys_citer ie = d_the_keys->end();
+        for (; i != ie; i++) {
+            string name = (*i).first;
+            vector<string> values = (*i).second;
+            bool first = true;
+            for(string value: values){
+                ss << name << (first?"=":"+=") << value << endl;
+                first = false;
+            }
+        }
+    }
+    else {
+        ss << "# TheBESKeys are empty()" << endl;
+    }
+    return ss.str();
+}
+
 
 #define MAP_SEPARATOR ":"
 

--- a/dispatch/TheBESKeys.h
+++ b/dispatch/TheBESKeys.h
@@ -177,6 +177,7 @@ public:
     virtual void dump(std::ostream &strm) const;
     virtual std::string dump() const;
 
+    std::string get_as_config() const;
     /**
      * TheBESKeys::ConfigFile provides a way for the daemon and test code to
      * set the location of a particular configuration file.

--- a/modules/dmrpp_module/build_dmrpp.cc
+++ b/modules/dmrpp_module/build_dmrpp.cc
@@ -32,7 +32,6 @@
 #include <libgen.h>
 
 #include <D4Attributes.h>
-
 #include <Array.h>
 
 //#define H5D_FRIEND		// Workaround, needed to use H5D_chunk_rec_t
@@ -790,7 +789,7 @@ string cmdln(int argc, char *argv[]){
     return ss.str();
 }
 
-void inject_version_and_config(int argc, char *argv[], shared_ptr<DMRpp> dmrpp){
+void inject_version_and_configuration(int argc, char **argv, shared_ptr<DMRpp> dmrpp){
 
     // Build the version attributes for the DMR++
     D4Attribute *version = new D4Attribute("build_dmrpp_meta", StringToD4AttributeType("container"));
@@ -835,8 +834,9 @@ int main(int argc, char *argv[]) {
     string dmr_name = "";
     string url_name = "";
     int status = 0;
+    bool add_production_metadata = false;
 
-    GetOpt getopt(argc, argv, "c:f:r:u:dhvV");
+    GetOpt getopt(argc, argv, "c:f:r:u:dhvVM");
     int option_char;
     while ((option_char = getopt()) != -1) {
         switch (option_char) {
@@ -856,15 +856,23 @@ int main(int argc, char *argv[]) {
             case 'f':
                 h5_file_name = getopt.optarg;
                 break;
+
             case 'r':
                 dmr_name = getopt.optarg;
                 break;
+
             case 'u':
                 url_name = getopt.optarg;
                 break;
+
             case 'c':
                 TheBESKeys::ConfigFile = getopt.optarg;
                 break;
+
+            case 'M':
+                add_production_metadata = true;
+                break;
+
             case 'h':
                 cerr
                         << "build_dmrpp [-v] -c <bes.conf> -f <data file>  [-u <href url>] | build_dmrpp -f <data file> -r <dmr file> | build_dmrpp -h"
@@ -905,7 +913,9 @@ int main(int argc, char *argv[]) {
                 return 1;
             }
 
-            inject_version_and_config(argc, argv, dmrpp);
+            if(add_production_metadata) {
+                inject_version_and_configuration(argc, argv, dmrpp);
+            }
 
             // iterate over all the variables in the DMR
             get_chunks_for_all_variables(file, dmrpp->root());

--- a/modules/dmrpp_module/build_dmrpp.cc
+++ b/modules/dmrpp_module/build_dmrpp.cc
@@ -789,7 +789,7 @@ string cmdln(int argc, char *argv[]){
     return ss.str();
 }
 
-void inject_version_and_configuration(int argc, char **argv, shared_ptr<DMRpp> dmrpp){
+void inject_version_and_configuration(int argc, char **argv, DMRpp *dmrpp){
 
     // Build the version attributes for the DMR++
     D4Attribute *version = new D4Attribute("build_dmrpp_meta", StringToD4AttributeType("container"));
@@ -898,13 +898,13 @@ int main(int argc, char *argv[]) {
         // given HDF5 dataset
         if (!dmr_name.empty()) {
             // Get dmr:
-            shared_ptr<DMRpp> dmrpp(new DMRpp);
+            DMRpp dmrpp;
             DmrppTypeFactory dtf;
-            dmrpp->set_factory(&dtf);
+            dmrpp.set_factory(&dtf);
 
             ifstream in(dmr_name.c_str());
             D4ParserSax2 parser;
-            parser.intern(in, dmrpp.get(), false);
+            parser.intern(in, &dmrpp, false);
 
             // Open the hdf5 file
             file = H5Fopen(h5_file_name.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
@@ -914,14 +914,14 @@ int main(int argc, char *argv[]) {
             }
 
             if(add_production_metadata) {
-                inject_version_and_configuration(argc, argv, dmrpp);
+                inject_version_and_configuration(argc, argv, &dmrpp);
             }
 
             // iterate over all the variables in the DMR
-            get_chunks_for_all_variables(file, dmrpp->root());
+            get_chunks_for_all_variables(file, dmrpp.root());
 
             XMLWriter writer;
-            dmrpp->print_dmrpp(writer, url_name);
+            dmrpp.print_dmrpp(writer, url_name);
 
             cout << writer.get_doc();
         } else {

--- a/modules/dmrpp_module/data/get_dmrpp.in
+++ b/modules/dmrpp_module/data/get_dmrpp.in
@@ -529,6 +529,11 @@ function mkDapRequest() {
   # This is the return value of the function!
   echo "${DAP_RESPONSE}"
 
+#----------------------------------------------------------
+# I commented this out because it was screwing things up
+# to delete the configuration after the DMR was created but
+# before build_dmrpp had been run. ndp 11/01/21
+#
   # Clean up temporary files if not in debug mode
   #if test -z "${verbose}"; then
     #echo "DAP_CMD: ${DAP_CMD}"
@@ -536,6 +541,7 @@ function mkDapRequest() {
     # rm -f ${DAP_CMD} ${BES_CONF}
   #  ;
   #fi
+#----------------------------------------------------------
 
 }
 ########################################################################################################################
@@ -552,7 +558,7 @@ function mk_dmrpp() {
     echo "  BES_DATA_ROOT: ${BES_DATA_ROOT}"
     echo "       datafile: ${datafile}"
     echo " full_data_path: ${full_data_path}"
-    echo "       bes.conf: ${BES_CONF} "`ls -l  ${BES_CONF}`
+    echo "       bes.conf: ${BES_CONF} "
     echo "       dmr_file: ${SOURCE_DMR}"
     echo "      dmrpp_url: ${dmrpp_url}"
     echo "    output_file: ${output_file}"
@@ -564,6 +570,7 @@ function mk_dmrpp() {
     prms="${prms} -f ${full_data_path} "
     prms="${prms} -r ${SOURCE_DMR} "
     prms="${prms} -u ${dmrpp_url} "
+    prms="${prms} -M " # Adds the production metadata (version numbers and configuration) to the dmr++ result.
     if test -n "$verbose"; then echo "   build_params: ${prms}" >&2; fi
     if test -n "$output_file"; then
       build_dmrpp ${prms} >"${output_file}"
@@ -1056,7 +1063,6 @@ function dmrpp_value_test() {
 ########################################################################################################################
 
 BES_CONF=$(make_bes_conf "${bes_conf_file}" "${site_conf_file}")
-
 SOURCE_DMR=$(mkDapRequest "${input_data_file}" dmr)
 
 # If 'just_dmr' is set redirect SOURCE_DMR to either <stdout> or $output_file

--- a/modules/dmrpp_module/data/get_dmrpp.in
+++ b/modules/dmrpp_module/data/get_dmrpp.in
@@ -530,11 +530,12 @@ function mkDapRequest() {
   echo "${DAP_RESPONSE}"
 
   # Clean up temporary files if not in debug mode
-  if test -z "$verbose"; then
+  #if test -z "${verbose}"; then
     #echo "DAP_CMD: ${DAP_CMD}"
     #echo "BES_CONF: ${BES_CONF}"
-    rm -f ${DAP_CMD} ${BES_CONF}
-  fi
+    # rm -f ${DAP_CMD} ${BES_CONF}
+  #  ;
+  #fi
 
 }
 ########################################################################################################################
@@ -551,7 +552,7 @@ function mk_dmrpp() {
     echo "  BES_DATA_ROOT: ${BES_DATA_ROOT}"
     echo "       datafile: ${datafile}"
     echo " full_data_path: ${full_data_path}"
-    echo "       bes.conf: ${BES_CONF}"
+    echo "       bes.conf: ${BES_CONF} "`ls -l  ${BES_CONF}`
     echo "       dmr_file: ${SOURCE_DMR}"
     echo "      dmrpp_url: ${dmrpp_url}"
     echo "    output_file: ${output_file}"
@@ -784,7 +785,10 @@ function dap4_attributes() {
 #
 function dap4_vars() {
   grep \
+    -e "<Int8" \
+    -e "<UInt8" \
     -e "<Byte" \
+    -e "<Char" \
     -e "<Int" \
     -e "<UInt" \
     -e "<Float" \
@@ -1052,6 +1056,7 @@ function dmrpp_value_test() {
 ########################################################################################################################
 
 BES_CONF=$(make_bes_conf "${bes_conf_file}" "${site_conf_file}")
+
 SOURCE_DMR=$(mkDapRequest "${input_data_file}" dmr)
 
 # If 'just_dmr' is set redirect SOURCE_DMR to either <stdout> or $output_file
@@ -1067,9 +1072,15 @@ if [ -n "${just_dmr}" ]; then
   exit 0
 fi
 
+
 mk_dmrpp "${input_data_file}"
 retval=$?
 #echo "retval: ${retval}";
+
+if test -z "${verbose}"; then
+    if test -f "${BES_CONF}" ; then rm -f "${BES_CONF}"; fi
+    if test -f "${DAP_CMD}" ; then rm -f "${DAP_CMD}"; fi
+fi
 
 if test -n "${merge_missing_vars}"; then
 


### PR DESCRIPTION
Added dmr++ production metadata, including the bes and libdap versions and TheBESKeys contents to a top level attribute table in the dmr++ called  `build_dmrpp_meta` 
This is controlled by the new `-M` switch for build_dmrpp. The `get_dmrpp` script has been changed to always utilize the `-M` switch when invoking `build_dmrpp`
