### PR TITLE
Changed how the code links to the dap_module to fix 'non-portable' warnings

### DIFF
--- a/bes.spec.all_static.in
+++ b/bes.spec.all_static.in
@@ -98,7 +98,10 @@ developing applications that use %{name}.
 chmod a-x dispatch/BESStreamResponseHandler*
 
 %build
-%configure --disable-static --disable-dependency-tracking --with-dependencies=$prefix/deps --with-build=@PACKAGE_BUILD_NUMBER@
+%configure --disable-dependency-tracking --with-dependencies=$prefix/deps --with-build=@PACKAGE_BUILD_NUMBER@
+# Try removing --disable-static from the above so that libdap_module.a is built.
+# The code links with this to avoid linking to a Shared Object library that is
+# really a run-time loaded module. jhrg 1/21/22
 make %{?_smp_mflags}
 
 # make docs
@@ -127,6 +130,10 @@ sed -i.dist -e 's:=/tmp:=%{bescachedir}:' \
 rm -rf $RPM_BUILD_ROOT
 make install DESTDIR=$RPM_BUILD_ROOT
 find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
+# Static libraries are now built so the code can link against libdap_module.a in
+# some special cases. But, those should not be part of the RPM package so remove
+# them here (along with the libtool archives). jhrg 1/21/22
+find $RPM_BUILD_ROOT -name '*.a' -exec rm -f {} ';'
 mkdir -p $RPM_BUILD_ROOT%{bescachedir}
 chmod g+w $RPM_BUILD_ROOT%{bescachedir}
 mkdir -p $RPM_BUILD_ROOT%{bespkidir}/{cacerts,public}

--- a/dap/unit-tests/Makefile.am
+++ b/dap/unit-tests/Makefile.am
@@ -8,8 +8,13 @@ AUTOMAKE_OPTIONS = foreign
 AM_CPPFLAGS = -I$(top_srcdir)/dap -I$(top_srcdir)/dispatch $(DAP_CFLAGS) \
 -I$(top_srcdir)/modules/dmrpp_module
 
-LDADD = $(top_builddir)/dispatch/libbes_dispatch.la $(top_builddir)/dap/libdap_module.la \
-$(top_builddir)/modules/dmrpp_module/libdmrpp_module.la -ltest-types $(DAP_LIBS) $(LIBS)
+# Removed linking with shared objects. jhrg 1/21/11
+# LDADD = $(top_builddir)/dispatch/libbes_dispatch.la $(top_builddir)/dap/libdap_module.la \
+# $(top_builddir)/modules/dmrpp_module/libdmrpp_module.la -ltest-types $(DAP_LIBS) $(LIBS)
+
+LDADD = $(top_builddir)/dispatch/libbes_dispatch.la $(top_builddir)/dap/.libs/libdap_module.a \
+$(top_builddir)/modules/dmrpp_module/.libs/libdmrpp_module.a -ltest-types $(DAP_LIBS) $(LIBS)
+
 
 if CPPUNIT
 AM_CPPFLAGS += $(CPPUNIT_CFLAGS)

--- a/modules/cmr_module/unit-tests/Makefile.am
+++ b/modules/cmr_module/unit-tests/Makefile.am
@@ -6,7 +6,8 @@ AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/modules -I$(top_srcdir)/modules/cm
 -I$(top_srcdir)/dispatch -I$(top_srcdir)/dap -I$(top_srcdir)/http $(DAP_CFLAGS)
 
 # Added -lz for ubuntu
-LIBADD = $(BES_DISPATCH_LIB) $(BES_DAP_LIB) $(BES_EXTRA_LIBS) $(BES_HTTP_LIB)\
+STATIC_DAP_MODULE = $(top_builddir)/dap/.libs/libdap_module.a
+LIBADD = $(BES_DISPATCH_LIB) $(STATIC_DAP_MODULE) $(BES_EXTRA_LIBS) $(BES_HTTP_LIB)\
 $(DAP_SERVER_LIBS) $(DAP_CLIENT_LIBS) -lz
 
 if CPPUNIT

--- a/modules/dmrpp_module/Makefile.am
+++ b/modules/dmrpp_module/Makefile.am
@@ -65,10 +65,14 @@ $(H5_LDFLAGS) $(H5_LIBS) $(OPENSSL_LDFLAGS) $(OPENSSL_LIBS) -ltest-types
 bin_PROGRAMS = build_dmrpp check_dmrpp merge_dmrpp reduce_mdf
 noinst_PROGRAMS = retriever superchunky
 
