### PR TITLE
Fonc string arrays

### DIFF
--- a/modules/fileout_netcdf/FONcArray.cc
+++ b/modules/fileout_netcdf/FONcArray.cc
@@ -55,6 +55,7 @@ using namespace libdap;
 // This controls whether variables' data values are deleted as soon
 // as they are written (except for DAP2 Grid Maps, which may be shared).
 #define CLEAR_LOCAL_DATA 1
+#define STRING_ARRAY_OPT 1
 
 vector<FONcDim *> FONcArray::Dimensions;
 
@@ -629,8 +630,11 @@ void FONcArray::write(int ncid) {
         // Can we optimize for a special case where all strings are the same length?
         // jhrg 10/3/22
         if (equal_length(d_a->get_str())) {
+#if STRING_ARRAY_OPT
             write_equal_length_string_array(ncid);
-            //write_string_array(ncid);
+#else
+            write_string_array(ncid);
+#endif
         }
         else {
             write_string_array(ncid);
@@ -742,6 +746,10 @@ void FONcArray::write_for_nc3_types(int ncid) {
     }
 }
 
+/**
+ * @note This may not work for 'ragged arrays' of strings.
+ * @param ncid
+ */
 void FONcArray::write_string_array(int ncid) {
     vector<size_t> var_count(d_ndims);
     vector<size_t> var_start(d_ndims);

--- a/modules/fileout_netcdf/FONcArray.cc
+++ b/modules/fileout_netcdf/FONcArray.cc
@@ -602,12 +602,21 @@ void FONcArray::write(int ncid) {
         // that code needs to know that actual length of the individual strings in the
         // array. jhrg 6/4/21
 
+        // More info: In FONcArray::convert() for arrays of NC_CHAR, even though the
+        // libdap::Array variable has M dimension (e.g., 2) d_ndims will be M+1. The
+        // additional dimension is there because each character is actually a string,
+        // so the code needs to store both the character and a null terminator. This
+        // might be a mistake in the data model - using String for CHAR might not be
+        // the best plan. Right now, it's what we have. jhrg 10/3/22
+
         vector<size_t> var_count(d_ndims);
         vector<size_t> var_start(d_ndims);
         int dim = 0;
         for (dim = 0; dim < d_ndims; dim++) {
             // the count for each of the dimensions will always be 1 except
-            // for the string length dimension
+            // for the string length dimension.
+            // The size of the last dimension (var_count[d_ndims-1]) is set
+            // separately for each element below. jhrg 10/3/22
             var_count[dim] = 1;
 
             // the start for each of the dimensions will start at 0. We will

--- a/modules/fileout_netcdf/FONcArray.cc
+++ b/modules/fileout_netcdf/FONcArray.cc
@@ -574,6 +574,22 @@ void FONcArray::write_nc_variable(int ncid, nc_type var_type) {
 #endif
 }
 
+/**
+ * @brief Are all of the strngs the same length?
+ * @param the_array_strings
+ * @return True if the strings are the same length
+ */
+static bool optimize_array(vector<string> &the_array_strings)
+{
+    size_t string_length = the_array_strings[0].size();
+    // use if ( std::all_of(foo.begin(), foo.end(), [](int i){return i%2;}) )
+    for(auto const &s: the_array_strings) {
+        if (s.size() != string_length)
+            return false;
+    }
+    return true;
+}
+
 /** @brief Write the array out to the netcdf file
  *
  * Once the array is defined, the values of the array can be written out
@@ -609,6 +625,10 @@ void FONcArray::write(int ncid) {
         // might be a mistake in the data model - using String for CHAR might not be
         // the best plan. Right now, it's what we have. jhrg 10/3/22
 
+        // Can we optimize for a special case where all strings are the same length?
+        // jhrg 10/3/22
+
+        return true;
         vector<size_t> var_count(d_ndims);
         vector<size_t> var_start(d_ndims);
         int dim = 0;

--- a/modules/fileout_netcdf/FONcArray.cc
+++ b/modules/fileout_netcdf/FONcArray.cc
@@ -806,7 +806,7 @@ void FONcArray::write_equal_length_string_array(int ncid) {
     auto const &d_a_str = d_a->get_str();
 
     vector<char> text_data;
-    text_data.reserve(d_a_str.size() * d_a_str[0].size() * 2);
+    text_data.reserve(d_a_str.size() * (d_a_str[0].size() + 1));
     for (auto &str: d_a_str) {
         for (auto c: str)
             text_data.emplace_back(c);
@@ -817,7 +817,7 @@ void FONcArray::write_equal_length_string_array(int ncid) {
         var_start[dim] = 0;
     }
     for (int dim = 0; dim < d_ndims; dim++) {
-        var_start[dim] = 0;
+        var_count[dim] = d_dim_sizes[dim];
     }
     var_count[d_ndims - 1] = d_a_str[0].size() + 1;
 

--- a/modules/fileout_netcdf/FONcArray.cc
+++ b/modules/fileout_netcdf/FONcArray.cc
@@ -575,22 +575,22 @@ void FONcArray::write_nc_variable(int ncid, nc_type var_type) {
 }
 
 /**
- * @brief Are all of the strngs the same length?
+ * @brief Are all of the strings the same length?
  * @param the_array_strings
  * @return True if the strings are the same length
  */
-static bool optimize_array(vector<string> &the_array_strings)
+bool FONcArray::equal_length(vector<string> &the_strings)
 {
-    size_t string_length = the_array_strings[0].size();
-    // use if ( std::all_of(foo.begin(), foo.end(), [](int i){return i%2;}) )
-    for(auto const &s: the_array_strings) {
-        if (s.size() != string_length)
-            return false;
-    }
-    return true;
+    size_t length = the_strings[0].size();
+    if ( std::all_of(the_strings.begin()+1, the_strings.end(),
+                     [length](string &s){return s.size() == length;}) )
+        return true;
+    else
+        return false;
 }
 
-/** @brief Write the array out to the netcdf file
+/**
+ * @brief Write the array out to the netcdf file
  *
  * Once the array is defined, the values of the array can be written out
  * as well.
@@ -613,6 +613,7 @@ void FONcArray::write(int ncid) {
     // classic and enhanced data models;
     // 2. All the other types, written for the enhanced data model
     // 3. All the other types, written for the classic data model
+
     if (d_array_type == NC_CHAR) {
         // Note that String data are not read here but in FONcArray::convert() because
         // that code needs to know that actual length of the individual strings in the
@@ -627,158 +628,209 @@ void FONcArray::write(int ncid) {
 
         // Can we optimize for a special case where all strings are the same length?
         // jhrg 10/3/22
-
-        return true;
-        vector<size_t> var_count(d_ndims);
-        vector<size_t> var_start(d_ndims);
-        int dim = 0;
-        for (dim = 0; dim < d_ndims; dim++) {
-            // the count for each of the dimensions will always be 1 except
-            // for the string length dimension.
-            // The size of the last dimension (var_count[d_ndims-1]) is set
-            // separately for each element below. jhrg 10/3/22
-            var_count[dim] = 1;
-
-            // the start for each of the dimensions will start at 0. We will
-            // bump this up in the while loop below
-            var_start[dim] = 0;
+        if (equal_length(d_a->get_str())) {
+            write_equal_length_string_array(ncid);
+            //write_string_array(ncid);
         }
-
-        auto const &d_a_str = d_a->get_str();
-        for (int element = 0; element < d_nelements; element++) {
-            var_count[d_ndims - 1] = d_a_str[element].size() + 1;
-            var_start[d_ndims - 1] = 0;
-
-            // write out the string
-            int stax = nc_put_vara_text(ncid, d_varid, var_start.data(), var_count.data(), d_a_str[element].c_str());
-
-            if (stax != NC_NOERR) {
-                string err = (string) "fileout.netcdf - Failed to create array of strings for " + d_varname;
-                FONcUtils::handle_error(stax, err, __FILE__, __LINE__);
-            }
-
-            // bump up the start.
-            if (element + 1 < d_nelements) {
-                bool done = false;
-                dim = d_ndims - 2;
-                while (!done) {
-                    var_start[dim] = var_start[dim] + 1;
-                    if (var_start[dim] == d_dim_sizes[dim]) {
-                        var_start[dim] = 0;
-                        dim--;
-                    }
-                    else {
-                        done = true;
-                    }
-                }
-            }
+        else {
+            write_string_array(ncid);
         }
-
-        // TODO write data here
-
-        d_a->get_str().clear();
     }
-    // If we support the netCDF-4 enhanced model, the unsigned integer
-    // can be directly mapped to the netcdf-4 unsigned integer.
     else if (isNetCDF4_ENHANCED()) {
+        // If we support the netCDF-4 enhanced model, the unsigned integer
+        // can be directly mapped to the netcdf-4 unsigned integer.
         write_for_nc4_types(ncid);
     }
     else {
-        libdap::Type element_type = d_a->var()->type();
-        // create array to hold data hyperslab
-        switch (d_array_type) {
-            case NC_BYTE:
-            case NC_FLOAT:
-            case NC_DOUBLE:
-                write_nc_variable(ncid, d_array_type);
-                break;
-
-            case NC_SHORT:
-                // Given Byte/UInt8 will always be unsigned they must map
-                // to a NetCDF type that will support unsigned bytes.  This
-                // detects the original variable was of type Byte and typecasts
-                // each data value to a short.
-                if (element_type == libdap::dods_byte_c || element_type == libdap::dods_uint8_c) {
-                    if (d_is_dap4)
-                        d_a->intern_data();
-                    else
-                        d_a->intern_data(*get_eval(), *get_dds());
-
-                    // There's no practical way to get rid of the value copy, be here we
-                    // read directly from libdap::Array object's memory.
-                    vector<short> data(d_nelements);
-                    for (int d_i = 0; d_i < d_nelements; d_i++)
-                        data[d_i] = *(reinterpret_cast<unsigned char *>(d_a->get_buf()) + d_i);
-
-                    int stax = nc_put_var_short(ncid, d_varid, data.data());
-                    if (stax != NC_NOERR) {
-                        string err = (string) "fileout.netcdf - Failed to create array of shorts for " + d_varname;
-                        FONcUtils::handle_error(stax, err, __FILE__, __LINE__);
-                    }
-
-                    // Once we've written an array, reclaim its space _unless_ it is a Grid map.
-                    // It might be shared and other code here expects it to be resident in memory.
-                    // jhrg 6/4/21
-                    if (!FONcGrid::InMaps(d_a))
-                        d_a->clear_local_data();
-                }
-                else {
-                    write_nc_variable(ncid, NC_SHORT);
-                }
-                break;
-
-            case NC_INT:
-                // Added as a stop-gap measure to alert SAs and inform users of a misconfigured server.
-                // jhrg 6/15/20
-                if (element_type == libdap::dods_int64_c || element_type == libdap::dods_uint64_c) {
-                    // We should not be here. The server configuration is wrong since the netcdf classic
-                    // model is being used (either a netCDf3 response is requested OR a netCDF4 with the
-                    // classic model). Tell the user and the SA.
-                    string msg;
-                    if (FONcRequestHandler::classic_model == false) {
-                        msg = "You asked for one or more 64-bit integer values returned using a netCDF3 file. "
-                              "Try asking for netCDF4 enhanced and/or contact the server administrator.";
-                    }
-                    else {
-                        msg = "You asked for one or more 64-bit integer values, but either returned using a netCDF3 file or "
-                              "from a server that is configured to use the 'classic' netCDF data model with netCDF4. "
-                              "Try netCDF4 and/or contact the server administrator.";
-                    }
-                    throw BESInternalError(msg, __FILE__, __LINE__);
-                }
-
-                if (element_type == libdap::dods_uint16_c) {
-                    if (d_is_dap4)
-                        d_a->intern_data();
-                    else
-                        d_a->intern_data(*get_eval(), *get_dds());
-
-                    vector<int> data(d_nelements);
-                    for (int d_i = 0; d_i < d_nelements; d_i++)
-                        data[d_i] = *(reinterpret_cast<unsigned short *>(d_a->get_buf()) + d_i);
-
-                    int stax = nc_put_var_int(ncid, d_varid, data.data());
-                    if (stax != NC_NOERR) {
-                        string err = (string) "fileout.netcdf - Failed to create array of ints for " + d_varname;
-                        FONcUtils::handle_error(stax, err, __FILE__, __LINE__);
-                    }
-
-                    if (!FONcGrid::InMaps(d_a))
-                        d_a->clear_local_data();
-                }
-                else {
-                    write_nc_variable(ncid, NC_INT);
-                }
-                break;
-
-            default:
-                throw BESInternalError("Failed to transform array of unknown type in file out netcdf (2)",
-                                       __FILE__, __LINE__);
-        } // switch(d_array_type)
+        write_for_nc3_types(ncid);
     }
 
     BESDEBUG("fonc", "FONcArray::write() END  var: " << d_varname << "[" << d_nelements << "]" << endl);
 }
+
+void FONcArray::write_for_nc3_types(int ncid) {
+    Type element_type = d_a->var()->type();
+    // create array to hold data hyperslab
+    switch (d_array_type) {
+        case NC_BYTE:
+        case NC_FLOAT:
+        case NC_DOUBLE:
+            write_nc_variable(ncid, d_array_type);
+            break;
+
+        case NC_SHORT:
+            // Given Byte/UInt8 will always be unsigned they must map
+            // to a NetCDF type that will support unsigned bytes.  This
+            // detects the original variable was of type Byte and typecasts
+            // each data value to a short.
+            if (element_type == dods_byte_c || element_type == dods_uint8_c) {
+                if (d_is_dap4)
+                    d_a->intern_data();
+                else
+                    d_a->intern_data(*get_eval(), *get_dds());
+
+                // There's no practical way to get rid of the value copy, be here we
+                // read directly from libdap::Array object's memory.
+                vector<short> data(d_nelements);
+                for (int d_i = 0; d_i < d_nelements; d_i++)
+                    data[d_i] = *(reinterpret_cast<unsigned char *>(d_a->get_buf()) + d_i);
+
+                int stax = nc_put_var_short(ncid, d_varid, data.data());
+                if (stax != NC_NOERR) {
+                    string err = (string) "fileout.netcdf - Failed to create array of shorts for " + d_varname;
+                    FONcUtils::handle_error(stax, err, __FILE__, __LINE__);
+                }
+
+                // Once we've written an array, reclaim its space _unless_ it is a Grid map.
+                // It might be shared and other code here expects it to be resident in memory.
+                // jhrg 6/4/21
+                if (!FONcGrid::InMaps(d_a))
+                    d_a->clear_local_data();
+            }
+            else {
+                write_nc_variable(ncid, NC_SHORT);
+            }
+            break;
+
+        case NC_INT:
+            // Added as a stop-gap measure to alert SAs and inform users of a misconfigured server.
+            // jhrg 6/15/20
+            if (element_type == dods_int64_c || element_type == dods_uint64_c) {
+                // We should not be here. The server configuration is wrong since the netcdf classic
+                // model is being used (either a netCDf3 response is requested OR a netCDF4 with the
+                // classic model). Tell the user and the SA.
+                string msg;
+                if (FONcRequestHandler::classic_model == false) {
+                    msg = "You asked for one or more 64-bit integer values returned using a netCDF3 file. "
+                          "Try asking for netCDF4 enhanced and/or contact the server administrator.";
+                }
+                else {
+                    msg = "You asked for one or more 64-bit integer values, but either returned using a netCDF3 file or "
+                          "from a server that is configured to use the 'classic' netCDF data model with netCDF4. "
+                          "Try netCDF4 and/or contact the server administrator.";
+                }
+                throw BESInternalError(msg, __FILE__, __LINE__);
+            }
+
+            if (element_type == dods_uint16_c) {
+                if (d_is_dap4)
+                    d_a->intern_data();
+                else
+                    d_a->intern_data(*get_eval(), *get_dds());
+
+                vector<int> data(d_nelements);
+                for (int d_i = 0; d_i < d_nelements; d_i++)
+                    data[d_i] = *(reinterpret_cast<unsigned short *>(d_a->get_buf()) + d_i);
+
+                int stax = nc_put_var_int(ncid, d_varid, data.data());
+                if (stax != NC_NOERR) {
+                    string err = (string) "fileout.netcdf - Failed to create array of ints for " + d_varname;
+                    FONcUtils::handle_error(stax, err, __FILE__, __LINE__);
+                }
+
+                if (!FONcGrid::InMaps(d_a))
+                    d_a->clear_local_data();
+            }
+            else {
+                write_nc_variable(ncid, NC_INT);
+            }
+            break;
+
+        default:
+            throw BESInternalError("Failed to transform array of unknown type in file out netcdf (2)",
+                                   __FILE__, __LINE__);
+    }
+}
+
+void FONcArray::write_string_array(int ncid) {
+    vector<size_t> var_count(d_ndims);
+    vector<size_t> var_start(d_ndims);
+    int dim = 0;
+    for (dim = 0; dim < d_ndims; dim++) {
+        // the count for each of the dimensions will always be 1 except
+        // for the string length dimension.
+        // The size of the last dimension (var_count[d_ndims-1]) is set
+        // separately for each element below. jhrg 10/3/22
+        var_count[dim] = 1;
+
+        // the start for each of the dimensions will start at 0. We will
+        // bump this up in the while loop below
+        var_start[dim] = 0;
+    }
+
+    auto const &d_a_str = d_a->get_str();
+    for (int element = 0; element < d_nelements; element++) {
+        var_count[d_ndims - 1] = d_a_str[element].size() + 1;
+        var_start[d_ndims - 1] = 0;
+
+        // write out the string
+        int stax = nc_put_vara_text(ncid, d_varid, var_start.data(), var_count.data(),
+                                    d_a_str[element].c_str());
+
+        if (stax != NC_NOERR) {
+            string err = (string) "fileout.netcdf - Failed to create array of strings for " + d_varname;
+            FONcUtils::handle_error(stax, err, __FILE__, __LINE__);
+        }
+
+        // bump up the start.
+        if (element + 1 < d_nelements) {
+            bool done = false;
+            dim = d_ndims - 2;
+            while (!done) {
+                var_start[dim] = var_start[dim] + 1;
+                if (var_start[dim] == d_dim_sizes[dim]) {
+                    var_start[dim] = 0;
+                    dim--;
+                }
+                else {
+                    done = true;
+                }
+            }
+        }
+    }
+
+    d_a->get_str().clear();
+}
+
+/**
+ * @brief Take an n-dim array of string and treat it as a n+1 dim array of string
+ * Each string of the n+1 dim array is a single character. The strings
+ * are C-style strings (null-terminated). The field d_ndims is already
+ * set to n+1 when the server runs this method.
+ * @param ncid
+ */
+void FONcArray::write_equal_length_string_array(int ncid) {
+    vector<size_t> var_count(d_ndims);
+    vector<size_t> var_start(d_ndims);
+    // The flattened n-dim array as a vector of strings, row major order
+    auto const &d_a_str = d_a->get_str();
+
+    vector<char> text_data;
+    text_data.reserve(d_a_str.size() * d_a_str[0].size() * 2);
+    for (auto &str: d_a_str) {
+        for (auto c: str)
+            text_data.emplace_back(c);
+        text_data.emplace_back('\0');
+    }
+
+    for (int dim = 0; dim < d_ndims; dim++) {
+        var_start[dim] = 0;
+    }
+    for (int dim = 0; dim < d_ndims; dim++) {
+        var_start[dim] = 0;
+    }
+    var_count[d_ndims - 1] = d_a_str[0].size() + 1;
+
+    int stax = nc_put_vara_text(ncid, d_varid, var_start.data(), var_count.data(), text_data.data());
+
+    if (stax != NC_NOERR) {
+        string err = (string) "fileout.netcdf - Failed to create array of strings for " + d_varname;
+        FONcUtils::handle_error(stax, err, __FILE__, __LINE__);
+    }
+
+    d_a->get_str().clear();
+}
+
 
 /** @brief returns the name of the DAP Array
  *

--- a/modules/fileout_netcdf/FONcArray.h
+++ b/modules/fileout_netcdf/FONcArray.h
@@ -102,10 +102,16 @@ private:
 
     FONcDim * find_dim(const std::vector<std::string> &embed, const std::string &name, int size, bool ignore_size = false);
 
-    void write_for_nc4_types(int ncid);
-
     // Used in write()
+    void write_for_nc4_types(int ncid);
+    void write_for_nc3_types(int ncid);
     void write_nc_variable(int ncid, nc_type var_type);
+    static bool equal_length(vector<string> &the_strings);
+    void write_string_array(int ncid);
+    void write_equal_length_string_array(int ncid);
+
+    FONcArray() = default;      // Used in some unit tests
+    friend class FONcArrayTest;
 
 public:
     explicit FONcArray(libdap::BaseType *b);
@@ -119,10 +125,7 @@ public:
 
     std::string name() override;
 
-    virtual libdap::Array *array()
-    {
-        return d_a;
-    }
+    virtual libdap::Array *array() { return d_a; }
 
     virtual void dump(std::ostream &strm) const override;
     // The below line is not necessary. Still keep it here for the future use.

--- a/modules/fileout_netcdf/FONcBaseType.h
+++ b/modules/fileout_netcdf/FONcBaseType.h
@@ -74,9 +74,8 @@ protected:
     libdap::DDS *d_dds = nullptr;
     libdap::ConstraintEvaluator *d_eval = nullptr;
 
-    FONcBaseType() = default;
-
 public:
+    FONcBaseType() = default;
     ~FONcBaseType() override = default;
 
     libdap::DDS *get_dds() const {return d_dds;}
@@ -85,11 +84,22 @@ public:
     libdap::ConstraintEvaluator *get_eval() const {return d_eval;}
     void set_eval(libdap::ConstraintEvaluator *eval) {d_eval = eval;}
 
-    virtual void convert(std::vector<std::string> embed, bool is_dap4= false, bool is_dap4_group=false);
+    // I made this change to see how hard it would be to refactor a virtual
+    // method that used parameters with default (prohibited) values. jhrg 10/3/22
+    void convert(std::vector<std::string> embed) {
+        convert(embed, false, false);
+    }
+    void convert(std::vector<std::string> embed, bool is_dap4) {
+        convert(embed, is_dap4, false);
+    }
+    virtual void convert(std::vector<std::string> embed, bool is_dap4, bool is_dap4_group);
+
     virtual void define(int ncid);
+
     virtual void write(int ncid) = 0;
 
     virtual std::string name() = 0;
+
     virtual nc_type type();
     virtual void clear_embedded();
     virtual int varid() const { return d_varid; }

--- a/modules/fileout_netcdf/unit-tests/FONcArrayTest.cc
+++ b/modules/fileout_netcdf/unit-tests/FONcArrayTest.cc
@@ -1,0 +1,125 @@
+// -*- mode: c++; c-basic-offset:4 -*-
+
+// This file is part of libdap, A C++ implementation of the OPeNDAP Data
+// Access Protocol.
+
+// Copyright (c) 2013 OPeNDAP, Inc.
+// Author: Nathan David Potter <ndp@opendap.org>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+// You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+
+#include <vector>
+#include <string>
+
+#include "run_tests_cppunit.h"
+#include "test_config.h"
+
+#include "FONcArray.h"
+
+using namespace std;
+
+class FONcArrayTest: public CppUnit::TestFixture {
+    FONcArray fa;
+
+public:
+    // Called once before everything gets tested
+    FONcArrayTest() = default;
+
+    // Called at the end of the test
+    ~FONcArrayTest() = default;
+
+    // These tests don't define specializations of void setUp() OR void tearDown().
+    // jhrg 2/25/22
+
+    void test_equal_length_1() {
+        vector<string> stuff;
+        stuff.reserve(100);
+        for (int i = 0; i < 100; ++i) {
+            stuff.emplace_back("test_data");
+        }
+
+        CPPUNIT_ASSERT_MESSAGE("All the string are the same length", fa.equal_length(stuff));
+    }
+
+    void test_equal_length_2() {
+        vector<string> stuff;
+        stuff.reserve(100);
+        for (int i = 0; i < 100; ++i) {
+            stuff.emplace_back("test_data");
+        }
+
+        stuff.at(49) = "longer_test_data";
+
+        CPPUNIT_ASSERT_MESSAGE("All the string are not the same length", !fa.equal_length(stuff));
+    }
+
+    void test_equal_length_3() {
+        vector<string> stuff;
+        stuff.reserve(100);
+        for (int i = 0; i < 100; ++i) {
+            stuff.emplace_back("test_data");
+        }
+
+        stuff.at(0) = "longer_test_data";
+
+        CPPUNIT_ASSERT_MESSAGE("All the string are not the same length", !fa.equal_length(stuff));
+    }
+
+    void test_equal_length_4() {
+        vector<string> stuff;
+        stuff.reserve(100);
+        for (int i = 0; i < 100; ++i) {
+            stuff.emplace_back("test_data");
+        }
+
+        stuff.at(99) = "longer_test_data";
+
+        CPPUNIT_ASSERT_MESSAGE("All the string are not the same length", !fa.equal_length(stuff));
+    }
+
+    void test_equal_length_for_profiler() {
+        vector<string> stuff;
+        stuff.reserve(100000000);
+        for (int i = 0; i < 100; ++i) {
+            stuff.emplace_back("test_data");
+        }
+
+        sleep(1);
+
+        CPPUNIT_ASSERT_MESSAGE("All the string are the same length", fa.equal_length(stuff));
+    }
+
+    CPPUNIT_TEST_SUITE( FONcArrayTest );
+
+    CPPUNIT_TEST(test_equal_length_1);
+    CPPUNIT_TEST(test_equal_length_2);
+    CPPUNIT_TEST(test_equal_length_3);
+    CPPUNIT_TEST(test_equal_length_4);
+
+    // equal_length is so fast the profiler does not sample its call. jhrg 10/4/22
+    // CPPUNIT_TEST(test_equal_length_for_profiler);
+
+    CPPUNIT_TEST_SUITE_END();
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(FONcArrayTest);
+
+int main(int argc, char *argv[])
+{
+    return bes_run_tests<FONcArrayTest>(argc, argv, "cerr,fonc") ? 0: 1;
+}
+

--- a/modules/fileout_netcdf/unit-tests/Makefile.am
+++ b/modules/fileout_netcdf/unit-tests/Makefile.am
@@ -53,7 +53,7 @@ tmp:
 #
 
 if CPPUNIT
-UNIT_TESTS = HistoryUtilsTest
+UNIT_TESTS = HistoryUtilsTest FONcArrayTest
 else
 UNIT_TESTS =
 
@@ -71,3 +71,6 @@ LDFLAGS = -static
 
 HistoryUtilsTest_SOURCES = HistoryUtilsTest.cc
 HistoryUtilsTest_LDADD = $(OBJS) $(LIBADD)
+
+FONcArrayTest_SOURCES = FONcArrayTest.cc
+FONcArrayTest_LDADD = $(LIBADD) ../.libs/libfonc_module.a

--- a/modules/fileout_netcdf/unit-tests/Makefile.am
+++ b/modules/fileout_netcdf/unit-tests/Makefile.am
@@ -73,4 +73,4 @@ HistoryUtilsTest_SOURCES = HistoryUtilsTest.cc
 HistoryUtilsTest_LDADD = $(OBJS) $(LIBADD)
 
 FONcArrayTest_SOURCES = FONcArrayTest.cc
-FONcArrayTest_LDADD = $(LIBADD) ../.libs/libfonc_module.a
+FONcArrayTest_LDADD = ../.libs/libfonc_module.a $(LIBADD)


### PR DESCRIPTION
This branch contains an optimization for the fileout_netcdf handler when it is working with an array of strings. For a test dataset with a large string array, processing time dropped significantly and the time spent in FONcArray::wrote() dropped from 70% to 7.6%. The optimization build the data in memory and make a single call to nc_put_vara_text() instead of one call for each string.