### PR TITLE
Error redux

### DIFF
--- a/dap/BESDapError.cc
+++ b/dap/BESDapError.cc
@@ -31,32 +31,15 @@
 //      jgarcia     Jose Garcia <jgarcia@ucar.edu>
 
 #include <sstream>
-#include <iostream>
-
-using std::ostringstream;
-using std::endl;
 
 #include "BESDapError.h"
-#include "BESContextManager.h"
-#include "BESDapErrorInfo.h"
 
-#if 0
-#include "BESInfoList.h"
-#include "TheBESKeys.h"
-#endif
+using namespace std;
 
-BESDapError::BESDapError(const string &s, bool fatal, libdap::ErrorCode ec, const string &file, int line) :
-        BESError(s, 0, file, line), d_dap_error_code(ec)
+BESDapError::BESDapError(string msg, bool fatal, libdap::ErrorCode ec, string file, unsigned int line) :
+        BESError(std::move(msg), 0, std::move(file), line), d_dap_error_code(ec)
 {
     set_bes_error_type(convert_error_code(ec, fatal));
-
-#if 0
-    if (fatal)
-    set_bes_error_type(BES_INTERNAL_FATAL_ERROR);
-    else
-    set_bes_error_type(BES_INTERNAL_ERROR);
-#endif
-
 }
 
 /** @brief converts the libdap error code to the bes error type
@@ -89,30 +72,24 @@ int BESDapError::convert_error_code(int error_code, int current_error_type)
     case undefined_error:
     case unknown_error: {
         return BES_INTERNAL_ERROR;
-        break;
     }
     case internal_error: {
         return BES_INTERNAL_FATAL_ERROR;
-        break;
     }
     case no_such_file: {
         return BES_NOT_FOUND_ERROR;
-        break;
     }
     case no_such_variable:
     case malformed_expr: {
         return BES_SYNTAX_USER_ERROR;
-        break;
     }
     case no_authorization:
     case cannot_read_file:
     case dummy_message: {
         return BES_FORBIDDEN_ERROR;
-        break;
     }
     default: {
         return BES_INTERNAL_ERROR;
-        break;
     }
     }
 }
@@ -121,199 +98,6 @@ int BESDapError::convert_error_code(int error_code, bool fatal)
 {
     return convert_error_code(error_code, (fatal) ? BES_INTERNAL_FATAL_ERROR: BES_INTERNAL_ERROR);
 }
-
-#if 0
-void log_error(BESError &e)
-{
-    string error_name = "";
-    // TODO This should be configurable; I'm changing the values below to always log all errors.
-    // I'm also confused about the actual intention. jhrg 11/14/17
-    bool only_log_to_verbose = false;
-    switch (e.get_bes_error_type()) {
-    case BES_INTERNAL_FATAL_ERROR:
-        error_name = "BES Internal Fatal Error";
-        break;
-
-    case BES_INTERNAL_ERROR:
-        error_name = "BES Internal Error";
-        break;
-
-    case BES_SYNTAX_USER_ERROR:
-        error_name = "BES User Syntax Error";
-        only_log_to_verbose = false; // TODO Was 'true.' jhrg 11/14/17
-        break;
-
-    case BES_FORBIDDEN_ERROR:
-        error_name = "BES Forbidden Error";
-        break;
-
-    case BES_NOT_FOUND_ERROR:
-        error_name = "BES Not Found Error";
-        only_log_to_verbose = false; // TODO was 'true.' jhrg 11/14/17
-        break;
-
-    default:
-        error_name = "Unrecognized BES Error";
-        break;
-    }
-
-    if (only_log_to_verbose) {
-            VERBOSE("ERROR: " << error_name << ", type: " << e.get_bes_error_type() << ", file: " << e.get_file() << ":"
-                    << e.get_line()  << ", message: " << e.get_message() << endl);
-
-    }
-	else {
-		LOG("ERROR: " << error_name << ": " << e.get_message() << endl);
-	}
-}
-#endif
-
-
-#if 0
-/** @brief Register an exception handler with the manager
-
- Signature of the function is as follows:
-
- int function_name( BESError &e, BESDataHandlerInterface &dhi ) ;
-
- If the handler does not handle the exception then it should return
- 0. Otherwise, return a status code. Pre-defined status
- codes can be found in BESError.h
-
- @param ehm exception handler function
- @see BESError
- */
-void BESDapError::add_ehm_callback(ptr_bes_ehm ehm)
-{
-    _ehm_list.push_back(ehm);
-}
-#endif
-
-
-#if 0
-int BESDapError::handleBESError(BESError &e, BESDataHandlerInterface &dhi)
-{
-    // Let's see if any of these exception callbacks can handle the
-    // exception. The first callback that can handle the exception wins
-    for (ehm_iter i = _ehm_list.begin(), ei = _ehm_list.end(); i != ei; ++i) {
-        ptr_bes_ehm p = *i;
-        int handled = p(e, dhi);
-        if (handled) {
-            return handled;
-        }
-    }
-
-    dhi.error_info = BESInfoList::TheList()->build_info();
-    string action_name = dhi.action_name;
-    if (action_name.empty()) action_name = "BES";
-    dhi.error_info->begin_response(action_name, dhi);
-
-    string administrator = "";
-    try {
-        bool found = false;
-        vector<string> vals;
-        string key = "BES.ServerAdministrator";
-        TheBESKeys::TheKeys()->get_value(key, administrator, found);
-    }
-    catch (...) {
-        administrator = DEFAULT_ADMINISTRATOR;
-    }
-    if (administrator.empty()) {
-        administrator = DEFAULT_ADMINISTRATOR;
-    }
-    dhi.error_info->add_exception(e, administrator);
-    dhi.error_info->end_response();
-
-    // Write a message in the log file about this error...
-    log_error(e);
-
-    return e.get_bes_error_type();
-}
-
-/** @brief handles exceptions if the error context is set to dap2
- *
- * If the error context from the BESContextManager is set to dap2 then
- * handle all exceptions by returning transmitting them as dap2 error
- * messages.
- *
- * @param e exception to be handled
- * @param dhi structure that holds request and response information
- */
-int BESDapError::handleException(BESError &e, BESDataHandlerInterface &dhi)
-{
-<<<<<<< HEAD
-    // If we are handling errors in a dap2 context, then create a
-    // DapErrorInfo object to transmit/print the error as a dap2
-    // response.
-    bool found = false;
-    // I changed 'dap_format' to 'errors' in the following line. jhrg 10/6/08
-    string context = BESContextManager::TheManager()->get_context("errors", found);
-    if (context == "dap2" | context == "dap") {
-        ErrorCode ec = unknown_error;
-        BESDapError *de = dynamic_cast<BESDapError*>(&e);
-        if (de) {
-            ec = de->get_dap_error_code();
-        }
-        e.set_bes_error_type(convert_error_code(ec, e.get_bes_error_type()));
-        dhi.error_info = new BESDapErrorInfo(ec, e.get_message());
-
-        return e.get_bes_error_type();
-    }
-    else {
-        // If we are not in a dap2 context and the exception is a dap
-        // handler exception, then convert the error message to include the
-        // error code. If it is or is not a dap exception, we simply return
-        // that the exception was not handled.
-        BESError *e_p = &e;
-        BESDapError *de = dynamic_cast<BESDapError*>(e_p);
-        if (de) {
-            ostringstream s;
-            s << "libdap exception building response: error_code = " << de->get_dap_error_code() << ": "
-            << de->get_message();
-            e.set_message(s.str());
-            e.set_bes_error_type(convert_error_code(de->get_dap_error_code(), e.get_bes_error_type()));
-        }
-    }
-    return 0;
-=======
-	// If we are handling errors in a dap2 context, then create a
-	// DapErrorInfo object to transmit/print the error as a dap2
-	// response.
-	bool found = false;
-	// I changed 'dap_format' to 'errors' in the following line. jhrg 10/6/08
-	string context = BESContextManager::TheManager()->get_context("errors", found);
-	if (context == "dap2") {
-		ErrorCode ec = unknown_error;
-		BESDapError *de = dynamic_cast<BESDapError*>(&e);
-		if (de) {
-			ec = de->get_dap_error_code();
-		}
-		e.set_bes_error_type(convert_error_code(ec, e.get_bes_error_type()));
-		dhi.error_info = new BESDapErrorInfo(ec, e.get_message());
-
-		return e.get_bes_error_type();
-	}
-	else {
-		// If we are not in a dap2 context and the exception is a dap
-		// handler exception, then convert the error message to include the
-		// error code. If it is or is not a dap exception, we simply return
-		// that the exception was not handled.
-		BESError *e_p = &e;
-		BESDapError *de = dynamic_cast<BESDapError*>(e_p);
-		if (de) {
-			ostringstream s;
-			s << "libdap exception building response: error_code = " << de->get_dap_error_code() << ": "
-					<< de->get_message();
-			e.set_message(s.str());
-			e.set_bes_error_type(convert_error_code(de->get_dap_error_code(), e.get_bes_error_type()));
-		}
-	}
-
-	return 0;
->>>>>>> master
-}
-#endif
-
 
 /** @brief dumps information about this object
  *

--- a/dap/BESDapError.h
+++ b/dap/BESDapError.h
@@ -58,44 +58,27 @@ typedef int (*ptr_bes_ehm)(BESError &e, BESDataHandlerInterface &dhi);
  */
 class BESDapError: public BESError {
 private:
-    libdap::ErrorCode d_dap_error_code;
+    libdap::ErrorCode d_dap_error_code {unknown_error};
 
 protected:
-    BESDapError() : d_dap_error_code(unknown_error)
-    {
-    }
-
+    BESDapError() = default;
 
 public:
-    BESDapError(const string &s, bool fatal, libdap::ErrorCode ec, const string &file, int line);
+    BESDapError(std::string s, bool fatal, libdap::ErrorCode ec, std::string file, unsigned int line);
 
-    virtual ~BESDapError()
-    {
-    }
+    ~BESDapError() override = default;
 
-    //Deprecated because it's only available in this class.
+    /// Deprecated because it's only available in this class.
     /// @deprecated
     virtual int get_dap_error_code() const
     {
         return d_dap_error_code;
     }
 
-#if 0
-    virtual int get_bes_error_type()
-    {
-        return (int)d_dap_error_code;
-    }
-#endif
+    void dump(ostream &strm) const override;
 
-    virtual void dump(ostream &strm) const;
-
-    int convert_error_code(int error_code, int current_error_type);
-    int convert_error_code(int error_code, bool fatal);
-
-#if 0
-    static int handleException(BESError &e, BESDataHandlerInterface &dhi);
-#endif
-
+    static int convert_error_code(int error_code, int current_error_type);
+    static int convert_error_code(int error_code, bool fatal);
 };
 
 #endif // BESDapError_h_

