### PR TITLE
Hyrax 706

### DIFF
--- a/modules/fileout_netcdf/FONcArray.cc
+++ b/modules/fileout_netcdf/FONcArray.cc
@@ -146,6 +146,18 @@ void FONcArray::convert(vector<string> embed, bool _dap4, bool is_dap4_group) {
 
     d_array_type = FONcUtils::get_nc_type(d_a->var(), isNetCDF4_ENHANCED());
 
+    if(d_array_type == NC_NAT) {
+
+        string err = "fileout_netcdf: The datatype of this variable '" + _varname;
+        err += "' is not supported. It is very possible that you try to obtain ";
+        err += "a netCDF file that follows the netCDF classic model. ";
+        err += "The unsigned 32-bit integer and signed/unsigned 64-bit integer ";
+        err += "are not supported by the netCDF classic model. Downloading this file as the netCDF-4 file that ";
+        err += "follows the netCDF enhanced model should solve the problem.";
+
+        throw BESInternalError(err, __FILE__, __LINE__);
+    }
+
 #if !NDEBUG
     if (d4_dim_ids.size() > 0) {
         BESDEBUG("fonc", "FONcArray::convert() - d4_dim_ids size is " << d4_dim_ids.size() << endl);

--- a/modules/fileout_netcdf/tests/bescmd/arrayT.2.bescmd.baseline
+++ b/modules/fileout_netcdf/tests/bescmd/arrayT.2.bescmd.baseline
@@ -3,7 +3,7 @@
     <getDODS>
         <BESError>
             <Type>1</Type>
-            <Message>fileout.netcdf - Failed to define variable ui32_array: NetCDF: Not a valid data type or _FillValue type mismatch</Message>
+            <Message>fileout_netcdf: The datatype of this variable 'ui32_array' is not supported. It is very possible that you try to obtain a netCDF file that follows the netCDF classic model. The unsigned 32-bit integer and signed/unsigned 64-bit integer are not supported by the netCDF classic model. Downloading this file as the netCDF-4 file that follows the netCDF enhanced model should solve the problem.</Message>
             <Administrator>support@opendap.org</Administrator>
             <Location>
                 removed file

--- a/modules/fileout_netcdf/tests/bescmd/arrayT.3.bescmd.baseline
+++ b/modules/fileout_netcdf/tests/bescmd/arrayT.3.bescmd.baseline
@@ -3,7 +3,7 @@
     <getDODS>
         <BESError>
             <Type>1</Type>
-            <Message>fileout.netcdf - Failed to define variable ui32_array: NetCDF: Not a valid data type or _FillValue type mismatch</Message>
+            <Message>fileout_netcdf: The datatype of this variable 'ui32_array' is not supported. It is very possible that you try to obtain a netCDF file that follows the netCDF classic model. The unsigned 32-bit integer and signed/unsigned 64-bit integer are not supported by the netCDF classic model. Downloading this file as the netCDF-4 file that follows the netCDF enhanced model should solve the problem.</Message>
             <Administrator>support@opendap.org</Administrator>
             <Location>
                 removed file

--- a/modules/fileout_netcdf/tests/bescmd/structT01.2.bescmd.baseline
+++ b/modules/fileout_netcdf/tests/bescmd/structT01.2.bescmd.baseline
@@ -3,7 +3,7 @@
     <getDODS>
         <BESError>
             <Type>1</Type>
-            <Message>fileout.netcdf - Failed to define variable s1.s2.ui32a: NetCDF: Not a valid data type or _FillValue type mismatch</Message>
+            <Message>fileout_netcdf: The datatype of this variable 's1.s2.ui32a' is not supported. It is very possible that you try to obtain a netCDF file that follows the netCDF classic model. The unsigned 32-bit integer and signed/unsigned 64-bit integer are not supported by the netCDF classic model. Downloading this file as the netCDF-4 file that follows the netCDF enhanced model should solve the problem.</Message>
             <Administrator>support@opendap.org</Administrator>
             <Location>
                 removed file

--- a/modules/fileout_netcdf/tests/bescmd/structT01.3.bescmd.baseline
+++ b/modules/fileout_netcdf/tests/bescmd/structT01.3.bescmd.baseline
@@ -3,7 +3,7 @@
     <getDODS>
         <BESError>
             <Type>1</Type>
-            <Message>fileout.netcdf - Failed to define variable s1.s2.ui32a: NetCDF: Not a valid data type or _FillValue type mismatch</Message>
+            <Message>fileout_netcdf: The datatype of this variable 's1.s2.ui32a' is not supported. It is very possible that you try to obtain a netCDF file that follows the netCDF classic model. The unsigned 32-bit integer and signed/unsigned 64-bit integer are not supported by the netCDF classic model. Downloading this file as the netCDF-4 file that follows the netCDF enhanced model should solve the problem.</Message>
             <Administrator>support@opendap.org</Administrator>
             <Location>
                 removed file


### PR DESCRIPTION
Add more meaningful error message when variable datatype is not supported by the netCDF classic model.