### PR TITLE
Makefile.am was 'cleaning' the testsuite scripts

### DIFF
--- a/dapreader/tests/Makefile.am
+++ b/dapreader/tests/Makefile.am
@@ -5,8 +5,10 @@ AM_CPPFLAGS = -I$(top_srcdir)
 
 noinst_DATA = bes.conf bes.mds.conf mds
 
-CLEANFILES = bes.conf bes.mds.conf mds_ledger.txt bes.log $(srcdir)/package.m4 \
-$(TESTSUITE) 
+CLEANFILES = bes.conf bes.mds.conf mds_ledger.txt bes.log
+
+# Remove these to avoid 'make clean -j12' failure. jhrg 4/13/22
+# $(srcdir)/package.m4 $(TESTSUITE)
 
 EXTRA_DIST = dap $(TESTSUITE) $(TESTSUITE).at atlocal.in \
 bes.conf.in bes.mds.conf.in $(srcdir)/package.m4

--- a/modules/dmrpp_module/tests/Makefile.am
+++ b/modules/dmrpp_module/tests/Makefile.am
@@ -5,7 +5,9 @@ AM_CPPFLAGS = -I$(top_srcdir)
 
 noinst_DATA = bes.conf
 
-CLEANFILES = bes.conf bes.log bes_serial.conf $(TESTSUITE) $(TESTSUITE_S3) $(srcdir)/package.m4
+CLEANFILES = bes.conf bes.log bes_serial.conf
+
+# Parallel make clean fail. jhrg 4/13/22 $(TESTSUITE) $(TESTSUITE_S3) $(srcdir)/package.m4
 
 EXTRA_DIST = contiguous chunked compact new_types s3 $(TESTSUITE) $(TESTSUITE).at \
 $(TESTSUITE_S3)  $(TESTSUITE_S3).at atlocal.in bes.conf.in bes_serial.conf.in \

--- a/modules/dmrpp_module/tests_build_dmrpp/Makefile.am
+++ b/modules/dmrpp_module/tests_build_dmrpp/Makefile.am
@@ -3,7 +3,9 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = -I$(top_srcdir)
 
-CLEANFILES = $(TESTSUITE_DMRPP)
+CLEANFILES =
+
+# Parallel make clean fail. jhrg 4/13/22 $(TESTSUITE_DMRPP)
 
 EXTRA_DIST = get_dmrpp $(srcdir)/package.m4 $(TESTSUITE_DMRPP) $(TESTSUITE_DMRPP).at \
 atlocal.in build_dmrpp_macros.m4


### PR DESCRIPTION
Cleaning these scripts with a parallel make meant that
in some cases the testsuite script was removed before it
could be run as per 'clean-local' resulting a failure.
Since the testsuite script is included in the tar ball,
I removed it from CLEANFILES in three Makefile.am files.
This seems to fix the issues with 'make clean --jobs=12'
failing.