### PR TITLE
Switch to python for path normalization in tests_get_dmrpp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -214,7 +214,6 @@ dnl AC_PROG_LEX
 AM_PROG_LEX
 AM_PATH_PYTHON
 
-
 dnl NB: CentOS 6 does not support C++-11 but does support some features:
 dnl https://gcc.gnu.org/gcc-4.4/cxx0x_status.html.
 dnl For now, I'm counting 0x as supporting C++-11 in our code.


### PR DESCRIPTION
readlink -f fails on OSX 11.6.4 and we're already using the
python code in other places. There is one question abou the
python version, but that might be a red herring.