### PR TITLE
I modified the get_dmrpp CLI tests to include two tests for -r

### DIFF
--- a/modules/dmrpp_module/tests_build_dmrpp/.gitignore
+++ b/modules/dmrpp_module/tests_build_dmrpp/.gitignore
@@ -1,0 +1,6 @@
+a.out
+chunked_oneD.h5
+grid_1_2d.h5
+grid_2_2d.h5
+grid_2_2d.h5.missing
+mds_ledger.txt

--- a/modules/dmrpp_module/tests_build_dmrpp/Makefile.am
+++ b/modules/dmrpp_module/tests_build_dmrpp/Makefile.am
@@ -10,9 +10,9 @@ CLEANFILES =
 EXTRA_DIST = get_dmrpp_baselines $(srcdir)/package.m4 $(TESTSUITE_DMRPP) $(TESTSUITE_DMRPP).at \
 atlocal.in build_dmrpp_macros.m4 test_bes.conf.in
 
-DISTCLEANFILES = atconfig test_bes.conf a.out chunked_oneD.h5 grid_1_2d.h5 grid_1_2d.h5.missing
+DISTCLEANFILES = atconfig test_bes.conf a.out chunked_oneD.h5 grid_1_2d.h5 grid_2_2d.h5 grid_1_2d.h5.missing
 
-noinst_DATA = $(abs_builddir)/grid_1_2d.h5
+noinst_DATA = $(abs_builddir)/grid_1_2d.h5 $(abs_builddir)/grid_2_2d.h5
 
 ############## Autotest follows #####################
 
@@ -51,13 +51,15 @@ $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 		-e "s%[@]abs_top_builddir[@]%${abs_top_builddir}%" \
 		-e "s%[@]modulesdir[@]%${modulesdir}%" $< > $@
 
-$(abs_builddir)/grid_1_2d.h5:
+$(abs_builddir)/grid_1_2d.h5 $(abs_builddir)/grid_2_2d.h5:
 	@echo "# abs_top_srcdir: $(abs_top_srcdir)"
 	@echo "# top_srcdir: $(top_srcdir)"
 	@echo "# srcdir: $(srcdir)"
 	@echo "# abs_top_builddir: $(abs_top_builddir)"
 	@echo "# abs_builddir: $(abs_builddir)"
 	@echo "# builddir: $(builddir)"
-	@echo "# Coping grid_1_2d.h5 from: '$(top_srcdir)/modules/dmrpp_module/data/dmrpp/grid_1_2d.h5' to '$(abs_builddir)/grid_1_2d.h5'"
+	@echo "# Coping grid_1_2d.h5 from: '$(top_srcdir)/modules/dmrpp_module/data/dmrpp/grid_1_2d.h5' to '$(abs_builddir)/'"
+	@echo "# Duplicating grid_1_2d.h5 to grid_2_2d.h5"
 	cp $(top_srcdir)/modules/dmrpp_module/data/dmrpp/grid_1_2d.h5 $(abs_builddir)/grid_1_2d.h5
