### PR TITLE
Moved setContext XML command handling to build_data_request_plan

### DIFF
--- a/xmlcommand/BESXMLInterface.cc
+++ b/xmlcommand/BESXMLInterface.cc
@@ -177,7 +177,6 @@ void BESXMLInterface::build_data_request_plan()
                 if (node_name == SET_CONTEXT_STR) {
                     current_cmd->parse_request(current_node);
                 } else {
-
                     // push this new command to the back of the list
                     d_xml_cmd_list.push_back(current_cmd);
 

--- a/xmlcommand/BESXMLInterface.cc
+++ b/xmlcommand/BESXMLInterface.cc
@@ -181,7 +181,7 @@ void BESXMLInterface::build_data_request_plan()
                     //
                     // SetContextsResponseHandler::execute() only calls BESContextManager::set_context(),
                     // and these actions need to occur before execute_data_request_plan().
-                    BESDataHandlerInterface setContext_xml_dhi = current_cmd->get_xmlcmd_dhi();
+                    BESDataHandlerInterface &setContext_xml_dhi = current_cmd->get_xmlcmd_dhi();
                     setContext_xml_dhi.response_handler->execute(setContext_xml_dhi);
 
                 } else {

--- a/xmlcommand/BESXMLInterface.cc
+++ b/xmlcommand/BESXMLInterface.cc
@@ -149,12 +149,12 @@ void BESXMLInterface::build_data_request_plan()
                 // BESXMLCommand object
                 string node_name = (char *) current_node->name;
 
-                if(node_name == SETCONTAINER_STR){
+                if (node_name == SETCONTAINER_STR) {
                     string name;
                     string value;
-                    map<string,string> props;
+                    map<string, string> props;
                     BESXMLUtils::GetNodeInfo(current_node, name, value, props);
-                    BESDEBUG(MODULE, prolog << "In "  << SETCONTAINER_STR << " element. Value: " << value << endl);
+                    BESDEBUG(MODULE, prolog << "In " << SETCONTAINER_STR << " element. Value: " << value << endl);
                     TheBESKeys::TheKeys()->load_dynamic_config(value);
                 }
 
@@ -166,37 +166,43 @@ void BESXMLInterface::build_data_request_plan()
                 p_xmlcmd_builder bldr = BESXMLCommand::find_command(node_name);
                 if (!bldr)
                     throw BESSyntaxUserError(string("Unable to find command for ").append(node_name), __FILE__,
-                        __LINE__);
+                                             __LINE__);
 
                 BESXMLCommand *current_cmd = bldr(d_xml_interface_dhi);
                 if (!current_cmd)
                     throw BESInternalError(string("Failed to build command object for ").append(node_name), __FILE__,
-                        __LINE__);
+                                           __LINE__);
 
-                // push this new command to the back of the list
-                d_xml_cmd_list.push_back(current_cmd);
+                // SPECIAL CASE: Process setContext xml_commands here; do not add to d_xml_cmd_list.
+                if (node_name == SET_CONTEXT_STR) {
+                    current_cmd->parse_request(current_node);
+                } else {
 
-                // only one of the commands in a request can build a response
-                bool cmd_has_response = current_cmd->has_response();
-                if (has_response && cmd_has_response)
-                    throw BESSyntaxUserError("Commands with multiple responses not supported.", __FILE__, __LINE__);
+                    // push this new command to the back of the list
+                    d_xml_cmd_list.push_back(current_cmd);
 
-                has_response = cmd_has_response;
+                    // only one of the commands in a request can build a response
+                    bool cmd_has_response = current_cmd->has_response();
+                    if (has_response && cmd_has_response)
+                        throw BESSyntaxUserError("Commands with multiple responses not supported.", __FILE__, __LINE__);
 
-                // parse the request given the current node
-                current_cmd->parse_request(current_node);
+                    has_response = cmd_has_response;
 
-                // Check if the correct transmitter is present. We look for it again in do_transmit()
-                // where it is actually used. This test just keeps us from building a response that
-                // cannot be transmitted. jhrg 11/8/17
-                //
-                // TODO We could add the 'transmitter' to the DHI.
-                BESDataHandlerInterface &current_dhi = current_cmd->get_xmlcmd_dhi();
+                    // parse the request given the current node
+                    current_cmd->parse_request(current_node);
 
-                string return_as = current_dhi.data[RETURN_CMD];
-                if (!return_as.empty() && !BESReturnManager::TheManager()->find_transmitter(return_as))
-                    throw BESSyntaxUserError(string("Unable to find transmitter ").append(return_as), __FILE__,
-                        __LINE__);
+                    // Check if the correct transmitter is present. We look for it again in do_transmit()
+                    // where it is actually used. This test just keeps us from building a response that
+                    // cannot be transmitted. jhrg 11/8/17
+                    //
+                    // TODO We could add the 'transmitter' to the DHI.
+                    BESDataHandlerInterface &current_dhi = current_cmd->get_xmlcmd_dhi();
+
+                    string return_as = current_dhi.data[RETURN_CMD];
+                    if (!return_as.empty() && !BESReturnManager::TheManager()->find_transmitter(return_as))
+                        throw BESSyntaxUserError(string("Unable to find transmitter ").append(return_as), __FILE__,
+                                                 __LINE__);
+                }
             }
 
             current_node = current_node->next;