--- a/dispatch/BESError.cc
+++ b/dispatch/BESError.cc
@@ -40,7 +40,7 @@
 using namespace std;
 
 string
-BESError::get_verbose_message()
+BESError::get_verbose_message() const
 {
     ostringstream oss;
     oss << _msg << " (" << _file << ":" << _line << ")";

--- a/dispatch/BESError.h
+++ b/dispatch/BESError.h
@@ -53,8 +53,8 @@
 // I added this for the timeout feature. jhrg 12/28/15
 #define BES_TIMEOUT_ERROR 6
 
-/** @brief Abstract exception class for the BES with basic string message
- *
+/**
+ * @brief Base exception class for the BES with basic string message
  */
 class BESError: public std::exception,  public BESObj {
 protected:
@@ -81,42 +81,48 @@ public:
             _msg(std::move(msg)), _type(type), _file(std::move(file)), _line(line)
     { }
 
+    BESError(const BESError &src) noexcept
+        : exception(), _msg(std::move(src._msg)), _type(src._type), _file(std::move(src._file)), _line(src._line) { }
+
     ~BESError() override = default;
 
     /** @brief set the error message for this exception
      *
      * @param msg message string
      */
-    virtual void set_message(const std::string &msg)
+    void set_message(const std::string &msg)
     {
         _msg = msg;
     }
+
     /** @brief get the error message for this exception
      *
      * @return error message
      */
-    virtual std::string get_message() const
+    std::string get_message() const
     {
         return _msg;
     }
+
     /** @brief get the file name where the exception was thrown
      *
      * @return file name
      */
-    virtual std::string get_file() const
+    std::string get_file() const
     {
         return _file;
     }
+
     /** @brief get the line number where the exception was thrown
      *
      * @return line number
      */
-    virtual unsigned int get_line() const
+    unsigned int get_line() const
     {
         return _line;
     }
 
-    // Return the message, file and line
+    // Return the message, file and line. Over load this for special messages, etc.
     virtual std::string get_verbose_message() const;
 
     /** @brief Set the return code for this particular error class
@@ -128,7 +134,7 @@ public:
      * be one of BES_INTERNAL_ERROR, BES_INTERNAL_FATAL_ERROR,
      * BES_SYNTAX_USER_ERROR, BES_FORBIDDEN_ERROR, BES_NOT_FOUND_ERROR
      */
-    virtual void set_bes_error_type(int type)
+    void set_bes_error_type(unsigned int type)
     {
         _type = type;
     }
@@ -139,7 +145,7 @@ public:
      * the need to terminate or do something specific base on the error
      * @return context string
      */
-    virtual unsigned int get_bes_error_type() const
+    unsigned int get_bes_error_type() const
     {
         return _type;
     }

--- a/dispatch/BESForbiddenError.h
+++ b/dispatch/BESForbiddenError.h
@@ -40,24 +40,20 @@
 class BESForbiddenError : public BESError
 {
 protected:
-      			BESForbiddenError() {}
+    BESForbiddenError() = default;
 public:
-      			BESForbiddenError( const std::string &s,
-					  const std::string &file,
-					  unsigned int line )
-			    : BESError( s, BES_FORBIDDEN_ERROR,
-			                file, line ) {}
-    virtual		~BESForbiddenError() {}
+    BESForbiddenError( std::string s, std::string file, unsigned int line )
+        : BESError( std::move(s), BES_FORBIDDEN_ERROR, std::move(file), line ) {}
 
-    virtual void	dump( std::ostream &strm ) const
-			{
-			    strm << "BESForbiddenError::dump - ("
-			         << (void *)this << ")" << std::endl ;
-			    BESIndent::Indent() ;
-			    BESError::dump( strm ) ;
-			    BESIndent::UnIndent() ;
-			}
+    ~BESForbiddenError() override = default;
 
+    void dump( std::ostream &strm ) const override
+    {
+        strm << "BESForbiddenError::dump - (" << (void *)this << ")" << std::endl ;
+        BESIndent::Indent() ;
+        BESError::dump( strm ) ;
+        BESIndent::UnIndent() ;
+    }
 };
 
 #endif // BESForbiddenError_h_

--- a/dispatch/BESInterface.cc
+++ b/dispatch/BESInterface.cc
@@ -39,7 +39,7 @@
 #include <unistd.h>
 #endif
 
-#include <setjmp.h> // Used for the timeout processing
+#include <csetjmp> // Used for the timeout processing
 
 #include <string>
 #include <sstream>

--- a/dispatch/BESInternalError.h
+++ b/dispatch/BESInternalError.h
@@ -42,26 +42,21 @@
  */
 class BESInternalError: public BESError {
 protected:
-	BESInternalError()
-	{
-	}
-public:
-	BESInternalError(const std::string &msg, const std::string &file, unsigned int line) :
-			BESError(msg, BES_INTERNAL_ERROR, file, line)
-	{
-	}
-	virtual ~BESInternalError()
-	{
-	}
+	BESInternalError() = default;
 
-	virtual void dump(std::ostream &strm) const
+public:
+	BESInternalError(std::string msg, std::string file, unsigned int line) :
+			BESError(std::move(msg), BES_INTERNAL_ERROR, std::move(file), line) { }
+
+	~BESInternalError() override = default;
+
+	void dump(std::ostream &strm) const override
 	{
 		strm << "BESInternalError::dump - (" << (void *) this << ")" << std::endl;
 		BESIndent::Indent();
 		BESError::dump(strm);
 		BESIndent::UnIndent();
 	}
-
 };
 
 #endif // BESInternalError_h_

--- a/dispatch/BESInternalFatalError.h
+++ b/dispatch/BESInternalFatalError.h
@@ -42,26 +42,21 @@
  */
 class BESInternalFatalError: public BESError {
 protected:
-    BESInternalFatalError()
-    {
-    }
-public:
-    BESInternalFatalError(const std::string &s, const std::string &file, unsigned int line) :
-        BESError(s, BES_INTERNAL_FATAL_ERROR, file, line)
-    {
-    }
-    virtual ~BESInternalFatalError()
-    {
-    }
+    BESInternalFatalError() = default;
 
-    virtual void dump(std::ostream &strm) const
+public:
+    BESInternalFatalError(std::string s, std::string file, unsigned int line) :
+        BESError(std::move(s), BES_INTERNAL_FATAL_ERROR, std::move(file), line) { }
+
+    ~BESInternalFatalError() override = default;
+
+    void dump(std::ostream &strm) const override
     {
         strm << "BESInternalFatalError::dump - (" << (void *) this << ")" << std::endl;
         BESIndent::Indent();
         BESError::dump(strm);
         BESIndent::UnIndent();
     }
-
 };
 
 #endif // BESInternalFatalError_h_

--- a/dispatch/BESNotFoundError.h
+++ b/dispatch/BESNotFoundError.h
@@ -40,24 +40,21 @@
 class BESNotFoundError : public BESError
 {
 protected:
-      			BESNotFoundError() {}
+    BESNotFoundError() = default;
+
 public:
-      			BESNotFoundError( const std::string &s,
-					  const std::string &file,
-					  unsigned int line )
-			    : BESError( s, BES_NOT_FOUND_ERROR,
-			                file, line ) {}
-    virtual		~BESNotFoundError() {}
+    BESNotFoundError(std::string s, std::string file, unsigned int line )
+        : BESError( std::move(s), BES_NOT_FOUND_ERROR, std::move(file), line ) {}
 
-    virtual void	dump( std::ostream &strm ) const
-			{
-			    strm << "BESNotFoundError::dump - ("
-			         << (void *)this << ")" << std::endl ;
-			    BESIndent::Indent() ;
-			    BESError::dump( strm ) ;
-			    BESIndent::UnIndent() ;
-			}
+    ~BESNotFoundError() override = default;
 
+    void dump( std::ostream &strm ) const override
+    {
+        strm << "BESNotFoundError::dump - (" << (void *)this << ")" << std::endl ;
+        BESIndent::Indent() ;
+        BESError::dump( strm ) ;
+        BESIndent::UnIndent() ;
+    }
 };
 
 #endif // BESNotFoundError_h_

--- a/dispatch/BESSyntaxUserError.h
+++ b/dispatch/BESSyntaxUserError.h
@@ -40,27 +40,21 @@
  */
 class BESSyntaxUserError: public BESError {
 protected:
-    BESSyntaxUserError()
-    {
-    }
+    BESSyntaxUserError() = default;
+
 public:
-    BESSyntaxUserError(const std::string &s, const std::string &file, unsigned int line) :
-        BESError(s, BES_SYNTAX_USER_ERROR, file, line)
-    {
-    }
+    BESSyntaxUserError(std::string s, std::string file, unsigned int line) :
+        BESError(std::move(s), BES_SYNTAX_USER_ERROR, std::move(file), line) { }
 
-    virtual ~BESSyntaxUserError()
-    {
-    }
+    ~BESSyntaxUserError() override = default;
 
-    virtual void dump(std::ostream &strm) const
+    void dump(std::ostream &strm) const override
     {
         strm << "BESSyntaxUserError::dump - (" << (void *) this << ")" << std::endl;
         BESIndent::Indent();
         BESError::dump(strm);
         BESIndent::UnIndent();
     }
-
 };
 
 #endif // BESSyntaxUserError_h_

--- a/dispatch/BESTimeoutError.h
+++ b/dispatch/BESTimeoutError.h
@@ -41,24 +41,20 @@
 class BESTimeoutError : public BESError
 {
 protected:
-    BESTimeoutError() {}
+    BESTimeoutError() =default;
 public:
-    BESTimeoutError( const std::string &s,
-					  const std::string &file,
-					  unsigned int line )
-			    : BESError( s, BES_TIMEOUT_ERROR,
-			                file, line ) {}
-    virtual		~BESTimeoutError() {}
+    BESTimeoutError(std::string s, std::string file, unsigned int line )
+        : BESError( std::move(s), BES_TIMEOUT_ERROR, std::move(file), line ) { }
 
-    virtual void	dump( std::ostream &strm ) const
-			{
-			    strm << "BESTimeoutError::dump - ("
-			         << (void *)this << ")" << std::endl ;
-			    BESIndent::Indent() ;
-			    BESError::dump( strm ) ;
-			    BESIndent::UnIndent() ;
-			}
+    ~BESTimeoutError() override = default;
 
+    void dump( std::ostream &strm ) const override
+    {
+        strm << "BESTimeoutError::dump - (" << (void *)this << ")" << std::endl ;
+        BESIndent::Indent() ;
+        BESError::dump( strm ) ;
+        BESIndent::UnIndent() ;
+    }
 };
 
 #endif // BESTimeoutError_h_

--- a/server/BESXMLWriter.cc
+++ b/server/BESXMLWriter.cc
@@ -32,9 +32,9 @@
 
 #include <BESInternalFatalError.h>
 
-constexpr char *ENCODING = "ISO-8859-1";
+static const char *ENCODING = "ISO-8859-1";
 // Hack
-constexpr char *HAI_NS = "https://xml.opendap.org/ns/bes/admin/1.0#";
+static const char *HAI_NS = "https://xml.opendap.org/ns/bes/admin/1.0#";
 constexpr int XML_BUF_SIZE = 2000000;
 
 BESXMLWriter::BESXMLWriter() // : d_ns_uri(HAI_NS)

--- a/server/test/TestException.h
+++ b/server/test/TestException.h
@@ -22,7 +22,7 @@
 //
 // You can contact University Corporation for Atmospheric Research at
 // 3080 Center Green Drive, Boulder, CO 80301
- 
+
 // (c) COPYRIGHT University Corporation for Atmospheric Research 2004-2005
 // Please read the full copyright statement in the file COPYRIGHT_UCAR.
 //
@@ -33,26 +33,26 @@
 #ifndef TestException_h_
 #define TestException_h_ 1
 
+#include <string>
 #include "BESError.h"
-#include "BESDataHandlerInterface.h"
+
+class BESDataHandlerInterface;
 
 #define CEDAR_AUTHENTICATE_EXCEPTION 13
 
 /** @brief exception thrown if authentication fails
  */
-class TestException: public BESError
-{
+class TestException : public BESError {
 private:
-      			TestException() ;
-public:
-      			TestException( const string &s,
-			               const string &file,
-				       unsigned int line ) :
-			    BESError( s, 12, file, line ) { }
-      virtual		~TestException() {}
+    TestException() =default;
 
-      static int	handleException( BESError &e,
-					 BESDataHandlerInterface &dhi ) ;
+public:
+    TestException(std::string s, std::string file, unsigned int line)
+        : BESError(std::move(s), 12, std::move(file), line) {}
+
+    ~TestException() override = default;
+
+    static int handleException(BESError &e, BESDataHandlerInterface &dhi);
 };
 
 #endif // TestException_h_ 


### PR DESCRIPTION
This refactoring of the BESError class hierarchy addresses a number of C++11 issues.

Now BESError has a noexcept copy constructor, uses override and inherits from 
std::exception. This means that we can, at various places, just catch std::exception
and get all the errors - libdap::Error also now inherits from std::exception.

Caveat: the what() method is limited to only showing the 'message' and cannot
build up a new string unless we extend the class to provide storage for that. 
std::exception::what() returns a const char * so the object must provide the storage.