-	chmod -R ug+rw $(abs_builddir)/grid_1_2d.h5
+	cp $(abs_builddir)/grid_1_2d.h5 $(abs_builddir)/grid_2_2d.h5
+	chmod -R ug+rw $(abs_builddir)/grid_1_2d.h5 $(abs_builddir)/grid_2_2d.h5

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/md_reduce.baseline.missing
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/md_reduce.baseline.missing
@@ -1,0 +1,15 @@
+netcdf grid_1_2d.h5 {
+dimensions:
+	lon = 8 ;
+	lat = 4 ;
+variables:
+	float lon(lon) ;
+		lon:units = "degrees_east" ;
+	float lat(lat) ;
+		lat:units = "degrees_north" ;
+data:
+
+ lon = 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5 ;
+
+ lat = 3.5, 2.5, 1.5, 0.5 ;
+}

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/md_reduce_url_1_dmrpp.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/md_reduce_url_1_dmrpp.baseline
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="grid_1_2d.h5" dmrpp:href="OPeNDAP_DMRpp_DATA_ACCESS_URL" removed dmrpp:version>
+    <Dimension name="lon" size="8"/>
+    <Dimension name="lat" size="4"/>
+    <Float32 name="lon">
+        <Dim name="/lon"/>
+        <Attribute name="units" type="String">
+            <Value>degrees_east</Value>
+        </Attribute>
+        <dmrpp:chunks compressionType="deflate" fillValue="0" byteOrder="LE">
+            <dmrpp:chunkDimensionSizes>8</dmrpp:chunkDimensionSizes>
+            <dmrpp:chunk offset="3087" nBytes="33" chunkPositionInArray="[0]" href="OPeNDAP_DMRpp_MISSING_DATA_ACCESS_URL" />
+        </dmrpp:chunks>
+    </Float32>
+    <Float32 name="lat">
+        <Dim name="/lat"/>
+        <Attribute name="units" type="String">
+            <Value>degrees_north</Value>
+        </Attribute>
+        <dmrpp:chunks compressionType="deflate" fillValue="0" byteOrder="LE">
+            <dmrpp:chunkDimensionSizes>4</dmrpp:chunkDimensionSizes>
+            <dmrpp:chunk offset="5216" nBytes="22" chunkPositionInArray="[0]" href="OPeNDAP_DMRpp_MISSING_DATA_ACCESS_URL" />
+        </dmrpp:chunks>
+    </Float32>
+    <Float32 name="temperature">
+        <Dim name="/lat"/>
+        <Dim name="/lon"/>
+        <Attribute name="units" type="String">
+            <Value>K</Value>
+        </Attribute>
+        <Attribute name="origname" type="String">
+            <Value>temperature</Value>
+        </Attribute>
+        <Attribute name="fullnamepath" type="String">
+            <Value>/HDFEOS/GRIDS/GeoGrid/Data Fields/temperature</Value>
+        </Attribute>
+        <Attribute name="orig_dimname_list" type="String">
+            <Value>YDim XDim</Value>
+        </Attribute>
+        <Map name="/lat"/>
+        <Map name="/lon"/>
+        <dmrpp:chunks fillValue="0" byteOrder="LE">
+            <dmrpp:chunk offset="40672" nBytes="128"/>
+        </dmrpp:chunks>
+    </Float32>
+    <String name="StructMetadata_0">
+        <Attribute name="origname" type="String">
+            <Value>StructMetadata.0</Value>
+        </Attribute>
+        <Attribute name="fullnamepath" type="String">
+            <Value>/HDFEOS INFORMATION/StructMetadata.0</Value>
+        </Attribute>
+        <dmrpp:chunks fillValue="">
+            <dmrpp:chunk offset="5304" nBytes="32000"/>
+        </dmrpp:chunks>
+    </String>
+    <Attribute name="HDFEOS" type="Container"/>
+    <Attribute name="HDFEOS_ADDITIONAL" type="Container"/>
+    <Attribute name="HDFEOS_ADDITIONAL_FILE_ATTRIBUTES" type="Container"/>
+    <Attribute name="HDFEOS_GRIDS" type="Container"/>
+    <Attribute name="HDFEOS_GRIDS_GeoGrid" type="Container"/>
+    <Attribute name="HDFEOS_GRIDS_GeoGrid_Data_Fields" type="Container"/>
+    <Attribute name="HDFEOS_INFORMATION" type="Container">
+        <Attribute name="HDFEOSVersion" type="String">
+            <Value>HDFEOS_5.1.13</Value>
+        </Attribute>
+        <Attribute name="fullnamepath" type="String">
+            <Value>/HDFEOS INFORMATION</Value>
+        </Attribute>
+    </Attribute>
+    <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="build_dmrpp" type="String">
+            <Value>removed version</Value>
+        </Attribute>
+        <Attribute name="bes" type="String">
+            <Value>removed version</Value>
+        </Attribute>
+        <Attribute name="libdap" type="String">
+            <Value>removed version</Value>
+        </Attribute>
+        <Attribute name="configuration" type="String">
+            <Value>
+# TheBESKeys::get_as_config()
+AllowedHosts=^https?:\/\/
+BES.Catalog.catalog.FollowSymLinks=Yes
+BES.Catalog.catalog.RootDirectory=< path_removed >
+BES.Catalog.catalog.TypeMatch=dmrpp:.*\.(dmrpp)$;
+BES.Catalog.catalog.TypeMatch+=h5:.*(\.bz2|\.gz|\.Z)?$;
+BES.Data.RootDirectory=/dev/null
+BES.LogName=./bes.log
+BES.UncompressCache.dir=/tmp/hyrax_ux
+BES.UncompressCache.prefix=ux_
+BES.UncompressCache.size=500
+BES.module.cmd=< library_path_removed >
+BES.module.dap=< library_path_removed >
+BES.module.dmrpp=< library_path_removed >
+BES.module.fonc=< library_path_removed >
+BES.module.h5=< library_path_removed >
+BES.module.nc=< library_path_removed >
+BES.modules=dap,cmd,h5,dmrpp,nc,fonc
+FONc.ClassicModel=false
+FONc.NoGlobalAttrs=true
+H5.EnableCF=true
+H5.EnableCheckNameClashing=true
+</Value>
+        </Attribute>
+        <Attribute name="Removed(invocation)">
+        </Attribute>
+    </Attribute>
+</Dataset>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/md_reduce_url_2_dmrpp.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/md_reduce_url_2_dmrpp.baseline
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="grid_2_2d.h5" dmrpp:href="OPeNDAP_DMRpp_DATA_ACCESS_URL" removed dmrpp:version>
+    <Dimension name="lon" size="8"/>
+    <Dimension name="lat" size="4"/>
+    <Float32 name="lon">
+        <Dim name="/lon"/>
+        <Attribute name="units" type="String">
+            <Value>degrees_east</Value>
+        </Attribute>
+        <dmrpp:chunks compressionType="deflate" fillValue="0" byteOrder="LE">
+            <dmrpp:chunkDimensionSizes>8</dmrpp:chunkDimensionSizes>
+            <dmrpp:chunk offset="3087" nBytes="33" chunkPositionInArray="[0]" href="OPeNDAP_DMRpp_MISSING_DATA_ACCESS_URL" />
+        </dmrpp:chunks>
+    </Float32>
+    <Float32 name="lat">
+        <Dim name="/lat"/>
+        <Attribute name="units" type="String">
+            <Value>degrees_north</Value>
+        </Attribute>
+        <dmrpp:chunks compressionType="deflate" fillValue="0" byteOrder="LE">
+            <dmrpp:chunkDimensionSizes>4</dmrpp:chunkDimensionSizes>
+            <dmrpp:chunk offset="5216" nBytes="22" chunkPositionInArray="[0]" href="OPeNDAP_DMRpp_MISSING_DATA_ACCESS_URL" />
+        </dmrpp:chunks>
+    </Float32>
+    <Float32 name="temperature">
+        <Dim name="/lat"/>
+        <Dim name="/lon"/>
+        <Attribute name="units" type="String">
+            <Value>K</Value>
+        </Attribute>
+        <Attribute name="origname" type="String">
+            <Value>temperature</Value>
+        </Attribute>
+        <Attribute name="fullnamepath" type="String">
+            <Value>/HDFEOS/GRIDS/GeoGrid/Data Fields/temperature</Value>
+        </Attribute>
+        <Attribute name="orig_dimname_list" type="String">
+            <Value>YDim XDim</Value>
+        </Attribute>
+        <Map name="/lat"/>
+        <Map name="/lon"/>
+        <dmrpp:chunks fillValue="0" byteOrder="LE">
+            <dmrpp:chunk offset="40672" nBytes="128"/>
+        </dmrpp:chunks>
+    </Float32>
+    <String name="StructMetadata_0">
+        <Attribute name="origname" type="String">
+            <Value>StructMetadata.0</Value>
+        </Attribute>
+        <Attribute name="fullnamepath" type="String">
+            <Value>/HDFEOS INFORMATION/StructMetadata.0</Value>
+        </Attribute>
+        <dmrpp:chunks fillValue="">
+            <dmrpp:chunk offset="5304" nBytes="32000"/>
+        </dmrpp:chunks>
+    </String>
+    <Attribute name="HDFEOS" type="Container"/>
+    <Attribute name="HDFEOS_ADDITIONAL" type="Container"/>
+    <Attribute name="HDFEOS_ADDITIONAL_FILE_ATTRIBUTES" type="Container"/>
+    <Attribute name="HDFEOS_GRIDS" type="Container"/>
+    <Attribute name="HDFEOS_GRIDS_GeoGrid" type="Container"/>
+    <Attribute name="HDFEOS_GRIDS_GeoGrid_Data_Fields" type="Container"/>
+    <Attribute name="HDFEOS_INFORMATION" type="Container">
+        <Attribute name="HDFEOSVersion" type="String">
+            <Value>HDFEOS_5.1.13</Value>
+        </Attribute>
+        <Attribute name="fullnamepath" type="String">
+            <Value>/HDFEOS INFORMATION</Value>
+        </Attribute>
+    </Attribute>
+    <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="build_dmrpp" type="String">
+            <Value>removed version</Value>
+        </Attribute>
+        <Attribute name="bes" type="String">
+            <Value>removed version</Value>
+        </Attribute>
+        <Attribute name="libdap" type="String">
+            <Value>removed version</Value>
+        </Attribute>
+        <Attribute name="configuration" type="String">
+            <Value>
+# TheBESKeys::get_as_config()
+AllowedHosts=^https?:\/\/
+BES.Catalog.catalog.FollowSymLinks=Yes
+BES.Catalog.catalog.RootDirectory=< path_removed >
+BES.Catalog.catalog.TypeMatch=dmrpp:.*\.(dmrpp)$;
+BES.Catalog.catalog.TypeMatch+=h5:.*(\.bz2|\.gz|\.Z)?$;
+BES.Data.RootDirectory=/dev/null
+BES.LogName=./bes.log
+BES.UncompressCache.dir=/tmp/hyrax_ux
+BES.UncompressCache.prefix=ux_
+BES.UncompressCache.size=500
+BES.module.cmd=< library_path_removed >
+BES.module.dap=< library_path_removed >
+BES.module.dmrpp=< library_path_removed >
+BES.module.fonc=< library_path_removed >
+BES.module.h5=< library_path_removed >
+BES.module.nc=< library_path_removed >
+BES.modules=dap,cmd,h5,dmrpp,nc,fonc
+FONc.ClassicModel=false
+FONc.NoGlobalAttrs=true
+H5.EnableCF=true
+H5.EnableCheckNameClashing=true
+</Value>
+        </Attribute>
+        <Attribute name="Removed(invocation)">
+        </Attribute>
+    </Attribute>
+</Dataset>

