### PR TITLE
Modified build_dmrpp so that 'deflate' only appears once

### DIFF
--- a/modules/dmrpp_module/build_dmrpp.cc
+++ b/modules/dmrpp_module/build_dmrpp.cc
@@ -130,7 +130,9 @@ void usage() {
        Builds the DMR using the HDF5 handler as configured using the options in the <bes.conf>.
 
     build_dmrpp build_dmrpp -f <data file> -r <dmr file> [-u <href url>]: As above, but uses the DMR
-       read from the given file (so it does not run the HDF5 handler code.
+       read from the given file (so it does not run the HDF5 handler code and does not require the
+       Metadata Store - MDS - be configured). Note that the get_dmrpp command appears to use this
+       option and thus, the configuration options listed in the built DMR++ files lack the MDS setup.
 
     Other options:
         -v: Verbose
@@ -233,7 +235,7 @@ int main(int argc, char *argv[]) {
             // Use the values from the bes.conf file... jhrg 5/21/18
             bes::DmrppMetadataStore *mds = bes::DmrppMetadataStore::get_instance();
             if (!mds) {
-                cerr << "The Metadata Store (MDS) must be configured for this command to work." << endl;
+                cerr << "The Metadata Store (MDS) must be configured for this command to work (but see the -r option)." << endl;
                 return EXIT_FAILURE;
             }
 

--- a/modules/dmrpp_module/build_dmrpp_util.cc
+++ b/modules/dmrpp_module/build_dmrpp_util.cc
@@ -159,7 +159,13 @@ static void set_filter_information(hid_t dataset_id, DmrppCommon *dc) {
             VERBOSE(cerr << "Found H5 Filter Type: " << h5_filter_name(filter_type) << " (" << filter_type << ")" << endl);
             switch (filter_type) {
                 case H5Z_FILTER_DEFLATE:
-                    filters.append("deflate ");
+                    // For HYRAX-733. Sometimes deflate shows up twice in the filters for a variable.
+                    // The DMR++ ignores the second time deflate is listed, but other users of the DMR++
+                    // might not be savvy and try to decompress the chunk/buffer/variable two times,
+                    // which will fail.
+                    // Here, we only add 'deflate' if it is not already in the filters info. jhrg 5/24/22
+                    if (filters.find("deflate") == string::npos)
+                        filters.append("deflate ");
                     break;
                 case H5Z_FILTER_SHUFFLE:
                     filters.append("shuffle ");


### PR DESCRIPTION
In some cases (we have a sample GHRSST VIIRS granule) the 'deflate'
filter is listed twice even though it seems clear that it should be
applied only once. I added a test that adds that filter only once,
but did not extend that 'courtesy' to the other filbters.