### PR TITLE
Add a README file to the top level of our test data hierarchy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1525,7 +1525,7 @@ add_executable(bes
     modules/ncml_module/OtherXMLParser.h
     modules/ncml_module/RCObject.cc
     modules/ncml_module/RCObject.h
-    modules/ncml_module/RCObjectInterface.cc
+    # modules/ncml_module/RCObjectInterface.cc
     modules/ncml_module/RCObjectInterface.h
     modules/ncml_module/ReadMetadataElement.cc
     modules/ncml_module/ReadMetadataElement.h
@@ -1604,7 +1604,7 @@ add_executable(bes
 	modules/ngap_module/NgapContainerStorage.h
 	modules/ngap_module/NgapContainer.cc
 	modules/ngap_module/NgapContainer.h
-	modules/ngap_module/NgapError.h
+	# modules/ngap_module/NgapError.h
 	modules/ngap_module/NgapModule.cc
 	modules/ngap_module/NgapModule.h
 	modules/ngap_module/NgapNames.h

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -5,11 +5,16 @@
 AUTOMAKE_OPTIONS = foreign
 
 # Might move these to a child directory for testing things. jhrg 5/16/18
-EXTRA_DIST = read_test_baseline.cc read_test_baseline.h handler_tests_macros.m4 bes_run_tests_cppunit.h
+EXTRA_DIST = data/README read_test_baseline.cc read_test_baseline.h handler_tests_macros.m4 bes_run_tests_cppunit.h
+
+toplevel_datadir = $(datadir)/hyrax/data
+toplevel_data_DATA = data/README
+
 
 SUBDIRS = csv_handler usage asciival freeform_handler
 
 # www-interface Removed jhrg 3/21/22
+
 
 if WITH_CMR
 SUBDIRS += cmr_module 

--- a/modules/data/README
+++ b/modules/data/README
@@ -1,0 +1,13 @@
+###############################################################################
+
+Greetings,
+
+This directory and its children contain the test data fot the Hyrax Data
+Server. These data can be used to run the Hyrax's regression tests which
+verify its correct functionality in a full deployment.
+
+Sincerely,
+
+The Hyrax Development Team at OPeNDAP Inc.
+
+###############################################################################


### PR DESCRIPTION
Because we don't have one now and I need something to test the retrieval of non data files from Hyrax.