### PR TITLE
modules/hdf5_handler/gctp: C99 compatibility improvements

### DIFF
--- a/modules/hdf5_handler/gctp/include/gctp_prototypes.h
+++ b/modules/hdf5_handler/gctp/include/gctp_prototypes.h
@@ -280,5 +280,13 @@ int bceainvint(double r_maj, double r_min, double center_lon,
 	       double center_lat, double false_east, double false_north);
 int bceainv(double x, double y, double *lon, double *lat);
 
+int hfor_init(int outsys, int outzone, double *outparm, int outdatum, char *fn27, char *fn83, int *iflg, int (*hfor_trans[])(double, double, double *, double *));
+long untfz(long inunit, long outunit, double *factor);
+int init(long ipr, long jpr, char *efile, char *pfile);
+void close_file(void);
+int hinv_init(int insys, int inzone, double *inparm, int indatum, char *fn27, char *fn83, int *iflg, int (*hinv_trans[])(double, double, double*, double*));
+int gctp(double *incoor, long *insys, long *inzone, double *inparm, long *inunit, long *indatum, long *ipr, char *efile, long *jpr, char *pfile, double *outcoor, long *outsys, long *outzone, double *outparm, long *outunit, long *outdatum, char *fn27, char *fn83, long *iflg);
+int gctp_(double *incoor, long *insys, long *inzone, double *inparm, long *inunit, long *indatum, long *ipr, char *efile, long *jpr, char *pfile, double *outcoor, long *outsys, long *outzone, double *outparm, long *outunit, long *outdatum, char *fn27, char *fn83, long *iflg);
+
 #endif
 #endif

--- a/modules/hdf5_handler/gctp/src/br_gctp.c
+++ b/modules/hdf5_handler/gctp/src/br_gctp.c
@@ -1,9 +1,10 @@
+#include "cproj.h"
 
 #ifdef unix
 /*  Fortran bridge routine for the UNIX */
 
-void gctp_(incoor,insys,inzone,inparm,inunit,indatum,ipr,efile,jpr,pfile,
-               outcoor, outsys,outzone,outparm,outunit,fn27,fn83,iflg)
+int gctp_(incoor,insys,inzone,inparm,inunit,indatum,ipr,efile,jpr,pfile,
+               outcoor, outsys,outzone,outparm,outunit,outdatum,fn27,fn83,iflg)
 
 double *incoor;
 long *insys;
@@ -20,12 +21,13 @@ long *outsys;
 long *outzone;
 double *outparm;
 long *outunit;
+long *outdatum;
+char *fn27;
+char *fn83;
 long *iflg;
 
 {
-gctp(incoor,insys,inzone,inparm,inunit,indatum,ipr,efile,jpr,pfile,outcoor,
-     outsys,outzone,outparm,outunit,fn27,fn83,iflg);
-
-return;
+return gctp(incoor,insys,inzone,inparm,inunit,indatum,ipr,efile,jpr,pfile,
+            outcoor, outsys,outzone,outparm,outunit,outdatum,fn27,fn83,iflg);
 }
 #endif

--- a/modules/hdf5_handler/gctp/src/gctp.c
+++ b/modules/hdf5_handler/gctp/src/gctp.c
@@ -69,6 +69,7 @@ static long NAD83[134] = {101,102,5010,5300,201,202,203,301,302,401,402,403,
                 4502,4601,4602,4701,4702,4801,4802,4803,4901,4902,4903,4904,
                 5001,5002,5003,5004,5005,5006,5007,5008,5009,5200,0000,5400};
 */
+int
 gctp(incoor,insys,inzone,inparm,inunit,indatum,ipr,efile,jpr,pfile,outcoor,
      outsys,outzone,outparm,outunit,outdatum,fn27,fn83,iflg)
 


### PR DESCRIPTION
This change adds additional prototypes to avoid implicit function declarations, which will not be supported by future compilers by default, resulting in build failures.  Also add a missing int type, which future compilers will require, too.

The additional prototypes revealed that the wrapper function gctp_ has the wrong signature, which is also fixed in this commit.