### PR TITLE
HYRAX-927, fix the issue that causes the wrong attribute values in 1A…

### DIFF
--- a/modules/hdf5_handler/h5gmcfdap.cc
+++ b/modules/hdf5_handler/h5gmcfdap.cc
@@ -809,7 +809,7 @@ void gen_gmh5_cfdmr(D4Group* d4_root,const HDF5CF::GMFile *f) {
                             // the support of multi-unlimited dimension. KY 2016-02-09
                             if(dim->HaveUnlimitedDim() == true) {
                                 
-                                string unlimited_dim_name = cvar->getNewName();
+                                string unlimited_dim_name = dim->getNewName();
                                 if(unlimited_dim_names=="") 
                                    unlimited_dim_names = unlimited_dim_name;
                                 else {


### PR DESCRIPTION
… and 2A GPM files

Just one line of code introduced in another ticket. Tested both hdf5 handler and fileout-netCDF for all NASA testsuites.