### PR TITLE
Changed TempFile to take a separate dir and file template as parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,7 +405,6 @@ add_executable(bes
     dispatch/BESNames.h
     dispatch/BESNotFoundError.h
 		dispatch/BESObj.h
-		dispatch/BESObj.cc
     dispatch/BESPlugin.h
     dispatch/BESPluginFactory.h
     dispatch/BESProcIdResponseHandler.cc

--- a/dap/GlobalMetadataStore.cc
+++ b/dap/GlobalMetadataStore.cc
@@ -1253,7 +1253,7 @@ GlobalMetadataStore::get_dmr_object(const string &name)
 DDS *
 GlobalMetadataStore::get_dds_object(const string &name)
 {
-    TempFile dds_tmp(get_cache_directory() + "/opendapXXXXXX");
+    TempFile dds_tmp(get_cache_directory(), "/mds_dds_XXXXXX");
 
     fstream dds_fs(dds_tmp.get_name().c_str(), std::fstream::out);
     try {
@@ -1269,7 +1269,7 @@ GlobalMetadataStore::get_dds_object(const string &name)
     unique_ptr<DDS> dds(new DDS(&btf));
     dds->parse(dds_tmp.get_name());
 
-    TempFile das_tmp(get_cache_directory() + "/opendapXXXXXX");
+    TempFile das_tmp(get_cache_directory(), "/mds_das_XXXXXX");
     fstream das_fs(das_tmp.get_name().c_str(), std::fstream::out);
     try {
         write_das_response(name, das_fs);     // throws BESInternalError if not found

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -75,79 +75,6 @@ void TempFile::sigpipe_handler(int sig)
     }
 }
 
-string mkdir_error_msg(int error_value){
-    string s;
-    switch(error_value){
-        case EACCES:
-            s = "The parent directory does not allow write permission to "
-                "the process, or one of the directories in pathname did not "
-                "allow search permission.";
-            break;
-
-        case EDQUOT:
-            s = "The user's quota of disk blocks or inodes on the "
-                "filesystem has been exhausted.";
-            break;
-
-        case EEXIST:
-            s = "The pathname already exists (not necessarily as a directory). "
-                "This includes the case where pathname is a symbolic link, "
-                "dangling or not.";
-            break;
-
-        case EFAULT:
-            s = "The pathname points outside your accessible address space.";
-            break;
-
-        case EINVAL:
-            s = "The final component (\"basename\") of the new directory's "
-                "pathname is invalid (e.g., it contains characters not "
-                "permitted by the underlying filesystem).";
-            break;
-
-        case ELOOP:
-            s = "Too many symbolic links were encountered in resolving pathname.";
-            break;
-
-        case EMLINK:
-            s = "The number of links to the parent directory would exceed LINK_MAX.";
-            break;
-
-        case ENAMETOOLONG:
-            s = "The pathname was too long.";
-            break;
-
-        case ENOENT:
-            s = "A directory component in pathname does not exist or is a dangling symbolic link.";
-            break;
-
-        case ENOMEM:
-            s = "Insufficient kernel memory was available.";
-            break;
-
-        case ENOSPC:
-            s = "The device containing pathname has no room for the new directory. Or, "
-                "The new directory cannot be created because the user's disk quota is exhausted.";
-            break;
-
-        case ENOTDIR:
-            s = "A component used as a directory in pathname is not, in fact, a directory.";
-            break;
-
-        case EPERM:
-            s = "The filesystem containing pathname does not support the creation of directories.";
-            break;
-
-        case EROFS:
-            s = "The pathname refers to a file on a read-only filesystem.";
-            break;
-
-        default:
-            s = "Unknown value of errno found after failed mkdir() call.";
-            break;
-    }
-    return s;
-}
 
 void TempFile::mk_temp_dir(const std::string &dir_name){
 
@@ -156,15 +83,15 @@ void TempFile::mk_temp_dir(const std::string &dir_name){
         if(errno != EEXIST){
             stringstream msg;
             msg << prolog  << "ERROR - Failed to create temp directory: " << dir_name;
-            msg << " errno: " << errno << " reason: " << mkdir_error_msg(errno);
+            msg << " errno: " << errno << " reason: " << strerror(errno);
             throw BESInternalFatalError(msg.str(),__FILE__,__LINE__);
         }
         else {
-            BESDEBUG(MODULE,prolog << "The temp directory: " << dir_name << " exists.");
+            BESDEBUG(MODULE,prolog << "The temp directory: " << dir_name << " exists." << endl);
         }
     }
     else {
-        BESDEBUG(MODULE,prolog << "The temp directory: " << dir_name << " was created.");
+        BESDEBUG(MODULE,prolog << "The temp directory: " << dir_name << " was created." << endl);
     }
 }
 
@@ -184,8 +111,14 @@ void TempFile::mk_temp_dir(const std::string &dir_name){
 TempFile::TempFile(const std::string &dir_name, const std::string &file_template, bool keep_temps)
     : d_keep_temps(keep_temps)
 {
+    BESDEBUG(MODULE, prolog << "dir_name: " << dir_name << endl);
     mk_temp_dir(dir_name);
+
+    BESDEBUG(MODULE, prolog << "file_template: " << file_template << endl);
+
     string target_file = BESUtil::pathConcat(dir_name,file_template);
+    BESDEBUG(MODULE, prolog << "target_file: " << target_file << endl);
+
 
     char tmp_name[target_file.length() + 1];
     std::string::size_type len = target_file.copy(tmp_name, target_file.length());
@@ -197,8 +130,12 @@ TempFile::TempFile(const std::string &dir_name, const std::string &file_template
     d_fd = mkstemp(tmp_name);
     umask(original_mode);
 
-    if (d_fd == -1) throw BESInternalError("Failed to open the temporary file.", __FILE__, __LINE__);
-
+    if (d_fd == -1) {
+        stringstream msg;
+        msg << "Failed to open the temporary file using mkstemp(). errno: " << errno;
+        msg << " message: " << strerror(errno) <<  " FileTemplate: " + target_file;
+        throw BESInternalError(msg.str(), __FILE__, __LINE__);
+    }
     d_fname.assign(tmp_name);
 
     // only register the SIGPIPE handler once. First time, size() is zero.

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -76,6 +76,10 @@ void TempFile::sigpipe_handler(int sig)
 }
 
 
+/**
+ * @brief Attempts to create the directory identified by dir_name, throws an exception if it fails.
+ * @param dir_name
+ */
 void TempFile::mk_temp_dir(const std::string &dir_name){
 
     mode_t mode = umask(007);
@@ -104,8 +108,10 @@ void TempFile::mk_temp_dir(const std::string &dir_name){
  *
  * @note If you pass in a bad template, behavior of this class is undefined.
  *
+ * @param dir_name The nae of the directory in which the temporary file
+ * will be created.
  * @param path_template Template passed to mkstemp() to build the temporary
- * file pathname.
+ * filename.
  * @param keep_temps Keep the temporary files.
  */
 TempFile::TempFile(const std::string &dir_name, const std::string &file_template, bool keep_temps)
@@ -118,7 +124,6 @@ TempFile::TempFile(const std::string &dir_name, const std::string &file_template
 
     string target_file = BESUtil::pathConcat(dir_name,file_template);
     BESDEBUG(MODULE, prolog << "target_file: " << target_file << endl);
-
 
     char tmp_name[target_file.length() + 1];
     std::string::size_type len = target_file.copy(tmp_name, target_file.length());
@@ -151,7 +156,6 @@ TempFile::TempFile(const std::string &dir_name, const std::string &file_template
             throw BESInternalFatalError("Could not register a handler to catch SIGPIPE.", __FILE__, __LINE__);
         }
     }
-
     open_files->insert(std::pair<string, int>(d_fname, d_fd));
 }
 

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -150,12 +150,9 @@ string mkdir_error_msg(int error_value){
 }
 
 void TempFile::mk_temp_dir(const std::string &dir_name){
-    char tmp_name[dir_name.length() + 1];
-    std::string::size_type len = dir_name.copy(tmp_name, dir_name.length());
-    tmp_name[len] = '\0';
 
     mode_t mode = umask(007);
-    if(mkdir(tmp_name, mode)){
+    if(mkdir(dir_name.c_str(), mode)){
         if(errno != EEXIST){
             stringstream msg;
             msg << prolog  << "ERROR - Failed to create temp directory: " << dir_name;

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -33,7 +33,8 @@
 
 namespace bes {
 
-const std::string default_tmp_file_template = "/tmp/opendapXXXXXX";
+const std::string default_tmp_file_template = "opendapXXXXXX";
+const std::string default_dir = "/tmp";
 
 /**
  * @brief Get a new temporary file
@@ -54,12 +55,14 @@ private:
 
     friend class TemporaryFileTest;
 
+    void mk_temp_dir(const std::string &dir_name = default_dir);
+
 public:
     // Odd, but even with TemporaryFileTest declared as a friend, the tests won't
     // compile unless this is declared public.
     static void sigpipe_handler(int signal);
 
-    TempFile(const std::string &path_template = default_tmp_file_template, bool keep_temps = false);
+    explicit TempFile(const std::string &dir_name = default_dir, const std::string &path_template = default_tmp_file_template, bool keep_temps = false);
 
     ~TempFile();
 

--- a/dap/unit-tests/TemporaryFileTest.cc
+++ b/dap/unit-tests/TemporaryFileTest.cc
@@ -64,10 +64,11 @@ using namespace CppUnit;
 using namespace bes;
 using namespace std;
 
-const string TEMP_FILE_TEMPLATE = BESUtil::assemblePath(TEST_BUILD_DIR, "tmp_XXXXXX");
-const string BES_CONF_FILE = BESUtil::assemblePath(TEST_BUILD_DIR, "bes.conf");
 
 class TemporaryFileTest: public CppUnit::TestFixture {
+    const string TEMP_DIR=TEST_BUILD_DIR;
+    const string TEMP_FILE_TEMPLATE = "tmp_XXXXXX";
+    const string BES_CONF_FILE = BESUtil::assemblePath(TEST_BUILD_DIR, "bes.conf");
 private:
 
 public:
@@ -99,7 +100,7 @@ public:
         std::string tmp_file_name;
 
         try {
-            bes::TempFile tf(TEMP_FILE_TEMPLATE);
+            bes::TempFile tf(TEMP_DIR, TEMP_FILE_TEMPLATE);
             tmp_file_name = tf.get_name();
             DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                 << tf.get_fd() << endl);
@@ -133,7 +134,7 @@ public:
 
         try {
             for (int i = 0; i < count; i++) {
-                tfiles[i] = new bes::TempFile(TEMP_FILE_TEMPLATE);
+                tfiles[i] = new bes::TempFile(TEMP_DIR, TEMP_FILE_TEMPLATE);
                 tmp_file_names[i] = tfiles[i]->get_name();
                 DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_names[i] << "' has been created. fd: "
                     << tfiles[i]->get_fd() << endl);
@@ -172,7 +173,7 @@ public:
         std::string tmp_file_name;
 
         try {
-            bes::TempFile tf(TEMP_FILE_TEMPLATE);
+            bes::TempFile tf(TEMP_DIR, TEMP_FILE_TEMPLATE);
             tmp_file_name = tf.get_name();
             DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_name << "' has been created. fd: " << tf.get_fd() << endl);
 
@@ -252,7 +253,7 @@ public:
             std::string tmp_file_name;
             try {
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
-                bes::TempFile tf(TEMP_FILE_TEMPLATE);
+                bes::TempFile tf(TEMP_DIR, TEMP_FILE_TEMPLATE);
                 tmp_file_name = tf.get_name();
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                     << tf.get_fd() << endl);
@@ -324,7 +325,7 @@ public:
 
                 // --------- File One ------------
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
-                bes::TempFile tf1(TEMP_FILE_TEMPLATE);
+                bes::TempFile tf1(TEMP_DIR, TEMP_FILE_TEMPLATE);
                 tmp_file_name = tf1.get_name();
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                     << tf1.get_fd() << endl);
@@ -337,7 +338,7 @@ public:
 
                 // --------- File Two ------------
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
-                bes::TempFile tf2(TEMP_FILE_TEMPLATE);
+                bes::TempFile tf2(TEMP_DIR, TEMP_FILE_TEMPLATE);
                 tmp_file_name = tf2.get_name();
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                     << tf2.get_fd() << endl);
@@ -350,7 +351,7 @@ public:
 
                 // --------- File Three ------------
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
-                bes::TempFile tf3(TEMP_FILE_TEMPLATE);
+                bes::TempFile tf3(TEMP_DIR, TEMP_FILE_TEMPLATE);
                 tmp_file_name = tf3.get_name();
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                     << tf3.get_fd() << endl);

--- a/modules/fileout_gdal/GeoTiffTransmitter.cc
+++ b/modules/fileout_gdal/GeoTiffTransmitter.cc
@@ -202,7 +202,7 @@ void GeoTiffTransmitter::send_data_as_geotiff(BESResponseObject *obj, BESDataHan
     }
 
     // This closes the file when it goes out of scope. jhrg 8/25/17
-    bes::TempFile temp_file(GeoTiffTransmitter::temp_dir + '/' + "geotiffXXXXXX");
+    bes::TempFile temp_file(GeoTiffTransmitter::temp_dir, "geotiff_XXXXXX");
 #if 0
     // Huh? Put the template for the temp file name in a char array. Use vector<char>
     // to avoid using new/delete.

--- a/modules/fileout_gdal/JPEG2000Transmitter.cc
+++ b/modules/fileout_gdal/JPEG2000Transmitter.cc
@@ -156,7 +156,7 @@ void JPEG2000Transmitter::send_data_as_jp2(BESResponseObject *obj, BESDataHandle
     // now we need to read the data
     BESDEBUG("JPEG20002", "JPEG2000Transmitter::send_data - reading data into DataDDS" << endl);
 
-    bes::TempFile temp_file(JPEG2000Transmitter::temp_dir, "jp2_XXXXXX");
+    bes::TempFile temp_file(JPEG2000Transmitter::temp_dir, "jp2000_XXXXXX");
 #if 0
     // Huh? Put the template for the temp file name in a char array. Use vector<char>
     // to avoid using new/delete.

--- a/modules/fileout_gdal/JPEG2000Transmitter.cc
+++ b/modules/fileout_gdal/JPEG2000Transmitter.cc
@@ -156,7 +156,7 @@ void JPEG2000Transmitter::send_data_as_jp2(BESResponseObject *obj, BESDataHandle
     // now we need to read the data
     BESDEBUG("JPEG20002", "JPEG2000Transmitter::send_data - reading data into DataDDS" << endl);
 
-    bes::TempFile temp_file(JPEG2000Transmitter::temp_dir + '/' + "jp2XXXXXX");
+    bes::TempFile temp_file(JPEG2000Transmitter::temp_dir, "jp2_XXXXXX");
 #if 0
     // Huh? Put the template for the temp file name in a char array. Use vector<char>
     // to avoid using new/delete.

--- a/modules/fileout_gdal/fong.conf.in
+++ b/modules/fileout_gdal/fong.conf.in
@@ -17,7 +17,7 @@ BES.module.fong = @bes_modules_dir@/libfong_module.so
 # File Out GDAL (FONg) module specific parameters
 
 # Directory to store temporary files during transformation
-FONg.Tempdir = /tmp/fong
+FONg.Tempdir = /tmp/hyrax_fong
 
 # URL to the FONg Reference Page at docs.opendap.org"
 FONg.Reference = http://docs.opendap.org/index.php/BES_-_Modules_-_FileOut_GDAL

--- a/modules/fileout_gdal/fong.conf.in
+++ b/modules/fileout_gdal/fong.conf.in
@@ -17,7 +17,7 @@ BES.module.fong = @bes_modules_dir@/libfong_module.so
 # File Out GDAL (FONg) module specific parameters
 
 # Directory to store temporary files during transformation
-FONg.Tempdir = /tmp
+FONg.Tempdir = /tmp/fong
 
 # URL to the FONg Reference Page at docs.opendap.org"
 FONg.Reference = http://docs.opendap.org/index.php/BES_-_Modules_-_FileOut_GDAL

--- a/modules/fileout_netcdf/FONcTransmitter.cc
+++ b/modules/fileout_netcdf/FONcTransmitter.cc
@@ -58,7 +58,9 @@
 
 #include <BESLog.h>
 #include <BESError.h>
+#include <BESInternalFatalError.h>
 #include <BESDapError.h>
+#include "BESDMRResponse.h"
 #include <stringbuffer.h>
 
 #include "FONcBaseType.h"
@@ -120,9 +122,12 @@ void FONcTransmitter::send_dap2_data(BESResponseObject *obj, BESDataHandlerInter
     BESDEBUG(MODULE,  prolog << "BEGIN" << endl);
 
     try { // Expanded try block so all DAP errors are caught. ndp 12/23/2015
+        auto bdds = dynamic_cast<BESDataDDSResponse *>(obj);
+        if (!bdds) throw BESInternalFatalError("Expected a BESDataDDSResponse instance", __FILE__, __LINE__);
+        auto dds = bdds->get_dds();
 
         // This object closes the file when it goes out of scope.
-        bes::TempFile temp_file(FONcRequestHandler::temp_dir + "/ncXXXXXX");
+        bes::TempFile temp_file(FONcRequestHandler::temp_dir, "/dap2_nc_"+dds->filename()+"_XXXXXX");
 
         BESDEBUG(MODULE,  prolog << "Building response file " << temp_file.get_name() << endl);
 
@@ -226,8 +231,12 @@ void FONcTransmitter::send_dap4_data(BESResponseObject *obj, BESDataHandlerInter
 
     try { // Expanded try block so all DAP errors are caught. ndp 12/23/2015
 
+        auto bdmr = dynamic_cast<BESDMRResponse *>(obj);
+        if (!bdmr) throw BESInternalFatalError("Expected a BESDMRResponse instance", __FILE__, __LINE__);
+        auto dmr = bdmr->get_dmr();
+
         // This object closes the file when it goes out of scope.
-        bes::TempFile temp_file(FONcRequestHandler::temp_dir + "/ncXXXXXX");
+        bes::TempFile temp_file(FONcRequestHandler::temp_dir,  "/dap4_nc_"+dmr->filename()+"_XXXXXX");
 
         BESDEBUG(MODULE,  prolog << "Building response file " << temp_file.get_name() << endl);
         // Note that 'RETURN_CMD' is the same as the string that determines the file type:

--- a/modules/fileout_netcdf/FONcTransmitter.cc
+++ b/modules/fileout_netcdf/FONcTransmitter.cc
@@ -126,8 +126,10 @@ void FONcTransmitter::send_dap2_data(BESResponseObject *obj, BESDataHandlerInter
         if (!bdds) throw BESInternalFatalError("Expected a BESDataDDSResponse instance", __FILE__, __LINE__);
         auto dds = bdds->get_dds();
 
+        string base_name = dds->filename().substr(dds->filename().find_last_of("/\\") + 1);
+
         // This object closes the file when it goes out of scope.
-        bes::TempFile temp_file(FONcRequestHandler::temp_dir, "/dap2_nc_"+dds->filename()+"_XXXXXX");
+        bes::TempFile temp_file(FONcRequestHandler::temp_dir, "/dap2_nc_"+base_name+"_XXXXXX");
 
         BESDEBUG(MODULE,  prolog << "Building response file " << temp_file.get_name() << endl);
 
@@ -235,8 +237,10 @@ void FONcTransmitter::send_dap4_data(BESResponseObject *obj, BESDataHandlerInter
         if (!bdmr) throw BESInternalFatalError("Expected a BESDMRResponse instance", __FILE__, __LINE__);
         auto dmr = bdmr->get_dmr();
 
+        string base_name = dmr->filename().substr(dmr->filename().find_last_of("/\\") + 1);
+
         // This object closes the file when it goes out of scope.
-        bes::TempFile temp_file(FONcRequestHandler::temp_dir,  "/dap4_nc_"+dmr->filename()+"_XXXXXX");
+        bes::TempFile temp_file(FONcRequestHandler::temp_dir,  "/dap4_nc_"+base_name+"_XXXXXX");
 
         BESDEBUG(MODULE,  prolog << "Building response file " << temp_file.get_name() << endl);
         // Note that 'RETURN_CMD' is the same as the string that determines the file type:

--- a/modules/fileout_netcdf/fonc.conf.in
+++ b/modules/fileout_netcdf/fonc.conf.in
@@ -22,7 +22,7 @@ BES.module.fonc=@bes_modules_dir@/libfonc_module.so
 # FONc.ClassicModel: When making a netCDF4 file, use only the 'classic' netCDF 
 # data model.
 
-FONc.Tempdir = /tmp
+FONc.Tempdir = /tmp/hyrax_fonc
 
 FONc.Reference = http://docs.opendap.org/index.php/BES_-_Modules_-_FileOut_Netcdf
 


### PR DESCRIPTION
Changed `TempFile` to take a separate directory name and file template as parameters to its constructor.
The `TempFile` will try to create the directory and if it fails it will throw an exception. 
If the directory exists already this is not a failure.
Now the code that uses TempFile is not limited to `/tmp` or some other prexisting directory, which allows use to be more discerning in where these temp files get placed.

Also in this PR I changed the way the filet_netcdf names its temples so that the temp file name contains the dataset name.