### PR TITLE
adding version as a state variable in DMRpp

### DIFF
--- a/modules/dmrpp_module/DMRpp.cc
+++ b/modules/dmrpp_module/DMRpp.cc
@@ -110,6 +110,11 @@ void DMRpp::print_dmrpp(XMLWriter &xml, const string &href, bool constrained, bo
                 (const xmlChar*) href.c_str()) < 0)
                 throw InternalErr(__FILE__, __LINE__, "Could not write attribute for href");
 
+        if (!get_version().empty())
+            if (xmlTextWriterWriteAttribute(xml.get_writer(), (const xmlChar*)string(DmrppCommon::d_ns_prefix).append(":version").c_str(),
+                                            (const xmlChar*) get_version().c_str()) < 0)
+                throw InternalErr(__FILE__, __LINE__, "Could not write attribute for version");
+
 
         root()->print_dap4(xml, constrained);
 

--- a/modules/dmrpp_module/DMRpp.h
+++ b/modules/dmrpp_module/DMRpp.h
@@ -46,6 +46,7 @@ class DmrppTypeFactory;
 class DMRpp : public libdap::DMR {
 private:
     std::string d_href;
+    std::string d_version;
     bool d_print_chunks;
 
 public:
@@ -58,6 +59,9 @@ public:
 
     virtual std::string get_href() const { return d_href; }
     virtual void set_href(const std::string &h) { d_href = h; }
+
+    virtual std::string get_version() const { return d_version; }
+    virtual void set_version(const std::string &version) { d_version = version; }
 
     virtual bool get_print_chunks() const { return d_print_chunks; }
     virtual void set_print_chunks(bool pc) { d_print_chunks = pc; }

--- a/modules/dmrpp_module/build_dmrpp.cc
+++ b/modules/dmrpp_module/build_dmrpp.cc
@@ -798,6 +798,8 @@ string cmdln(int argc, char *argv[]){
 
 void inject_version_and_configuration(int argc, char **argv, DMRpp *dmrpp){
 
+    dmrpp->set_version(CVER);
+
     // Build the version attributes for the DMR++
     D4Attribute *version = new D4Attribute("build_dmrpp_metadata", StringToD4AttributeType("container"));
 


### PR DESCRIPTION
This not done and I ran into the libdap `DMR::dmr_version()` ,method. the value of  `d_dmr_version` is serialized in the `<Dataset>` element's XML attribute `dmrVersion`.

Should we just use that and skip what I was doing here?

    /// The version of the DMR document
    std::string d_dmr_version;
