### PR TITLE
 HYRAX-974-1, the map variables can contain >1 dimension scales. So r…

### DIFF
--- a/modules/hdf5_handler/h5dmr.cc
+++ b/modules/hdf5_handler/h5dmr.cc
@@ -2109,11 +2109,16 @@ void add_dap4_coverage_default(D4Group* d4_root, const vector<string>& handled_a
     // First dimension scales.
     for (auto &ds_map:dsname_array_maps) {
         D4Maps *d4_maps = (ds_map.second)->maps();
+#if 0
         if (d4_maps->size() !=1) 
             throw InternalErr(__FILE__, __LINE__, "The number of dims of a dimension scale should be 1");
-        D4Map * d4_map = d4_maps->get_map(0);
-        d4_maps->remove_map(d4_map);
-        delete d4_map;
+#endif
+
+        for (unsigned i =0; i<d4_maps->size();i++) {
+            D4Map * d4_map = d4_maps->get_map(i);
+            d4_maps->remove_map(d4_map);
+            delete d4_map;
+        }
     }
 
     // Then coordinates


### PR DESCRIPTION
…emove the wrong sanity check.

Note: another pull request will be created to fix the map variable orders. This ticket will remove the fake error message.