--- a/xmlcommand/BESXMLInterface.cc
+++ b/xmlcommand/BESXMLInterface.cc
@@ -176,6 +176,14 @@ void BESXMLInterface::build_data_request_plan()
                 // SPECIAL CASE: Process setContext xml_commands here; do not add to d_xml_cmd_list.
                 if (node_name == SET_CONTEXT_STR) {
                     current_cmd->parse_request(current_node);
+
+                    // Call SetContextsResponseHandler::execute() here not in execute_data_request_plan().
+                    //
+                    // SetContextsResponseHandler::execute() only calls BESContextManager::set_context(),
+                    // and these actions need to occur before execute_data_request_plan().
+                    BESDataHandlerInterface setContext_xml_dhi = current_cmd->get_xmlcmd_dhi();
+                    setContext_xml_dhi.response_handler->execute(setContext_xml_dhi);
+
                 } else {
                     // push this new command to the back of the list
                     d_xml_cmd_list.push_back(current_cmd);

--- a/xmlcommand/BESXMLSetContextCommand.cc
+++ b/xmlcommand/BESXMLSetContextCommand.cc
@@ -86,12 +86,6 @@ void BESXMLSetContextCommand::parse_request(xmlNode *node)
     // now that we've set the action, go get the response handler for the
     // action
    BESXMLCommand::set_response();
-
-   // Call SetContextsResponseHandler::execute() here not in execute_data_request_plan().
-   //
-   // SetContextsResponseHandler::execute() only calls BESContextManager::set_context(),
-   // and these actions need to occur before execute_data_request_plan().
-   d_xmlcmd_dhi.response_handler->execute(d_xmlcmd_dhi);
 }
 
 /** @brief dumps information about this object

--- a/xmlcommand/BESXMLSetContextCommand.cc
+++ b/xmlcommand/BESXMLSetContextCommand.cc
@@ -86,6 +86,12 @@ void BESXMLSetContextCommand::parse_request(xmlNode *node)
     // now that we've set the action, go get the response handler for the
     // action
    BESXMLCommand::set_response();
+
+   // Call BESSetContextResponseHandler::execute() here not in execute_data_request_plan().
+   //
+   // BESSetContextResponseHandler::execute() only calls BESContextManager::set_context(),
+   // and these actions need to occur before execute_data_request_plan().
+   d_xmlcmd_dhi.response_handler->execute(d_xmlcmd_dhi);
 }
 
 /** @brief dumps information about this object

--- a/xmlcommand/BESXMLSetContextCommand.cc
+++ b/xmlcommand/BESXMLSetContextCommand.cc
@@ -87,9 +87,9 @@ void BESXMLSetContextCommand::parse_request(xmlNode *node)
     // action
    BESXMLCommand::set_response();
 
-   // Call BESSetContextResponseHandler::execute() here not in execute_data_request_plan().
+   // Call SetContextsResponseHandler::execute() here not in execute_data_request_plan().
    //
-   // BESSetContextResponseHandler::execute() only calls BESContextManager::set_context(),
+   // SetContextsResponseHandler::execute() only calls BESContextManager::set_context(),
    // and these actions need to occur before execute_data_request_plan().
    d_xmlcmd_dhi.response_handler->execute(d_xmlcmd_dhi);
 }


### PR DESCRIPTION
Moved handling of setContext XML commands into build_data_request_plan().   Still followed the previous approach of identifying the response_handler and calling its execute() method, which is somewhat opaque for this usage but works.  Only changes in xml_command/BESXMLInterface and xml_command/BESSetContextCommand.