### PR TITLE
Size fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,8 @@ add_executable(bes
     dap/ShowPathInfoResponseHandler.h
     dap/TempFile.cc
     dap/TempFile.h
+		dap/DapUtils.cc
+		dap/DapUtils.h
 
     dapreader/DapModule.cc
     dapreader/DapModule.h

--- a/dap/BESDapResponseBuilder.cc
+++ b/dap/BESDapResponseBuilder.cc
@@ -85,6 +85,8 @@
 #include <libdap/util.h>
 // #include <d4_function/D4FunctionEvaluator.h>
 
+#include "DapUtils.h"
+
 #if USE_LOCAL_TIMEOUT_SCHEME
 #ifndef WIN32
 #include <libdap/SignalHandler.h>
@@ -1110,7 +1112,6 @@ BESDapResponseBuilder::intern_dap2_data(BESResponseObject *obj, BESDataHandlerIn
     return dds;
 }
 
-
 /**
  * Build the DAP2 data response.
  *
@@ -1204,9 +1205,11 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
 #endif
     }
 
-    // get the request size in kilobytes
-    long req_size = (*dds)->get_request_size_kb(true);
+    dap_utils::log_request_and_memory_size(dds);
 
+#if 0
+    // This change addresses an issue on OSX where the size returned by getrusage() is in bytes, not kb.
+    // The BESUtil::get_current_memory_usage() function sorts the problem. jhrg 4/6/22
     struct rusage usage;
     int usage_val;
     usage_val = getrusage(RUSAGE_SELF, &usage);
@@ -1218,6 +1221,7 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
     else { //if the getrusage() wasn't successful, only output the request size
         INFO_LOG(prolog << "request size: "<< req_size << "KB" << endl );
     }
+#endif
 
     data_stream << flush;
 
@@ -1321,9 +1325,9 @@ void BESDapResponseBuilder::send_dap2_data(BESDataHandlerInterface &dhi, DDS **d
 #endif
     }
 
-    // get the request size in kilobytes
-    long req_size = (*dds)->get_request_size_kb(true);
+    dap_utils::log_request_and_memory_size(dds);
 
+#if 0
     struct rusage usage;
     int usage_val;
     usage_val = getrusage(RUSAGE_SELF, &usage);
@@ -1335,6 +1339,7 @@ void BESDapResponseBuilder::send_dap2_data(BESDataHandlerInterface &dhi, DDS **d
     else { //if the getrusage() wasn't successful, only output the request size
         INFO_LOG(prolog << "request size: "<< req_size << "KB" << endl );
     }
+#endif
 
     data_stream << flush;
 
@@ -1478,6 +1483,7 @@ void BESDapResponseBuilder::send_dap4_data_using_ce(ostream &out, DMR &dmr, bool
         dmr.root()->set_send_p(true);
     }
 
+    dap_utils::log_request_and_memory_size(dmr);
     throw_if_dap4_response_too_big(dmr);
 
     // The following block is for debugging purpose. KY 05/13/2020

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -1,0 +1,60 @@
+//
+// Created by James Gallagher on 4/6/22.
+//
+
+#include "config.h"
+
+#include <iostream>
+
+#include "BESUtil.h"
+#include "BESLog.h"
+
+#include <libdap/DDS.h>
+#include <libdap/DMR.h>
+
+using namespace libdap;
+
+namespace dap_utils {
+
+static void log_request_and_memory_size_helper(long req_size) {
+    long mem_size = BESUtil::get_current_memory_usage();    // size in KB or 0. jhrg 4/6/22
+    if (mem_size) {
+        INFO_LOG("request size: " << req_size << "KB|&|memory used by process: " << mem_size << "KB" << endl);
+    }
+    else {
+        INFO_LOG("request size: " << req_size << "KB" << endl);
+    }
+}
+
+/**
+ * Log information about memory used by this request.
+ *
+ * Use the given DDS to log information about the request. As a bonus, log the
+ * RSS for this process.
+ *
+ * @param dds Use this DDS to get the size of the request.
+ */
+void
+log_request_and_memory_size(DDS *const *dds)
+{
+    long req_size = (long)(*dds)->get_request_size_kb(true);
+    log_request_and_memory_size_helper(req_size);
+}
+
+/**
+ * Log information about memory used by this request.
+ *
+ * Use the given DDS to log information about the request. As a bonus, log the
+ * RSS for this process.
+ *
+ * @param dmr Use this DMR to get the size of the request.
+ */
+void
+log_request_and_memory_size(/*const*/ DMR &dmr)
+{
+    // The request_size_kb() method is not marked const. Fix. jhrg 4/6/22
+    long req_size = (long)dmr.request_size_kb(true);
+    log_request_and_memory_size_helper(req_size);
+}
+
+}   // namespace dap_utils

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -37,7 +37,7 @@ using namespace libdap;
 namespace dap_utils {
 
 static void log_request_and_memory_size_helper(long req_size) {
-    long mem_size = BESUtil::get_current_memory_usage();    // size in KB or 0. jhrg 4/6/22
+    auto mem_size = BESUtil::get_current_memory_usage();    // size in KB or 0. jhrg 4/6/22
     if (mem_size) {
         INFO_LOG("request size: " << req_size << "KB|&|memory used by process: " << mem_size << "KB" << endl);
     }
@@ -57,7 +57,7 @@ static void log_request_and_memory_size_helper(long req_size) {
 void
 log_request_and_memory_size(DDS *const *dds)
 {
-    long req_size = (long)(*dds)->get_request_size_kb(true);
+    auto req_size = (long)(*dds)->get_request_size_kb(true);
     log_request_and_memory_size_helper(req_size);
 }
 

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -73,7 +73,7 @@ void
 log_request_and_memory_size(/*const*/ DMR &dmr)
 {
     // The request_size_kb() method is not marked const. Fix. jhrg 4/6/22
-    long req_size = (long)dmr.request_size_kb(true);
+    auto req_size = (long)dmr.request_size_kb(true);
     log_request_and_memory_size_helper(req_size);
 }
 

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -1,3 +1,23 @@
+// This file is part of bes, A C++ back-end server implementation framework
+// for the OPeNDAP Data Access Protocol.
+
+// Copyright (c) 2022 OPeNDAP
+// Author: James Gallagher <jgallagher@opendap.org>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
 //
 // Created by James Gallagher on 4/6/22.
 //

--- a/dap/DapUtils.h
+++ b/dap/DapUtils.h
@@ -1,3 +1,23 @@
+// This file is part of bes, A C++ back-end server implementation framework
+// for the OPeNDAP Data Access Protocol.
+
+// Copyright (c) 2022 OPeNDAP
+// Author: James Gallagher <jgallagher@opendap.org>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
 //
 // Created by James Gallagher on 4/6/22.
 //

--- a/dap/DapUtils.h
+++ b/dap/DapUtils.h
@@ -1,0 +1,20 @@
+//
+// Created by James Gallagher on 4/6/22.
+//
+
+#ifndef BES_DAPUTILS_H
+#define BES_DAPUTILS_H
+
+namespace libdap {
+class DDS;
+class DMR;
+}
+
+namespace dap_utils {
+
+void log_request_and_memory_size(libdap::DDS *const *dds);
+
+void log_request_and_memory_size(/*const*/ libdap::DMR &dmr);
+
+}
+#endif //BES_DAPUTILS_H

--- a/dap/Makefile.am
+++ b/dap/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = foreign check-news
 
 ACLOCAL_AMFLAGS = -I conf
 
-AM_CPPFLAGS = $(XML2_CFLAGS) -I$(top_srcdir)/xmlcommand $(BES_CPPFLAGS) -I$(top_srcdir)/dispatch \
+AM_CPPFLAGS = $(XML2_CFLAGS) -I$(top_srcdir) -I$(top_srcdir)/xmlcommand $(BES_CPPFLAGS) -I$(top_srcdir)/dispatch \
 $(DAP_CFLAGS)
 
 #  -I$(top_srcdir)/modules/dmrpp_module

--- a/dap/Makefile.am
+++ b/dap/Makefile.am
@@ -61,6 +61,7 @@ BESDAP_SRCS = 	BESDASResponseHandler.cc \
 	BESDapFunctionResponseCache.cc \
 	BESStoredDapResultCache.cc \
 	DapFunctionUtils.cc \
+	DapUtils.cc \
 	CachedSequence.cc \
 	CacheTypeFactory.cc \
 	TempFile.cc \
@@ -95,6 +96,7 @@ BESDAP_HDRS = BESDASResponseHandler.h \
 	BESDapFunctionResponseCache.h \
 	BESStoredDapResultCache.h \
 	DapFunctionUtils.h \
+	DapUtils.h \
 	CachedSequence.h \
 	CacheTypeFactory.h \
 	TempFile.h \

--- a/dispatch/BESInterface.cc
+++ b/dispatch/BESInterface.cc
@@ -45,11 +45,12 @@
 
 #include <string>
 #include <sstream>
+#include <algorithm>
 
 #include "BESInterface.h"
 
 #include "TheBESKeys.h"
-#include "BESResponseHandler.h"
+// jhrg 4/6/22 #include "BESResponseHandler.h"
 #include "BESContextManager.h"
 
 #include "BESTransmitterNames.h"
@@ -59,6 +60,7 @@
 #include "BESInfoList.h"
 #include "BESXMLInfo.h"
 
+#include "BESUtil.h"
 #include "BESDebug.h"
 #include "BESStopWatch.h"
 #include "BESTimeoutError.h"
@@ -146,10 +148,16 @@ static void register_signal_handler()
 
 static inline void downcase(string &s)
 {
+#if 0
     for (unsigned int i = 0; i < s.length(); i++)
         s[i] = tolower(s[i]);
+#endif
+    transform(s.begin(), s.end(), s.begin(),
+              [](unsigned char c) -> unsigned char { return std::toupper(c); });
 }
 
+#if 0
+// moved to BESUtil. jhrg 4/6/22
 /**
  * @brief Get the Resident Set Size in KB
  * @return The RSS or 0 if getrusage() returns an error
@@ -171,6 +179,7 @@ get_current_memory_usage() noexcept
         return 0;
     }
 }
+#endif
 
 /**
  * @brief Write a phrase that describes the current RSS for this process
@@ -178,7 +187,7 @@ get_current_memory_usage() noexcept
  */
 ostream &add_memory_info(ostream &out)
 {
-    long mem_size = get_current_memory_usage();
+    long mem_size = BESUtil::get_current_memory_usage();
     if (mem_size) {
         out << ", current memory usage is " << mem_size << " KB.";
     }

--- a/dispatch/BESInterface.cc
+++ b/dispatch/BESInterface.cc
@@ -152,34 +152,8 @@ static inline void downcase(string &s)
     for (unsigned int i = 0; i < s.length(); i++)
         s[i] = tolower(s[i]);
 #endif
-    transform(s.begin(), s.end(), s.begin(),
-              [](unsigned char c) -> unsigned char { return std::toupper(c); });
+    transform(s.begin(), s.end(), s.begin(), [](int c) { return std::toupper(c); });
 }
-
-#if 0
-// moved to BESUtil. jhrg 4/6/22
-/**
- * @brief Get the Resident Set Size in KB
- * @return The RSS or 0 if getrusage() returns an error
- */
-static long
-get_current_memory_usage() noexcept
-{
-    struct rusage usage;
-    if (getrusage(RUSAGE_SELF, &usage) == 0) { // getrusage()  successful?
-#ifdef __APPLE__
-        // get the max size (man page says it is in bytes). This function returns the
-        // size in KB like Linux. jhrg 3/29/22
-        return usage.ru_maxrss / 1024;
-#else
-        return usage.ru_maxrss; // get the max size (man page says it is in kilobytes)
-#endif
-    }
-    else {
-        return 0;
-    }
-}
-#endif
 
 /**
  * @brief Write a phrase that describes the current RSS for this process

--- a/dispatch/BESLog.cc
+++ b/dispatch/BESLog.cc
@@ -170,40 +170,21 @@ void BESLog::dump_time()
     time_t now;
     time(&now);
 
-#if 0
-    char buf[sizeof "YYYY-MM-DDTHH:MM:SSzone"];
-    int status = 0;
-
-    // From StackOverflow:
-    // This will work too, if your compiler doesn't support %F or %T:
-    // strftime(buf, sizeof buf, "%Y-%m-%dT%H:%M:%S%Z", gmtime(&now));
-    //
-    // Apologies for the twisted logic - UTC is the default. Override to
-    // local time using BES.LogTimeLocal=yes in bes.conf. jhrg 11/15/17
-    if (!d_use_local_time)
-        status = strftime(buf, sizeof buf, "%FT%T%Z", gmtime(&now));
-    else
-        status = strftime(buf, sizeof buf, "%FT%T%Z", localtime(&now));
-#endif
-
     char buf[sizeof "YYYY-MM-DDTHH:MM:SS zones"];
-    int status = 0;
     if(d_use_unix_time){
         (*d_file_buffer) << now;
     }
     else {
-        struct tm dat_time;
+        struct tm date_time;
         if (!d_use_local_time){
-            gmtime_r(&now, &dat_time);
+            gmtime_r(&now, &date_time);
         }
         else{
-            localtime_r(&now, &dat_time);
+            localtime_r(&now, &date_time);
         }
-        status = strftime(buf, sizeof buf, "%FT%T %Z", &dat_time);
+        (void)strftime(buf, sizeof buf, "%FT%T %Z", &date_time);
         (*d_file_buffer) << buf;
     }
-
-
 #else
     const time_t sctime = time(NULL);
     const struct tm *sttime = localtime(&sctime);

--- a/dispatch/BESStopWatch.cc
+++ b/dispatch/BESStopWatch.cc
@@ -457,6 +457,7 @@ BESStopWatch::timeval_subtract()
 }
 
 #endif
+
 /** @brief dumps information about this object
  *
  * Displays the pointer value of this instance

--- a/dispatch/BESUtil.cc
+++ b/dispatch/BESUtil.cc
@@ -74,6 +74,28 @@ using namespace std;
 const string BES_KEY_TIMEOUT_CANCEL = "BES.CancelTimeoutOnSend";
 
 /**
+ * @brief Get the Resident Set Size in KB
+ * @return The RSS or 0 if getrusage() returns an error
+ */
+long
+BESUtil::get_current_memory_usage() noexcept
+{
+    struct rusage usage;
+    if (getrusage(RUSAGE_SELF, &usage) == 0) { // getrusage()  successful?
+#ifdef __APPLE__
+        // get the max size (man page says it is in bytes). This function returns the
+        // size in KB like Linux. jhrg 3/29/22
+        return usage.ru_maxrss / 1024;
+#else
+        return usage.ru_maxrss; // get the max size (man page says it is in kilobytes)
+#endif
+    }
+    else {
+        return 0;
+    }
+}
+
+/**
  * @brief If the string ends in a slash, remove it
  * This function works for empty strings (doing nothing). If the string
  * ends in a '/' it will be removed.

--- a/dispatch/BESUtil.cc
+++ b/dispatch/BESUtil.cc
@@ -34,6 +34,8 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/resource.h>
+
 #include <fcntl.h>
 #if HAVE_UNISTD_H
 #include <unistd.h>

--- a/dispatch/BESUtil.h
+++ b/dispatch/BESUtil.h
@@ -42,11 +42,13 @@
 
 class BESUtil {
 private:
-    static std::string rfc822_date(const time_t t);
+    static std::string rfc822_date(time_t t);
 
     static std::string entity(char c);
 
 public:
+    static long get_current_memory_usage() noexcept;
+
     static void trim_if_trailing_slash(std::string &value);
     static void trim_if_surrounding_quotes(std::string &value);
 

--- a/server/BESServerHandler.cc
+++ b/server/BESServerHandler.cc
@@ -138,7 +138,7 @@ void BESServerHandler::execute(Connection *connection)
     stringstream msg;
     msg << prolog << "Using ostream: " << (void *) &my_ostrm << " cout: " << (void *) &cout << endl;
     BESDEBUG(MODULE,  msg.str());
-    INFO_LOG( msg.str());
+    // jhrg 4/6/22 INFO_LOG(msg.str());
 #endif
 
     // we loop continuously waiting for messages. The only way we exit

--- a/server/BESServerHandler.cc
+++ b/server/BESServerHandler.cc
@@ -138,7 +138,6 @@ void BESServerHandler::execute(Connection *connection)
     stringstream msg;
     msg << prolog << "Using ostream: " << (void *) &my_ostrm << " cout: " << (void *) &cout << endl;
     BESDEBUG(MODULE,  msg.str());
-    // jhrg 4/6/22 INFO_LOG(msg.str());
 #endif
 
     // we loop continuously waiting for messages. The only way we exit


### PR DESCRIPTION
Apple's version of getrusage() returns size in bytes, not KB like the rest of the world (?). I fixed this with a #ifdef __APPLE__ ... block. At the same time I moved Sam's code into a new file so that we can more easily use it in the 'Transmitter handlers' at some point in the future.

The new file wraps the functions in a namespace instead of using a class filled with static methods. 