--- a/modules/dmrpp_module/tests_build_dmrpp/testsuite.at
+++ b/modules/dmrpp_module/tests_build_dmrpp/testsuite.at
@@ -36,7 +36,7 @@ AT_GET_DMRPP_3_20_MAKE_MISSING([-M, make missing data file], [grid_1_2d.h5], [mi
 AT_GET_DMRPP_3_20_MAKE_MISSING([-M -p, make missing data file with missing data url], [grid_1_2d.h5], [missing_data_url_dmrpp.baseline], [missing_data.baseline], [-M -p http://some.where.over.the.rainbow.oz -s ${abs_srcdir}/get_dmrpp_baselines/use_cf.conf], [a.out])
 
 # -r Provide missing variables sidecar file, requires use_cf_conf "site.conf" file
-AT_GET_DMRPP_3_20_MAKE_MISSING([-M -r, make missing data file with reused missing data url], [grid_1_2d.h5], [md_reduce_url_1_dmrpp.baseline], [md_reduce.baseline.missing], [-M -r grid_1_2d.h5.missing -s ${abs_srcdir}/get_dmrpp_baselines/use_cf.conf], [a.out], [xfail])
+AT_GET_DMRPP_3_20_MAKE_MISSING([-M -r, make missing data file with reused missing data url], [grid_1_2d.h5], [md_reduce_url_1_dmrpp.baseline], [md_reduce.baseline.missing], [-M -r grid_1_2d.h5.missing -s ${abs_srcdir}/get_dmrpp_baselines/use_cf.conf], [a.out])
 AT_GET_DMRPP_3_20_MAKE_MISSING([-M -r, make missing data file with reused missing data url], [grid_2_2d.h5], [md_reduce_url_2_dmrpp.baseline], [md_reduce.baseline.missing], [-M -r grid_1_2d.h5.missing -s ${abs_srcdir}/get_dmrpp_baselines/use_cf.conf], [a.out], [xfail])
 
 # AT_GET_DMRPP_3_20([grid_1_2d.h5], [grid_1_2d.h5.reduce_href.baseline], [-M -r ${abs_builddir}/grid_1_2d.h5.missing], [${abs_builddir}/a.out])

--- a/modules/dmrpp_module/tests_build_dmrpp/testsuite.at
+++ b/modules/dmrpp_module/tests_build_dmrpp/testsuite.at
@@ -36,7 +36,10 @@ AT_GET_DMRPP_3_20_MAKE_MISSING([-M, make missing data file], [grid_1_2d.h5], [mi
 AT_GET_DMRPP_3_20_MAKE_MISSING([-M -p, make missing data file with missing data url], [grid_1_2d.h5], [missing_data_url_dmrpp.baseline], [missing_data.baseline], [-M -p http://some.where.over.the.rainbow.oz -s ${abs_srcdir}/get_dmrpp_baselines/use_cf.conf], [a.out])
 
 # -r Provide missing variables sidecar file, requires use_cf_conf "site.conf" file
-#AT_GET_DMRPP_3_20([grid_1_2d.h5], [grid_1_2d.h5.reduce_href.baseline], [-M -r ${abs_builddir}/grid_1_2d.h5.missing], [${abs_builddir}/a.out])
+AT_GET_DMRPP_3_20_MAKE_MISSING([-M -r, make missing data file with reused missing data url], [grid_1_2d.h5], [md_reduce_url_1_dmrpp.baseline], [md_reduce.baseline.missing], [-M -r grid_1_2d.h5.missing -s ${abs_srcdir}/get_dmrpp_baselines/use_cf.conf], [a.out])
+AT_GET_DMRPP_3_20_MAKE_MISSING([-M -r, make missing data file with reused missing data url], [grid_2_2d.h5], [md_reduce_url_2_dmrpp.baseline], [md_reduce.baseline.missing], [-M -r grid_1_2d.h5.missing -s ${abs_srcdir}/get_dmrpp_baselines/use_cf.conf], [a.out], [xfail])
+
+# AT_GET_DMRPP_3_20([grid_1_2d.h5], [grid_1_2d.h5.reduce_href.baseline], [-M -r ${abs_builddir}/grid_1_2d.h5.missing], [${abs_builddir}/a.out])
 
 # -U Use input file located in AWS S3
 AT_GET_DMRPP_3_20([-U, AWS S3 pull and push test], [s3://opendap.travis.tests/data/dmrpp/chunked_oneD.h5], [s3_pull_push_test.baseline], [-U -b ${abs_builddir}], [${abs_builddir}/a.out])

--- a/modules/dmrpp_module/tests_build_dmrpp/testsuite.at
+++ b/modules/dmrpp_module/tests_build_dmrpp/testsuite.at
@@ -36,7 +36,7 @@ AT_GET_DMRPP_3_20_MAKE_MISSING([-M, make missing data file], [grid_1_2d.h5], [mi
 AT_GET_DMRPP_3_20_MAKE_MISSING([-M -p, make missing data file with missing data url], [grid_1_2d.h5], [missing_data_url_dmrpp.baseline], [missing_data.baseline], [-M -p http://some.where.over.the.rainbow.oz -s ${abs_srcdir}/get_dmrpp_baselines/use_cf.conf], [a.out])
 
 # -r Provide missing variables sidecar file, requires use_cf_conf "site.conf" file
-AT_GET_DMRPP_3_20_MAKE_MISSING([-M -r, make missing data file with reused missing data url], [grid_1_2d.h5], [md_reduce_url_1_dmrpp.baseline], [md_reduce.baseline.missing], [-M -r grid_1_2d.h5.missing -s ${abs_srcdir}/get_dmrpp_baselines/use_cf.conf], [a.out])
+AT_GET_DMRPP_3_20_MAKE_MISSING([-M -r, make missing data file with reused missing data url], [grid_1_2d.h5], [md_reduce_url_1_dmrpp.baseline], [md_reduce.baseline.missing], [-M -r grid_1_2d.h5.missing -s ${abs_srcdir}/get_dmrpp_baselines/use_cf.conf], [a.out], [xfail])
 AT_GET_DMRPP_3_20_MAKE_MISSING([-M -r, make missing data file with reused missing data url], [grid_2_2d.h5], [md_reduce_url_2_dmrpp.baseline], [md_reduce.baseline.missing], [-M -r grid_1_2d.h5.missing -s ${abs_srcdir}/get_dmrpp_baselines/use_cf.conf], [a.out], [xfail])
 
 # AT_GET_DMRPP_3_20([grid_1_2d.h5], [grid_1_2d.h5.reduce_href.baseline], [-M -r ${abs_builddir}/grid_1_2d.h5.missing], [${abs_builddir}/a.out])


### PR DESCRIPTION
The -r option is the 'reduce' option where a single file for missing values can be used for more than one data file. One of two of the new tests work. I also added a very verbose option so that the versbose option by itself is easier to use while retaining the more complete output of the orignal version.