### PR TITLE
Use int32 type for temp_num_dim_attrs

### DIFF
--- a/modules/hdf4_handler/HDFSP.cc
+++ b/modules/hdf4_handler/HDFSP.cc
@@ -1703,7 +1703,7 @@ throw (Exception)
             }	
 
             // Obtain dimension info.: dim_name, dim_size,dim_type and num of dim. attrs.
-            int temp_num_dim_attrs = 0;
+            int32 temp_num_dim_attrs = 0;
             status =  SDdiminfo (dimid, dim_name, &dim_size, &dim_type, &temp_num_dim_attrs);
             if (status == FAIL) {
                delete sd;


### PR DESCRIPTION
The build of the Fedora package of 3.20.13 fails on i686 with:
```
HDFSP.cc: In static member function 'static HDFSP::SD* HDFSP::SD::Read(int32, int32)':
HDFSP.cc:1707:73: error: invalid conversion from 'int*' to 'int32*' {aka 'long int*'} [-fpermissive]
 1707 |             status =  SDdiminfo (dimid, dim_name, &dim_size, &dim_type, &temp_num_dim_attrs);
      |                                                                         ^~~~~~~~~~~~~~~~~~~
      |                                                                         |
      |                                                                         int*
In file included from HDFCFUtil.h:24:
/usr/include/hdf/mfhdf.h:165:59: note:   initializing argument 5 of 'intn SDdiminfo(int32, char*, int32*, int32*, int32*)'
  165 |     (int32 id, char *name, int32 *size, int32 *nt, int32 *nattr);
      |                                                    ~~~~~~~^~~~~
```
This fixes that.