+STATIC_DAP_MODULE = $(top_builddir)/dap/.libs/libdap_module.a
+
 # build_dmrpp config
 build_dmrpp_CPPFLAGS = $(AM_CPPFLAGS) $(H5_CPPFLAGS) -I$(srcdir)/../hdf5_handler
 build_dmrpp_SOURCES = $(BES_SRCS) $(BES_HDRS) $(BUILD_DMRPP) build_dmrpp.cc $(srcdir)/../hdf5_handler/h5common.cc
-build_dmrpp_LDFLAGS = $(BES_DAP_LIB_LDFLAGS)
+build_dmrpp_LDFLAGS = $(STATIC_DAP_MODULE)
+# Was using $(BES_DAP_LIB_LDFLAGS) which caused linking to the .so library. On linux
+# this is flagged as not portable. jhrg 1/21/2
 build_dmrpp_LDADD = $(BES_DISPATCH_LIB) $(BES_HTTP_LIB) $(BES_EXTRA_LIBS) \
 $(H5_LDFLAGS) $(H5_LIBS) $(DAP_SERVER_LIBS) $(DAP_CLIENT_LIBS) $(OPENSSL_LDFLAGS) \
 $(OPENSSL_LIBS) $(XML2_LIBS) $(BYTESWAP_LIBS) -lz
@@ -89,7 +93,7 @@ reduce_mdf_LDADD = $(OPENSSL_LDFLAGS) $(OPENSSL_LIBS) -lz
 # retriever config
 retriever_CPPFLAGS = $(AM_CPPFLAGS)
 retriever_SOURCES = $(BES_SRCS) $(BES_HDRS) $(BUILD_DMRPP) retriever.cc
-retriever_LDFLAGS = $(BES_DAP_LIB_LDFLAGS)
+retriever_LDFLAGS = $(STATIC_DAP_MODULE)
 retriever_LDADD = $(BES_DISPATCH_LIB) $(BES_HTTP_LIB) $(BES_EXTRA_LIBS) \
 $(H5_LDFLAGS) $(H5_LIBS) $(DAP_SERVER_LIBS) $(DAP_CLIENT_LIBS) $(OPENSSL_LDFLAGS) \
 $(OPENSSL_LIBS) $(XML2_LIBS) $(BYTESWAP_LIBS) -lz
@@ -97,7 +101,7 @@ $(OPENSSL_LIBS) $(XML2_LIBS) $(BYTESWAP_LIBS) -lz
 # superchunky config
 superchunky_CPPFLAGS = $(AM_CPPFLAGS)
 superchunky_SOURCES = $(BES_SRCS) $(BES_HDRS) $(BUILD_DMRPP) SuperChunky.cc
-superchunky_LDFLAGS = $(BES_DAP_LIB_LDFLAGS)
+superchunky_LDFLAGS = $(STATIC_DAP_MODULE)
 superchunky_LDADD = $(BES_DISPATCH_LIB) $(BES_HTTP_LIB) $(BES_EXTRA_LIBS) \
 $(H5_LDFLAGS) $(H5_LIBS) $(DAP_SERVER_LIBS) $(DAP_CLIENT_LIBS) $(OPENSSL_LDFLAGS) \
 $(OPENSSL_LIBS) $(XML2_LIBS) $(BYTESWAP_LIBS) -lz

--- a/modules/dmrpp_module/unit-tests/Makefile.am
+++ b/modules/dmrpp_module/unit-tests/Makefile.am
@@ -13,7 +13,8 @@ AM_CPPFLAGS = $(H5_CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/modules -I$(top_src
 $(DAP_CFLAGS) $(OPENSSL_INC)
 
 # Added -lz for ubuntu
-LIBADD = $(BES_DISPATCH_LIB) $(BES_DAP_LIB) $(BES_HTTP_LIB) $(BES_EXTRA_LIBS) \
+STATIC_DAP_MODULE = $(top_builddir)/dap/.libs/libdap_module.a
+LIBADD = $(BES_DISPATCH_LIB) $(STATIC_DAP_MODULE) $(BES_HTTP_LIB) $(BES_EXTRA_LIBS) \
 $(H5_LDFLAGS) $(H5_LIBS) $(DAP_SERVER_LIBS) $(DAP_CLIENT_LIBS) \
 $(OPENSSL_LDFLAGS) $(OPENSSL_LIBS) $(XML2_LIBS) -lz
 


### PR DESCRIPTION

The code was linking against dap_module.la which becomes dap_module.so
which is actually a 'module' and not a real library. This generates
warnings from libtool and also, on linux, with rpath. The changes are
mostly in unit-tests but also appears in the dmrpp tools like build_dmrpp.