### PR TITLE
New init() for TempFile static member

### DIFF
--- a/dap/GlobalMetadataStore.cc
+++ b/dap/GlobalMetadataStore.cc
@@ -1254,7 +1254,7 @@ DDS *
 GlobalMetadataStore::get_dds_object(const string &name)
 {
     TempFile dds_tmp;
-    string dds_tmp_name = dds_tmp.create(get_cache_directory(), "mds_dds_XXXXXX");
+    string dds_tmp_name = dds_tmp.create(get_cache_directory(), "mds_dds");
 
     fstream dds_fs(dds_tmp_name.c_str(), std::fstream::out);
     try {
@@ -1271,7 +1271,7 @@ GlobalMetadataStore::get_dds_object(const string &name)
     dds->parse(dds_tmp_name);
 
     TempFile das_tmp;
-    string das_tmp_name = das_tmp.create(get_cache_directory(), "mds_das_XXXXXX");
+    string das_tmp_name = das_tmp.create(get_cache_directory(), "mds_das");
     fstream das_fs(das_tmp_name.c_str(), std::fstream::out);
     try {
         write_das_response(name, das_fs);     // throws BESInternalError if not found

--- a/dap/GlobalMetadataStore.cc
+++ b/dap/GlobalMetadataStore.cc
@@ -343,7 +343,7 @@ GlobalMetadataStore::get_instance()
         d_enabled = d_instance->cache_enabled();
         if (!d_enabled) {
             delete d_instance;
-            d_instance = NULL;
+            d_instance = nullptr;
             BESDEBUG(DEBUG_KEY, "GlobalMetadataStore::"<<__func__ << "() - " << "MDS is DISABLED"<< endl);
         }
         else {
@@ -1253,9 +1253,10 @@ GlobalMetadataStore::get_dmr_object(const string &name)
 DDS *
 GlobalMetadataStore::get_dds_object(const string &name)
 {
-    TempFile dds_tmp(get_cache_directory(), "/mds_dds_XXXXXX");
+    TempFile dds_tmp;
+    string dds_tmp_name = dds_tmp.create(get_cache_directory(), "/mds_dds_XXXXXX");
 
-    fstream dds_fs(dds_tmp.get_name().c_str(), std::fstream::out);
+    fstream dds_fs(dds_tmp_name.c_str(), std::fstream::out);
     try {
         write_dds_response(name, dds_fs);     // throws BESInternalError if not found
         dds_fs.close();
@@ -1267,10 +1268,11 @@ GlobalMetadataStore::get_dds_object(const string &name)
 
     BaseTypeFactory btf;
     unique_ptr<DDS> dds(new DDS(&btf));
-    dds->parse(dds_tmp.get_name());
+    dds->parse(dds_tmp_name);
 
-    TempFile das_tmp(get_cache_directory(), "/mds_das_XXXXXX");
-    fstream das_fs(das_tmp.get_name().c_str(), std::fstream::out);
+    TempFile das_tmp;
+    string das_tmp_name = das_tmp.create(get_cache_directory(), "/mds_das_XXXXXX");
+    fstream das_fs(das_tmp_name.c_str(), std::fstream::out);
     try {
         write_das_response(name, das_fs);     // throws BESInternalError if not found
         das_fs.close();
@@ -1281,7 +1283,7 @@ GlobalMetadataStore::get_dds_object(const string &name)
     }
 
     unique_ptr<DAS> das(new DAS());
-    das->parse(das_tmp.get_name());
+    das->parse(das_tmp_name);
 
     dds->transfer_attributes(das.get());
     dds->set_factory(nullptr);

--- a/dap/GlobalMetadataStore.cc
+++ b/dap/GlobalMetadataStore.cc
@@ -1254,7 +1254,7 @@ DDS *
 GlobalMetadataStore::get_dds_object(const string &name)
 {
     TempFile dds_tmp;
-    string dds_tmp_name = dds_tmp.create(get_cache_directory(), "/mds_dds_XXXXXX");
+    string dds_tmp_name = dds_tmp.create(get_cache_directory(), "mds_dds_XXXXXX");
 
     fstream dds_fs(dds_tmp_name.c_str(), std::fstream::out);
     try {
@@ -1271,7 +1271,7 @@ GlobalMetadataStore::get_dds_object(const string &name)
     dds->parse(dds_tmp_name);
 
     TempFile das_tmp;
-    string das_tmp_name = das_tmp.create(get_cache_directory(), "/mds_das_XXXXXX");
+    string das_tmp_name = das_tmp.create(get_cache_directory(), "mds_das_XXXXXX");
     fstream das_fs(das_tmp_name.c_str(), std::fstream::out);
     try {
         write_das_response(name, das_fs);     // throws BESInternalError if not found

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -90,7 +90,6 @@ void TempFile::sigpipe_handler(int sig)
     catch (...) {
         cerr << "Encountered unknown error in " << __FILE__ << " at line: " << __LINE__ << endl;
     }
-
 }
 
 
@@ -273,7 +272,6 @@ TempFile::~TempFile()
         cerr << "Encountered unknown error while closing " << d_fname;
         cerr << "  " << __FILE__ << " at line: " << __LINE__ << endl;
     }
-
 }
 
 } // namespace bes

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -133,7 +133,7 @@ void TempFile::init() {
     open_files.reset(new std::map<string, int>());
 }
 
-TempFile::TempFile(bool keep_temps): d_fd(-1), d_keep_temps(keep_temps) {
+TempFile::TempFile(bool keep_temps): d_keep_temps(keep_temps) {
     std::call_once(d_init_once,TempFile::init);
 }
 
@@ -211,13 +211,11 @@ string TempFile::create(const std::string &dir_name, const std::string &file_tem
 TempFile::~TempFile()
 {
     try {
-        if(d_fd != -1) {
-            if (close(d_fd) == -1) {
-                stringstream msg;
-                msg << "Error closing temporary file: '" << d_fname ;
-                msg << " errno: " << errno << " message: " << strerror(errno) << endl;
-                ERROR_LOG(msg.str());
-            }
+        if(d_fd != -1 && close(d_fd) == -1) {
+            stringstream msg;
+            msg << "Error closing temporary file: '" << d_fname ;
+            msg << " errno: " << errno << " message: " << strerror(errno) << endl;
+            ERROR_LOG(msg.str());
         }
         if (!d_keep_temps && !d_fname.empty()) {
             if (unlink(d_fname.c_str()) == -1) {

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -35,6 +35,7 @@
 #include <cerrno>
 #include <vector>
 #include <string>
+#include <memory>
 
 #include <BESInternalError.h>
 #include <BESInternalFatalError.h>

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -264,7 +264,7 @@ TempFile::~TempFile()
             }
         }
     }
-    catch (BESError &e) {
+    catch (BESError const &e) {
         cerr << "Encountered BESError will closing " << d_fname << " Message: " << e.get_verbose_message();
         cerr << " (location: " << __FILE__ << " at line: " << __LINE__ << ")" <<  endl;
     }

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -146,32 +146,29 @@ TempFile::TempFile(bool keep_temps): d_keep_temps(keep_temps) {
 /**
  * @brief Create a new temporary file
  *
- * Get a new temporary file using the given directory and temporary file template.
+ * Get a new temporary file using the given directory and temporary file prefix.
  * If the directory does not exist it will be created.
- * The temporary file template and must end in six Xs with no characters following.
- *
- * @note If you pass in a bad template, a BESInternalError will be thrown.
  *
  * @param dir_name The name of the directory in which the temporary file
  * will be created.
- * @param path_template Template passed to mkstemp() to build the temporary
- * filename.
+ * @param temp_file_prefix A prefix to be used for the temporary file.
  * @param keep_temps Keep the temporary files.
  * @return The name of the temporary file.
  */
-string TempFile::create(const std::string &dir_name, const std::string &file_template)
+string TempFile::create(const std::string &dir_name, const std::string &temp_file_prefix)
 {
     std::lock_guard<std::recursive_mutex> lock_me(d_tf_lock_mutex);
 
     BESDEBUG(MODULE, prolog << "dir_name: " << dir_name << endl);
     mk_temp_dir(dir_name);
 
-    BESDEBUG(MODULE, prolog << "file_template: " << file_template << endl);
-    if(!BESUtil::endsWith(file_template,"XXXXXX")){
-        stringstream msg;
-        msg << prolog << "ERROR - The temporary file template: '"<< file_template << "' does not end in XXXXXX.";
-        throw BESInternalError(msg.str(),__FILE__,__LINE__);
+    BESDEBUG(MODULE, prolog << "temp_file_prefix: " << temp_file_prefix << endl);
+    string tmplt("XXXXXX");
+    if(BESUtil::endsWith(temp_file_prefix,"_")){
+        tmplt = "_" + tmplt;
     }
+    string file_template = temp_file_prefix + tmplt;
+    BESDEBUG(MODULE, prolog << "file_template: " << file_template << endl);
 
     string target_file = BESUtil::pathConcat(dir_name,file_template);
     BESDEBUG(MODULE, prolog << "target_file: " << target_file << endl);

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -85,7 +85,7 @@ void TempFile::mk_temp_dir(const std::string &dir_name) {
 
     mode_t mode = S_IRWXU | S_IRWXG;
     stringstream ss;
-    ss << prolog << "mode: " <<  std::oct << mode << "(8) " << std::dec << mode << "(10) " << std::hex << mode << "(16)" << endl;
+    ss << prolog << "mode: " <<  std::oct << mode << endl;
     BESDEBUG(MODULE, ss.str());
 
     if(mkdir(dir_name.c_str(), mode)){
@@ -97,6 +97,22 @@ void TempFile::mk_temp_dir(const std::string &dir_name) {
         }
         else {
             BESDEBUG(MODULE,prolog << "The temp directory: " << dir_name << " exists." << endl);
+            uid_t uid = getuid();
+            gid_t gid = getgid();
+            BESDEBUG(MODULE,prolog << "Assuming ownership. uid: " << uid << " gid: "<< gid << endl);
+            if(chown(dir_name.c_str(),uid,gid)){
+                stringstream msg;
+                msg << prolog  << "ERROR - Failed to assume ownership of: " << dir_name;
+                msg << " errno: " << errno << " reason: " << strerror(errno);
+                throw BESInternalFatalError(msg.str(),__FILE__,__LINE__);
+            }
+            BESDEBUG(MODULE,prolog << "Changing permissions to mode: " << std::oct << mode << endl);
+            if(chmod(dir_name.c_str(),mode)){
+                stringstream msg;
+                msg << prolog  << "ERROR - Failed to change permissions for: " << dir_name;
+                msg << " errno: " << errno << " reason: " << strerror(errno);
+                throw BESInternalFatalError(msg.str(),__FILE__,__LINE__);
+            }
         }
     }
     else {

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -50,6 +50,8 @@ using namespace std;
 #define MODULE "dap"
 #define prolog string("TempFile::").append(__func__).append("() - ")
 
+#define STRICT 0
+
 namespace bes {
 
 std::once_flag TempFile::d_init_once;
@@ -97,6 +99,7 @@ void TempFile::mk_temp_dir(const std::string &dir_name) {
         }
         else {
             BESDEBUG(MODULE,prolog << "The temp directory: " << dir_name << " exists." << endl);
+#if STRICT
             uid_t uid = getuid();
             gid_t gid = getgid();
             BESDEBUG(MODULE,prolog << "Assuming ownership of " << dir_name << " (uid: " << uid << " gid: "<< gid << ")" << endl);
@@ -115,6 +118,7 @@ void TempFile::mk_temp_dir(const std::string &dir_name) {
                 msg << " errno: " << errno << " reason: " << strerror(errno);
                 throw BESInternalFatalError(msg.str(),__FILE__,__LINE__);
             }
+#endif
         }
     }
     else {
@@ -174,7 +178,6 @@ TempFile::TempFile(const std::string &dir_name, const std::string &file_template
         throw BESInternalError(msg.str(), __FILE__, __LINE__);
     }
     d_fname.assign(tmp_name);
-
 
     std::lock_guard<std::recursive_mutex> lock_me(d_tf_lock_mutex);
 

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -52,9 +52,7 @@ using namespace std;
 
 namespace bes {
 
-// static std::once_flag d_tfile_init_once;
-std::once_flag TempFile::d_tfile_init;
-
+std::once_flag TempFile::d_init_once;
 std::unique_ptr< std::map<std::string, int> > TempFile::open_files;
 struct sigaction TempFile::cached_sigpipe_handler;
 
@@ -85,7 +83,11 @@ void TempFile::sigpipe_handler(int sig)
  */
 void TempFile::mk_temp_dir(const std::string &dir_name) {
 
-    mode_t mode = umask(007);
+    mode_t mode = S_IRWXU | S_IRWXG;
+    stringstream ss;
+    ss << prolog << "mode: " <<  std::oct << mode << "(8) " << std::dec << mode << "(10) " << std::hex << mode << "(16)" << endl;
+    BESDEBUG(MODULE, ss.str());
+
     if(mkdir(dir_name.c_str(), mode)){
         if(errno != EEXIST){
             stringstream msg;
@@ -127,7 +129,7 @@ void TempFile::init() {
 TempFile::TempFile(const std::string &dir_name, const std::string &file_template, bool keep_temps)
     : d_keep_temps(keep_temps)
 {
-    std::call_once(d_tfile_init,TempFile::init);
+    std::call_once(d_init_once,TempFile::init);
 
     BESDEBUG(MODULE, prolog << "dir_name: " << dir_name << endl);
     mk_temp_dir(dir_name);

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -29,7 +29,6 @@
 #include <signal.h>
 #include <sys/wait.h> // for wait
 #include <sstream>      // std::stringstream
-#include <mutex>
 
 #include <cstdlib>
 #include <cstring>

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -99,17 +99,19 @@ void TempFile::mk_temp_dir(const std::string &dir_name) {
             BESDEBUG(MODULE,prolog << "The temp directory: " << dir_name << " exists." << endl);
             uid_t uid = getuid();
             gid_t gid = getgid();
-            BESDEBUG(MODULE,prolog << "Assuming ownership. uid: " << uid << " gid: "<< gid << endl);
+            BESDEBUG(MODULE,prolog << "Assuming ownership of " << dir_name << " (uid: " << uid << " gid: "<< gid << ")" << endl);
             if(chown(dir_name.c_str(),uid,gid)){
                 stringstream msg;
-                msg << prolog  << "ERROR - Failed to assume ownership of: " << dir_name;
+                msg << prolog  << "ERROR - Failed to assume ownership (uid: "<< uid;
+                msg << " gid: " << gid << ") of: " << dir_name;
                 msg << " errno: " << errno << " reason: " << strerror(errno);
                 throw BESInternalFatalError(msg.str(),__FILE__,__LINE__);
             }
             BESDEBUG(MODULE,prolog << "Changing permissions to mode: " << std::oct << mode << endl);
             if(chmod(dir_name.c_str(),mode)){
                 stringstream msg;
-                msg << prolog  << "ERROR - Failed to change permissions for: " << dir_name;
+                msg << prolog  << "ERROR - Failed to change permissions (mode: " << std::oct << mode;
+                msg << ") for: " << dir_name;
                 msg << " errno: " << errno << " reason: " << strerror(errno);
                 throw BESInternalFatalError(msg.str(),__FILE__,__LINE__);
             }

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -66,7 +66,7 @@ struct sigaction TempFile::cached_sigpipe_handler;
 void TempFile::sigpipe_handler(int sig)
 {
     if (sig == SIGPIPE) {
-        for(auto &mpair: *open_files){
+        for(const auto &mpair: *open_files){
             if (unlink((mpair.first).c_str()) == -1)
                 ERROR_LOG(string("Error unlinking temporary file: '").append(mpair.first).append("': ").append(strerror(errno)).append("\n"));
         }

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -52,7 +52,8 @@ using namespace std;
 
 namespace bes {
 
-static std::once_flag d_tfile_init_once;
+// static std::once_flag d_tfile_init_once;
+std::once_flag TempFile::d_tfile_init;
 
 std::unique_ptr< std::map<std::string, int> > TempFile::open_files;
 struct sigaction TempFile::cached_sigpipe_handler;
@@ -126,7 +127,7 @@ void TempFile::init() {
 TempFile::TempFile(const std::string &dir_name, const std::string &file_template, bool keep_temps)
     : d_keep_temps(keep_temps)
 {
-    std::call_once(d_tfile_init_once,TempFile::init);
+    std::call_once(d_tfile_init,TempFile::init);
 
     BESDEBUG(MODULE, prolog << "dir_name: " << dir_name << endl);
     mk_temp_dir(dir_name);

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -130,7 +130,7 @@ void TempFile::mk_temp_dir(const std::string &dir_name) {
  * @brief Initialize static class members, should only be called once using std::call_once()
  */
 void TempFile::init() {
-    open_files = unique_ptr<std::map<string, int>>(new std::map<string, int>());
+    open_files.reset(new std::map<string, int>());
 }
 
 /**

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -49,7 +49,7 @@ private:
     static struct sigaction cached_sigpipe_handler;
     mutable std::recursive_mutex d_tf_lock_mutex;
     static void init();
-    static std::once_flag d_tfile_init;
+    static std::once_flag d_init_once;
 
     // Holds the static list of all open files
     static std::unique_ptr< std::map<std::string, int> > open_files;

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -43,24 +43,31 @@ namespace bes {
  */
 class TempFile {
 private:
+    static std::map<std::string, int> *open_files;
+    static struct sigaction cached_sigpipe_handler;
+    mutable std::recursive_mutex d_tf_lock_mutex;
+
+
     int d_fd;
     std::string d_fname;
     bool d_keep_temps;
 
-    static std::map<std::string, int> *open_files;
-    static struct sigaction cached_sigpipe_handler;
+
+
+    // Thread safe lifecycle controls
+    static void init();
+    static void delete_instance();
+
+    void mk_temp_dir(const std::string &dir_name = "/tmp/hyrax_tmp") const;
 
     friend class TemporaryFileTest;
-
-    static void init();
-    void mk_temp_dir(const std::string &dir_name = "/tmp") const;
 
 public:
     // Odd, but even with TemporaryFileTest declared as a friend, the tests won't
     // compile unless this is declared public.
     static void sigpipe_handler(int signal);
 
-    explicit TempFile(const std::string &dir_name = "/tmp", const std::string &path_template = "opendapXXXXXX", bool keep_temps = false);
+    explicit TempFile(const std::string &dir_name = "/tmp/hyrax_tmp", const std::string &path_template = "opendapXXXXXX", bool keep_temps = false);
 
     ~TempFile();
 

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <map>
 #include <mutex>
+#include <memory>
 
 namespace bes {
 

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -71,7 +71,7 @@ public:
     explicit TempFile(bool keep_temps = false);
     ~TempFile();
 
-    std::string create(const std::string &dir_name = "/tmp/hyrax_tmp", const std::string &path_template = "opendap_XXXXXX");
+    std::string create(const std::string &dir_name = "/tmp/hyrax_tmp", const std::string &path_template = "opendap");
 
     /** @return The temporary file's file descriptor */
     int get_fd() const { return d_fd; }

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -33,9 +33,6 @@
 
 namespace bes {
 
-const std::string default_tmp_file_template = "opendapXXXXXX";
-const std::string default_dir = "/tmp";
-
 /**
  * @brief Get a new temporary file
  *
@@ -55,14 +52,15 @@ private:
 
     friend class TemporaryFileTest;
 
-    void mk_temp_dir(const std::string &dir_name = default_dir);
+    static void init();
+    void mk_temp_dir(const std::string &dir_name = "/tmp") const;
 
 public:
     // Odd, but even with TemporaryFileTest declared as a friend, the tests won't
     // compile unless this is declared public.
     static void sigpipe_handler(int signal);
 
-    explicit TempFile(const std::string &dir_name = default_dir, const std::string &path_template = default_tmp_file_template, bool keep_temps = false);
+    explicit TempFile(const std::string &dir_name = "/tmp", const std::string &path_template = "opendapXXXXXX", bool keep_temps = false);
 
     ~TempFile();
 

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -49,6 +49,7 @@ private:
     static struct sigaction cached_sigpipe_handler;
     mutable std::recursive_mutex d_tf_lock_mutex;
     static void init();
+    static std::once_flag d_tfile_init;
 
     // Holds the static list of all open files
     static std::unique_ptr< std::map<std::string, int> > open_files;

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -30,6 +30,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <mutex>
 
 namespace bes {
 

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -68,9 +68,11 @@ public:
     // compile unless this is declared public.
     static void sigpipe_handler(int signal);
 
-    explicit TempFile(const std::string &dir_name = "/tmp/hyrax_tmp", const std::string &path_template = "opendapXXXXXX", bool keep_temps = false);
-
+    explicit TempFile(bool keep_temps = false);
     ~TempFile();
+
+    std::string create(const std::string &dir_name = "/tmp/hyrax_tmp", const std::string &path_template = "opendapXXXXXX");
+
 
     /** @return The temporary file's file descriptor */
     int get_fd() const { return d_fd; }

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -44,22 +44,20 @@ namespace bes {
  */
 class TempFile {
 private:
-    static std::map<std::string, int> *open_files;
+    // Lifecycle controls
     static struct sigaction cached_sigpipe_handler;
     mutable std::recursive_mutex d_tf_lock_mutex;
+    static void init();
 
+    // Holds the static list of all open files
+    static std::unique_ptr< std::map<std::string, int> > open_files;
 
+    // Instance variables
     int d_fd;
     std::string d_fname;
     bool d_keep_temps;
 
-
-
-    // Thread safe lifecycle controls
-    static void init();
-    static void delete_instance();
-
-    void mk_temp_dir(const std::string &dir_name = "/tmp/hyrax_tmp") const;
+    static void mk_temp_dir(const std::string &dir_name = "/tmp/hyrax_tmp") ;
 
     friend class TemporaryFileTest;
 

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -55,7 +55,7 @@ private:
     static std::unique_ptr< std::map<std::string, int> > open_files;
 
     // Instance variables
-    int d_fd;
+    int d_fd = -1;
     std::string d_fname;
     bool d_keep_temps;
 

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -71,8 +71,7 @@ public:
     explicit TempFile(bool keep_temps = false);
     ~TempFile();
 
-    std::string create(const std::string &dir_name = "/tmp/hyrax_tmp", const std::string &path_template = "opendapXXXXXX");
-
+    std::string create(const std::string &dir_name = "/tmp/hyrax_tmp", const std::string &path_template = "opendap_XXXXXX");
 
     /** @return The temporary file's file descriptor */
     int get_fd() const { return d_fd; }

--- a/dap/unit-tests/Makefile.am
+++ b/dap/unit-tests/Makefile.am
@@ -56,7 +56,7 @@ pathinfo_files:
 	(cd pathinfo_files && ln -s nc link_to_nc)
 
 clean-local:
-	-rm -rf mds pathinfo_files response_cache tmp
+	-rm -rf mds pathinfo_files response_cache tmp temp_file_test
 
 EXTRA_DIST = input-files mds_baselines test_utils.cc test_utils.h TestFunction.h \
 test_config.h.in bes.conf.in

--- a/dap/unit-tests/TemporaryFileTest.cc
+++ b/dap/unit-tests/TemporaryFileTest.cc
@@ -68,7 +68,7 @@ using namespace std;
 
 class TemporaryFileTest: public CppUnit::TestFixture {
     const string TEMP_DIR=string(TEST_BUILD_DIR).append("/temp_file_test");
-    const string TEMP_FILE_TEMPLATE = "tmp_XXXXXX";
+    const string TEMP_FILE_PREFIX = "tmpf_test_";
     const string BES_CONF_FILE = BESUtil::assemblePath(TEST_BUILD_DIR, "bes.conf");
 private:
 
@@ -91,7 +91,7 @@ public:
         // to configure the BESKeys with the BES config file name so
         // that there is a log file name... Oy.
         TheBESKeys::ConfigFile = BES_CONF_FILE;
-        DBG(cerr << __func__ << "() - Temp file template is: '" << TEMP_FILE_TEMPLATE << "'" << endl);
+        DBG(cerr << __func__ << "() - Temp file template is: '" << TEMP_FILE_PREFIX << "'" << endl);
         DBG2(cerr << __func__ << "() - END" << endl);
     }
 
@@ -105,7 +105,7 @@ public:
 
         try {
             bes::TempFile tf;
-            tmp_file_name = tf.create(TEMP_DIR, TEMP_FILE_TEMPLATE);
+            tmp_file_name = tf.create(TEMP_DIR, TEMP_FILE_PREFIX);
             DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                 << tf.get_fd() << endl);
 
@@ -139,7 +139,7 @@ public:
         try {
             for (int i = 0; i < count; i++) {
                 tfiles[i] = new bes::TempFile();
-                tmp_file_names[i] = tfiles[i]->create(TEMP_DIR, TEMP_FILE_TEMPLATE);
+                tmp_file_names[i] = tfiles[i]->create(TEMP_DIR, TEMP_FILE_PREFIX);
                 DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_names[i] << "' has been created. fd: "
                     << tfiles[i]->get_fd() << endl);
 
@@ -178,7 +178,7 @@ public:
 
         try {
             bes::TempFile tf;
-            tmp_file_name = tf.create(TEMP_DIR, TEMP_FILE_TEMPLATE);
+            tmp_file_name = tf.create(TEMP_DIR, TEMP_FILE_PREFIX);
             DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_name << "' has been created. fd: " << tf.get_fd() << endl);
 
             // Is it really there? Just sayin'...
@@ -223,7 +223,7 @@ public:
         // Because we are going to fork and the child will be making a temp file, we use shared memory to
         // allow the parent to know the resulting file name.
         char *glob_name;
-        int name_size = TEMP_FILE_TEMPLATE.length() + 1;
+        int name_size = TEMP_FILE_PREFIX.length() + 1;
         glob_name = (char *) mmap(nullptr, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 
         pid_t pid = fork();
@@ -258,7 +258,7 @@ public:
             try {
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
                 bes::TempFile tf;
-                tmp_file_name = tf.create(TEMP_DIR, TEMP_FILE_TEMPLATE);
+                tmp_file_name = tf.create(TEMP_DIR, TEMP_FILE_PREFIX);
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                     << tf.get_fd() << endl);
                 // copy the filename into shared memory.
@@ -287,7 +287,7 @@ public:
         // Because we are going to fork and the child will be making a temp file, we use shared memory to
         // allow the parent to know the resulting file names.
         char *glob_name[3];
-        int name_size = TEMP_FILE_TEMPLATE.length() + 1;
+        int name_size = TEMP_FILE_PREFIX.length() + 1;
         glob_name[0] = (char *) mmap(nullptr, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
         glob_name[1] = (char *) mmap(nullptr, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
         glob_name[2] = (char *) mmap(nullptr, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
@@ -330,7 +330,7 @@ public:
                 // --------- File One ------------
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
                 bes::TempFile tf1;
-                tmp_file_name = tf1.create(TEMP_DIR, TEMP_FILE_TEMPLATE);
+                tmp_file_name = tf1.create(TEMP_DIR, TEMP_FILE_PREFIX);
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                     << tf1.get_fd() << endl);
                 // copy the filename into shared memory.
@@ -343,7 +343,7 @@ public:
                 // --------- File Two ------------
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
                 bes::TempFile tf2;
-                tmp_file_name = tf2.create(TEMP_DIR, TEMP_FILE_TEMPLATE);
+                tmp_file_name = tf2.create(TEMP_DIR, TEMP_FILE_PREFIX);
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                     << tf2.get_fd() << endl);
                 // copy the filename into shared memory.
@@ -356,7 +356,7 @@ public:
                 // --------- File Three ------------
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
                 bes::TempFile tf3;
-                tmp_file_name = tf3.create(TEMP_DIR, TEMP_FILE_TEMPLATE);
+                tmp_file_name = tf3.create(TEMP_DIR, TEMP_FILE_PREFIX);
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                     << tf3.get_fd() << endl);
                 // copy the filename into shared memory.

--- a/dap/unit-tests/TemporaryFileTest.cc
+++ b/dap/unit-tests/TemporaryFileTest.cc
@@ -67,7 +67,7 @@ using namespace std;
 
 
 class TemporaryFileTest: public CppUnit::TestFixture {
-    const string TEMP_DIR=string(TEST_BUILD_DIR).append("/tf_test");
+    const string TEMP_DIR=string(TEST_BUILD_DIR).append("/temp_file_test");
     const string TEMP_FILE_TEMPLATE = "tmp_XXXXXX";
     const string BES_CONF_FILE = BESUtil::assemblePath(TEST_BUILD_DIR, "bes.conf");
 private:
@@ -79,7 +79,6 @@ public:
 
     ~TemporaryFileTest()
     {
-        rmdir(TEMP_DIR.c_str());
     }
 
     void setUp()

--- a/dap/unit-tests/TemporaryFileTest.cc
+++ b/dap/unit-tests/TemporaryFileTest.cc
@@ -45,6 +45,7 @@
 #include "BESInternalFatalError.h"
 #include "TheBESKeys.h"
 #include "BESUtil.h"
+#include "BESDebug.h"
 #include "TempFile.h"
 
 #include "test_config.h"
@@ -66,7 +67,7 @@ using namespace std;
 
 
 class TemporaryFileTest: public CppUnit::TestFixture {
-    const string TEMP_DIR=TEST_BUILD_DIR;
+    const string TEMP_DIR=string(TEST_BUILD_DIR).append("/tf_test");
     const string TEMP_FILE_TEMPLATE = "tmp_XXXXXX";
     const string BES_CONF_FILE = BESUtil::assemblePath(TEST_BUILD_DIR, "bes.conf");
 private:
@@ -78,11 +79,15 @@ public:
 
     ~TemporaryFileTest()
     {
+        rmdir(TEMP_DIR.c_str());
     }
 
     void setUp()
     {
         DBG2(cerr << __func__ << "() - BEGIN" << endl);
+
+        if (debug) BESDebug::SetUp("cerr,dap");
+
         // Because TemporaryFile uses the BESLog macro ERROR we have
         // to configure the BESKeys with the BES config file name so
         // that there is a log file name... Oy.

--- a/dap/unit-tests/TemporaryFileTest.cc
+++ b/dap/unit-tests/TemporaryFileTest.cc
@@ -85,7 +85,7 @@ public:
     {
         DBG2(cerr << __func__ << "() - BEGIN" << endl);
 
-        if (debug) BESDebug::SetUp("cerr,dap");
+        if (debug_2) BESDebug::SetUp("cerr,dap");
 
         // Because TemporaryFile uses the BESLog macro ERROR we have
         // to configure the BESKeys with the BES config file name so
@@ -399,10 +399,10 @@ int main(int argc, char*argv[])
     while ((option_char = getopt(argc, argv, "dDh")) != -1)
         switch (option_char) {
         case 'd':
-            debug = 1;  // debug is a static global
+            debug = true;  // debug is a static global
             break;
         case 'D':
-            debug_2 = 1;
+            debug_2 = true;
             break;
         case 'h': {     // help - show test names
             cerr << "Usage: TemporaryFileTest has the following tests:" << endl;

--- a/dap/unit-tests/TemporaryFileTest.cc
+++ b/dap/unit-tests/TemporaryFileTest.cc
@@ -104,8 +104,8 @@ public:
         std::string tmp_file_name;
 
         try {
-            bes::TempFile tf(TEMP_DIR, TEMP_FILE_TEMPLATE);
-            tmp_file_name = tf.get_name();
+            bes::TempFile tf;
+            tmp_file_name = tf.create(TEMP_DIR, TEMP_FILE_TEMPLATE);
             DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                 << tf.get_fd() << endl);
 
@@ -138,8 +138,8 @@ public:
 
         try {
             for (int i = 0; i < count; i++) {
-                tfiles[i] = new bes::TempFile(TEMP_DIR, TEMP_FILE_TEMPLATE);
-                tmp_file_names[i] = tfiles[i]->get_name();
+                tfiles[i] = new bes::TempFile();
+                tmp_file_names[i] = tfiles[i]->create(TEMP_DIR, TEMP_FILE_TEMPLATE);
                 DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_names[i] << "' has been created. fd: "
                     << tfiles[i]->get_fd() << endl);
 
@@ -177,8 +177,8 @@ public:
         std::string tmp_file_name;
 
         try {
-            bes::TempFile tf(TEMP_DIR, TEMP_FILE_TEMPLATE);
-            tmp_file_name = tf.get_name();
+            bes::TempFile tf;
+            tmp_file_name = tf.create(TEMP_DIR, TEMP_FILE_TEMPLATE);
             DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_name << "' has been created. fd: " << tf.get_fd() << endl);
 
             // Is it really there? Just sayin'...
@@ -224,7 +224,7 @@ public:
         // allow the parent to know the resulting file name.
         char *glob_name;
         int name_size = TEMP_FILE_TEMPLATE.length() + 1;
-        glob_name = (char *) mmap(NULL, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        glob_name = (char *) mmap(nullptr, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 
         pid_t pid = fork();
         CPPUNIT_ASSERT(pid >= 0); // Make sure it didn't fail.
@@ -257,8 +257,8 @@ public:
             std::string tmp_file_name;
             try {
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
-                bes::TempFile tf(TEMP_DIR, TEMP_FILE_TEMPLATE);
-                tmp_file_name = tf.get_name();
+                bes::TempFile tf;
+                tmp_file_name = tf.create(TEMP_DIR, TEMP_FILE_TEMPLATE);
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                     << tf.get_fd() << endl);
                 // copy the filename into shared memory.
@@ -288,9 +288,9 @@ public:
         // allow the parent to know the resulting file names.
         char *glob_name[3];
         int name_size = TEMP_FILE_TEMPLATE.length() + 1;
-        glob_name[0] = (char *) mmap(NULL, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-        glob_name[1] = (char *) mmap(NULL, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-        glob_name[2] = (char *) mmap(NULL, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        glob_name[0] = (char *) mmap(nullptr, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        glob_name[1] = (char *) mmap(nullptr, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        glob_name[2] = (char *) mmap(nullptr, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 
         pid_t pid = fork();
         CPPUNIT_ASSERT(pid >= 0); // Make sure it didn't fail.
@@ -329,8 +329,8 @@ public:
 
                 // --------- File One ------------
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
-                bes::TempFile tf1(TEMP_DIR, TEMP_FILE_TEMPLATE);
-                tmp_file_name = tf1.get_name();
+                bes::TempFile tf1;
+                tmp_file_name = tf1.create(TEMP_DIR, TEMP_FILE_TEMPLATE);
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                     << tf1.get_fd() << endl);
                 // copy the filename into shared memory.
@@ -342,8 +342,8 @@ public:
 
                 // --------- File Two ------------
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
-                bes::TempFile tf2(TEMP_DIR, TEMP_FILE_TEMPLATE);
-                tmp_file_name = tf2.get_name();
+                bes::TempFile tf2;
+                tmp_file_name = tf2.create(TEMP_DIR, TEMP_FILE_TEMPLATE);
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                     << tf2.get_fd() << endl);
                 // copy the filename into shared memory.
@@ -355,8 +355,8 @@ public:
 
                 // --------- File Three ------------
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
-                bes::TempFile tf3(TEMP_DIR, TEMP_FILE_TEMPLATE);
-                tmp_file_name = tf3.get_name();
+                bes::TempFile tf3;
+                tmp_file_name = tf3.create(TEMP_DIR, TEMP_FILE_TEMPLATE);
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
                     << tf3.get_fd() << endl);
                 // copy the filename into shared memory.

--- a/modules/fileout_gdal/GeoTiffTransmitter.cc
+++ b/modules/fileout_gdal/GeoTiffTransmitter.cc
@@ -203,7 +203,7 @@ void GeoTiffTransmitter::send_data_as_geotiff(BESResponseObject *obj, BESDataHan
 
     // This closes the file when it goes out of scope. jhrg 8/25/17
     bes::TempFile temp_file;
-    string temp_file_name = temp_file.create(GeoTiffTransmitter::temp_dir, "geotiff_XXXXXX");
+    string temp_file_name = temp_file.create(GeoTiffTransmitter::temp_dir, "geotiff_");
 #if 0
     // Huh? Put the template for the temp file name in a char array. Use vector<char>
     // to avoid using new/delete.

--- a/modules/fileout_gdal/GeoTiffTransmitter.cc
+++ b/modules/fileout_gdal/GeoTiffTransmitter.cc
@@ -202,7 +202,8 @@ void GeoTiffTransmitter::send_data_as_geotiff(BESResponseObject *obj, BESDataHan
     }
 
     // This closes the file when it goes out of scope. jhrg 8/25/17
-    bes::TempFile temp_file(GeoTiffTransmitter::temp_dir, "geotiff_XXXXXX");
+    bes::TempFile temp_file;
+    string temp_file_name = temp_file.create(GeoTiffTransmitter::temp_dir, "geotiff_XXXXXX");
 #if 0
     // Huh? Put the template for the temp file name in a char array. Use vector<char>
     // to avoid using new/delete.
@@ -223,10 +224,10 @@ void GeoTiffTransmitter::send_data_as_geotiff(BESResponseObject *obj, BESDataHan
         throw BESInternalError("Failed to open the temporary file: " + temp_file_name, __FILE__, __LINE__);
 #endif
     // transform the OPeNDAP DataDDS to the geotiff file
-    BESDEBUG("fong2", "GeoTiffTransmitter::send_data - transforming into temporary file " << temp_file.get_name() << endl);
+    BESDEBUG("fong2", "GeoTiffTransmitter::send_data - transforming into temporary file " << temp_file_name << endl);
 
     try {
-        FONgTransform ft(dds, bdds->get_ce(), temp_file.get_name());
+        FONgTransform ft(dds, bdds->get_ce(), temp_file_name);
 
         // Verify the request hasn't exceeded bes_timeout, and disable timeout if allowed.
         RequestServiceTimer::TheTimer()->throw_if_timeout_expired(prolog + "ERROR: bes-timeout expired before transmit", __FILE__, __LINE__);
@@ -235,9 +236,9 @@ void GeoTiffTransmitter::send_data_as_geotiff(BESResponseObject *obj, BESDataHan
         // transform() opens the temporary file, dumps data to it and closes it.
         ft.transform_to_geotiff();
 
-        BESDEBUG("fong2", "GeoTiffTransmitter::send_data - transmitting temp file " << temp_file.get_name() << endl );
+        BESDEBUG("fong2", "GeoTiffTransmitter::send_data - transmitting temp file " << temp_file_name << endl );
 
-        GeoTiffTransmitter::return_temp_stream(temp_file.get_name(), strm);
+        GeoTiffTransmitter::return_temp_stream(temp_file_name, strm);
     }
     catch (Error &e) {
 #if 0

--- a/modules/fileout_gdal/JPEG2000Transmitter.cc
+++ b/modules/fileout_gdal/JPEG2000Transmitter.cc
@@ -156,7 +156,8 @@ void JPEG2000Transmitter::send_data_as_jp2(BESResponseObject *obj, BESDataHandle
     // now we need to read the data
     BESDEBUG("JPEG20002", "JPEG2000Transmitter::send_data - reading data into DataDDS" << endl);
 
-    bes::TempFile temp_file(JPEG2000Transmitter::temp_dir, "jp2000_XXXXXX");
+    bes::TempFile temp_file;
+    string temp_file_name = temp_file.create(JPEG2000Transmitter::temp_dir, "jp2000_XXXXXX");
 #if 0
     // Huh? Put the template for the temp file name in a char array. Use vector<char>
     // to avoid using new/delete.
@@ -177,7 +178,7 @@ void JPEG2000Transmitter::send_data_as_jp2(BESResponseObject *obj, BESDataHandle
         throw BESInternalError("Failed to open the temporary file: " + temp_file_name, __FILE__, __LINE__);
 #endif
     // transform the OPeNDAP DataDDS to the geotiff file
-    BESDEBUG("JPEG20002", "JPEG2000Transmitter::send_data - transforming into temporary file " << temp_file.get_name() << endl);
+    BESDEBUG("JPEG20002", "JPEG2000Transmitter::send_data - transforming into temporary file " << temp_file_name << endl);
 
     try {
 
@@ -223,7 +224,7 @@ void JPEG2000Transmitter::send_data_as_jp2(BESResponseObject *obj, BESDataHandle
     }
 
     try {
-        FONgTransform ft(dds, bdds->get_ce(), temp_file.get_name());
+        FONgTransform ft(dds, bdds->get_ce(), temp_file_name);
 
         // Now that we are ready to start building the response data we
         // cancel any pending timeout alarm according to the configuration.
@@ -232,9 +233,9 @@ void JPEG2000Transmitter::send_data_as_jp2(BESResponseObject *obj, BESDataHandle
         // transform() opens the temporary file, dumps data to it and closes it.
         ft.transform_to_jpeg2000();
 
-        BESDEBUG("JPEG20002", "JPEG2000Transmitter::send_data - transmitting temp file " << temp_file.get_name() << endl );
+        BESDEBUG("JPEG20002", "JPEG2000Transmitter::send_data - transmitting temp file " << temp_file_name << endl );
 
-        JPEG2000Transmitter::return_temp_stream(temp_file.get_name(), strm);
+        JPEG2000Transmitter::return_temp_stream(temp_file_name, strm);
     }
     catch (Error &e) {
 #if 0

--- a/modules/fileout_gdal/JPEG2000Transmitter.cc
+++ b/modules/fileout_gdal/JPEG2000Transmitter.cc
@@ -157,7 +157,7 @@ void JPEG2000Transmitter::send_data_as_jp2(BESResponseObject *obj, BESDataHandle
     BESDEBUG("JPEG20002", "JPEG2000Transmitter::send_data - reading data into DataDDS" << endl);
 
     bes::TempFile temp_file;
-    string temp_file_name = temp_file.create(JPEG2000Transmitter::temp_dir, "jp2000_XXXXXX");
+    string temp_file_name = temp_file.create(JPEG2000Transmitter::temp_dir, "jp2000_");
 #if 0
     // Huh? Put the template for the temp file name in a char array. Use vector<char>
     // to avoid using new/delete.

--- a/modules/fileout_netcdf/FONcTransmitter.cc
+++ b/modules/fileout_netcdf/FONcTransmitter.cc
@@ -130,7 +130,7 @@ void FONcTransmitter::send_dap2_data(BESResponseObject *obj, BESDataHandlerInter
 
         // This object closes the file when it goes out of scope.
         bes::TempFile temp_file;
-        string temp_file_name = temp_file.create(FONcRequestHandler::temp_dir, "/dap2_nc_"+base_name+"_XXXXXX");
+        string temp_file_name = temp_file.create(FONcRequestHandler::temp_dir, "dap2_nc_"+base_name+"_XXXXXX");
 
         BESDEBUG(MODULE,  prolog << "Building response file " << temp_file_name << endl);
 
@@ -242,7 +242,7 @@ void FONcTransmitter::send_dap4_data(BESResponseObject *obj, BESDataHandlerInter
 
         // This object closes the file when it goes out of scope.
         bes::TempFile temp_file;
-        string temp_file_name = temp_file.create(FONcRequestHandler::temp_dir,  "/dap4_nc_"+base_name+"_XXXXXX");
+        string temp_file_name = temp_file.create(FONcRequestHandler::temp_dir,  "dap4_nc_"+base_name+"_XXXXXX");
 
         BESDEBUG(MODULE,  prolog << "Building response file " << temp_file_name << endl);
         // Note that 'RETURN_CMD' is the same as the string that determines the file type:

--- a/modules/fileout_netcdf/FONcTransmitter.cc
+++ b/modules/fileout_netcdf/FONcTransmitter.cc
@@ -129,18 +129,19 @@ void FONcTransmitter::send_dap2_data(BESResponseObject *obj, BESDataHandlerInter
         string base_name = dds->filename().substr(dds->filename().find_last_of("/\\") + 1);
 
         // This object closes the file when it goes out of scope.
-        bes::TempFile temp_file(FONcRequestHandler::temp_dir, "/dap2_nc_"+base_name+"_XXXXXX");
+        bes::TempFile temp_file;
+        string temp_file_name = temp_file.create(FONcRequestHandler::temp_dir, "/dap2_nc_"+base_name+"_XXXXXX");
 
-        BESDEBUG(MODULE,  prolog << "Building response file " << temp_file.get_name() << endl);
+        BESDEBUG(MODULE,  prolog << "Building response file " << temp_file_name << endl);
 
         ostream &strm = dhi.get_output_stream();
         if (!strm) throw BESInternalError("Output stream is not set, can not return as", __FILE__, __LINE__);
 
-        BESDEBUG(MODULE,  prolog << "Transmitting temp file " << temp_file.get_name() << endl);
+        BESDEBUG(MODULE,  prolog << "Transmitting temp file " << temp_file_name << endl);
 
         // Note that 'RETURN_CMD' is the same as the string that determines the file type:
         // netcdf 3 or netcdf 4. Hack. jhrg 9/7/16
-        FONcTransform ft(obj, &dhi, temp_file.get_name(), dhi.data[RETURN_CMD]);
+        FONcTransform ft(obj, &dhi, temp_file_name, dhi.data[RETURN_CMD]);
 
 #if 0
         // This is used to signal the BESUtil::file_to_stream_task() this code is done
@@ -240,13 +241,14 @@ void FONcTransmitter::send_dap4_data(BESResponseObject *obj, BESDataHandlerInter
         string base_name = dmr->filename().substr(dmr->filename().find_last_of("/\\") + 1);
 
         // This object closes the file when it goes out of scope.
-        bes::TempFile temp_file(FONcRequestHandler::temp_dir,  "/dap4_nc_"+base_name+"_XXXXXX");
+        bes::TempFile temp_file;
+        string temp_file_name = temp_file.create(FONcRequestHandler::temp_dir,  "/dap4_nc_"+base_name+"_XXXXXX");
 
-        BESDEBUG(MODULE,  prolog << "Building response file " << temp_file.get_name() << endl);
+        BESDEBUG(MODULE,  prolog << "Building response file " << temp_file_name << endl);
         // Note that 'RETURN_CMD' is the same as the string that determines the file type:
         // netcdf 3 or netcdf 4. Hack. jhrg 9/7/16
         // FONcTransform ft(loaded_dmr, dhi, temp_file.get_name(), dhi.data[RETURN_CMD]);
-        FONcTransform ft(obj, &dhi, temp_file.get_name(), dhi.data[RETURN_CMD]);
+        FONcTransform ft(obj, &dhi, temp_file_name, dhi.data[RETURN_CMD]);
 
         // Call the transform function for DAP4.
         ft.transform_dap4();
@@ -266,10 +268,10 @@ void FONcTransmitter::send_dap4_data(BESResponseObject *obj, BESDataHandlerInter
         RequestServiceTimer::TheTimer()->throw_if_timeout_expired("ERROR: bes-timeout expired before transmit", __FILE__, __LINE__);
         BESUtil::conditional_timeout_cancel();
 
-        BESDEBUG(MODULE,  prolog << "Transmitting temp file " << temp_file.get_name() << endl);
+        BESDEBUG(MODULE,  prolog << "Transmitting temp file " << temp_file_name << endl);
 
         // FONcTransmitter::write_temp_file_to_stream(temp_file.get_fd(), strm); //, loaded_dds->filename(), ncVersion);
-        BESUtil::file_to_stream(temp_file.get_name(),strm);
+        BESUtil::file_to_stream(temp_file_name,strm);
     }
     catch (Error &e) {
         throw BESDapError("Failed to read data: " + e.get_error_message(), false, e.get_error_code(), __FILE__, __LINE__);

--- a/modules/fileout_netcdf/FONcTransmitter.cc
+++ b/modules/fileout_netcdf/FONcTransmitter.cc
@@ -130,7 +130,7 @@ void FONcTransmitter::send_dap2_data(BESResponseObject *obj, BESDataHandlerInter
 
         // This object closes the file when it goes out of scope.
         bes::TempFile temp_file;
-        string temp_file_name = temp_file.create(FONcRequestHandler::temp_dir, "dap2_nc_"+base_name+"_XXXXXX");
+        string temp_file_name = temp_file.create(FONcRequestHandler::temp_dir, "dap2_nc_"+base_name);
 
         BESDEBUG(MODULE,  prolog << "Building response file " << temp_file_name << endl);
 
@@ -242,7 +242,7 @@ void FONcTransmitter::send_dap4_data(BESResponseObject *obj, BESDataHandlerInter
 
         // This object closes the file when it goes out of scope.
         bes::TempFile temp_file;
-        string temp_file_name = temp_file.create(FONcRequestHandler::temp_dir,  "dap4_nc_"+base_name+"_XXXXXX");
+        string temp_file_name = temp_file.create(FONcRequestHandler::temp_dir,  "dap4_nc_"+base_name);
 
         BESDEBUG(MODULE,  prolog << "Building response file " << temp_file_name << endl);
         // Note that 'RETURN_CMD' is the same as the string that determines the file type:


### PR DESCRIPTION
Instead of initializing the static class member variable `TempFile::open_files` in the .cc file like this:
```
std::map<string, int> *TempFile::open_files = new std::map<string, int>;
```
Which always produces complaints from **CLion** about the possibilities of an exception being thrown, I tried moving the actual initialization to a static `TempFile::init()` method which is call from the constructor using `std::call_once()`

I think this might be a pattern we could use in a number of places.

