### PR TITLE
Remove pthread

### DIFF
--- a/dap/CacheMarshaller.cc
+++ b/dap/CacheMarshaller.cc
@@ -24,15 +24,10 @@
 
 #include "config.h"
 
-#if 0 // def HAVE_PTHREAD_H
-// #include <pthread.h>
-#endif
-
 #include <cassert>
 
 #include <iostream>
 #include <sstream>
-// #include <iomanip>
 
 #include <libdap/Vector.h>
 

--- a/dap/CacheMarshaller.cc
+++ b/dap/CacheMarshaller.cc
@@ -24,15 +24,15 @@
 
 #include "config.h"
 
-#ifdef HAVE_PTHREAD_H
-#include <pthread.h>
+#if 0 // def HAVE_PTHREAD_H
+// #include <pthread.h>
 #endif
 
 #include <cassert>
 
 #include <iostream>
 #include <sstream>
-#include <iomanip>
+// #include <iomanip>
 
 #include <libdap/Vector.h>
 

--- a/dispatch/BESCatalogList.cc
+++ b/dispatch/BESCatalogList.cc
@@ -36,7 +36,9 @@
 #include <stdlib.h>
 #endif
 
-#include <pthread.h>
+#if 0
+// #include <pthread.h>
+#endif
 
 #include <sstream>
 

--- a/dispatch/BESCatalogList.cc
+++ b/dispatch/BESCatalogList.cc
@@ -32,14 +32,7 @@
 
 #include "config.h"
 
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-
-#if 0
-// #include <pthread.h>
-#endif
-
+#include <cstdlib>
 #include <sstream>
 
 #include "BESCatalogList.h"
@@ -48,16 +41,9 @@
 #include "BESCatalogEntry.h"
 #include "BESInfo.h"
 
-#include "BESSyntaxUserError.h"
 #include "TheBESKeys.h"
-#include "BESNames.h"
 
 using namespace std;
-
-#if 0
-static pthread_once_t BESCatalogList_instance_control = PTHREAD_ONCE_INIT;
-#endif
-
 
 BESCatalogList *BESCatalogList::d_instance = 0;
 

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -62,50 +62,6 @@ using namespace dmrpp;
 using namespace http;
 using namespace std;
 
-#if 0
-
-string pthread_error(unsigned int err){
-    string error_msg;
-    switch(err){
-        case EINVAL:
-            error_msg = "The mutex was either created with the "
-                        "protocol attribute having the value "
-                        "PTHREAD_PRIO_PROTECT and the calling "
-                        "thread's priority is higher than the "
-                        "mutex's current priority ceiling."
-                        "OR The value specified by mutex does not "
-                        "refer to an initialized mutex object.";
-            break;
-
-        case EBUSY:
-            error_msg = "The mutex could not be acquired "
-                        "because it was already locked.";
-            break;
-
-        case EAGAIN:
-            error_msg = "The mutex could not be acquired because "
-                        "the maximum number of recursive locks "
-                        "for mutex has been exceeded.";
-            break;
-
-        case EDEADLK:
-            error_msg = "The current thread already owns the mutex";
-            break;
-
-        case EPERM:
-            error_msg = "The current thread does not own the mutex.";
-            break;
-
-        default:
-            error_msg = "Unknown pthread error type.";
-            break;
-    }
-
-    return error_msg;
-}
-
-#endif
-
 /**
  * @brief Build a string with hex info about stuff libcurl gets
  *

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -24,21 +24,12 @@
 #include "config.h"
 
 #include <string>
-// #include <locale>
 #include <sstream>
-
-// #include <cstring>
-// #include <unistd.h>
+#include <ctime>
 
 #include <curl/curl.h>
 
 #include "CurlUtils.h"
-// #include "HttpNames.h"
-
-#include <ctime>
-
-// #include <libdap/util.h>   // long_to_string()
-
 #include "BESLog.h"
 #include "BESDebug.h"
 #include "BESInternalError.h"

--- a/modules/dmrpp_module/CurlHandlePool.h
+++ b/modules/dmrpp_module/CurlHandlePool.h
@@ -115,7 +115,7 @@ public:
 
     void release_handle(dmrpp_easy_handle *h);
 
-    void release_handle(Chunk *chunk);
+    void release_handle(const Chunk *chunk);
 
     void release_all_handles();
 };

--- a/modules/dmrpp_module/CurlHandlePool.h
+++ b/modules/dmrpp_module/CurlHandlePool.h
@@ -29,8 +29,6 @@
 #include <vector>
 #include <mutex>
 
-#include <pthread.h>
-
 #include <curl/curl.h>
 
 #include "url_impl.h"
@@ -90,8 +88,8 @@ public:
 
     ~CurlHandlePool()
     {
-        for (auto i = d_easy_handles.begin(), e = d_easy_handles.end(); i != e; ++i) {
-            delete *i;
+        for (auto & d_easy_handle : d_easy_handles) {
+            delete d_easy_handle;
         }
     }
 
@@ -102,8 +100,8 @@ public:
     unsigned int get_handles_available() const
     {
         unsigned int n = 0;
-        for (auto i = d_easy_handles.begin(), e = d_easy_handles.end(); i != e; ++i) {
-            if (!(*i)->d_in_use) {
+        for (auto d_easy_handle : d_easy_handles) {
+            if (!d_easy_handle->d_in_use) {
                 n++;
 
             }

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -35,20 +35,8 @@
 
 #include <cstring>
 #include <cassert>
-
-#if 0
-#include <cerrno>
-#endif
 #include <iomanip>
-
-#if 0
-#include <pthread.h>
-#endif
 #include <cmath>
-
-#if 0
-#include <unistd.h>
-#endif
 
 #include <libdap/D4Enum.h>
 #include <libdap/D4Attributes.h>
@@ -72,7 +60,6 @@
 
 // Used with BESDEBUG
 #define dmrpp_3 "dmrpp:3"
-#define dmrpp_4 "dmrpp:4"
 
 using namespace libdap;
 using namespace std;

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -35,13 +35,20 @@
 
 #include <cstring>
 #include <cassert>
+
+#if 0
 #include <cerrno>
+#endif
 #include <iomanip>
 
+#if 0
 #include <pthread.h>
+#endif
 #include <cmath>
 
+#if 0
 #include <unistd.h>
+#endif
 
 #include <libdap/D4Enum.h>
 #include <libdap/D4Attributes.h>

--- a/modules/dmrpp_module/DmrppCommon.h
+++ b/modules/dmrpp_module/DmrppCommon.h
@@ -33,6 +33,8 @@
 #define PUGIXML_HEADER_ONLY
 #include <pugixml.hpp>
 
+#include <libdap/Type.h>
+
 namespace libdap {
 class DMR;
 class BaseType;

--- a/modules/dmrpp_module/data/old/keepalive2.cc
+++ b/modules/dmrpp_module/data/old/keepalive2.cc
@@ -35,7 +35,10 @@
 #include <cassert>
 #include <map>
 #include <vector>
+
+#ifdef NEVER
 #include <pthread.h>
+#endif
 #include <curl/curl.h>
 
 static bool debug = false;

--- a/modules/dmrpp_module/unit-tests/CurlHandlePoolTest.cc
+++ b/modules/dmrpp_module/unit-tests/CurlHandlePoolTest.cc
@@ -167,14 +167,14 @@ public:
 
 class CurlHandlePoolTest : public CppUnit::TestFixture {
 private:
-    CurlHandlePool *chp;
+    CurlHandlePool *chp = nullptr;
 
 public:
     // Called once before everything gets tested
-    CurlHandlePoolTest(): chp(0){ }
-
-    // Called at the end of the test
-    ~CurlHandlePoolTest(){}
+    CurlHandlePoolTest() = default;
+    ~CurlHandlePoolTest() override = default;
+    CurlHandlePoolTest(const CurlHandlePoolTest &other) = delete;
+    CurlHandlePoolTest &operator=(const CurlHandlePoolTest &other) = delete;
 
     // Called before each test
     void setUp() override
@@ -190,7 +190,7 @@ public:
     void tearDown() override
     {
         delete chp;
-        chp = 0;
+        chp = nullptr;
     }
 
     void process_one_chunk_test()

--- a/modules/ugrid_functions/unit-tests/Makefile.am
+++ b/modules/ugrid_functions/unit-tests/Makefile.am
@@ -7,7 +7,9 @@ AUTOMAKE_OPTIONS = foreign
 
 # Headers in 'tests' are used by the arrayT unit tests.
 
-AM_CPPFLAGS = -I$(top_srcdir)/modules/ugrid_functions $(GF_CFLAGS) -I$(top_srcdir)/dispatch -I$(top_srcdir)/dap $(DAP_CFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/dispatch -I$(top_srcdir)/dap -I$(top_srcdir)/modules/ugrid_functions \
+$(GF_CFLAGS) $(DAP_CFLAGS)
+
 LIBADD = $(GF_LIBS) $(BES_DISPATCH_LIB) $(BES_EXTRA_LIBS) $(DAP_SERVER_LIBS) $(DAP_CLIENT_LIBS)
 
 if CPPUNIT

--- a/modules/ugrid_functions/unit-tests/possibly_lost.cc
+++ b/modules/ugrid_functions/unit-tests/possibly_lost.cc
@@ -29,14 +29,6 @@
 #include <iostream>
 #include <iterator>
 
-#ifdef NEVER
-
-#include <cppunit/TextTestRunner.h>
-#include <cppunit/extensions/TestFactoryRegistry.h>
-#include <cppunit/extensions/HelperMacros.h>
-
-#endif
-
 #include <libdap/BaseType.h>
 #include <libdap/Str.h>
 #include <libdap/DDS.h>

--- a/modules/ugrid_functions/unit-tests/possibly_lost.cc
+++ b/modules/ugrid_functions/unit-tests/possibly_lost.cc
@@ -24,83 +24,62 @@
 
 #include "config.h"
 
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-
-#include <pthread.h>
+#include <thread>
 
 #include <iostream>
 #include <iterator>
+
+#ifdef NEVER
 
 #include <cppunit/TextTestRunner.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/extensions/HelperMacros.h>
 
-#include <libdap/debug.h>
-#include <libdap/util.h>
+#endif
 
-#include <unistd.h>
 #include <libdap/BaseType.h>
 #include <libdap/Str.h>
 #include <libdap/DDS.h>
 #include <libdap/ServerFunction.h>
 
-static pthread_once_t instance_control = PTHREAD_ONCE_INIT;
-static bool debug = false;
+#include <libdap/util.h>
 
-#undef DBG
-#define DBG(x) do { if (debug) (x); } while(false);
+#include "modules/common/run_tests_cppunit.h"
 
 class SingletonList {
 private:
-    static SingletonList * d_instance;
+    static std::unique_ptr<SingletonList> d_instance;
+    static std::once_flag d_init_once;
 
-    std::multimap<std::string, libdap::ServerFunction *> d_func_list;
-
-    static void initialize_instance()
-    {
-        if (d_instance == 0) {
-            d_instance = new SingletonList;
-#if HAVE_ATEXIT
-            atexit(delete_instance);
-#endif
-        }
-    }
-
-    static void delete_instance()
-    {
-        delete d_instance;
-        d_instance = 0;
-    }
-
-    virtual ~SingletonList()
-    {
-        std::multimap<string, libdap::ServerFunction *>::iterator fit;
-        for (fit = d_func_list.begin(); fit != d_func_list.end(); fit++) {
-            libdap::ServerFunction *func = fit->second;
-            DBG(
-                cerr << "SingletonList::~SingletonList() - Deleting ServerFunction " << func->getName()
-                    << " from SingletonList." << endl);
-            delete func;
-        }
-        d_func_list.clear();
-    }
+    std::multimap<std::string, libdap::ServerFunction *, less<>> d_func_list;
 
     friend class PossiblyLost;
 
-protected:
-    SingletonList()
+public:
+    SingletonList() = default;
+    SingletonList(const SingletonList&) = delete;
+    SingletonList& operator=(const SingletonList&) = delete;
+    virtual ~SingletonList()
     {
+        for (const auto& fit: d_func_list) {
+            libdap::ServerFunction *func = fit.second;
+            DBG(cerr << "SingletonList::~SingletonList() - Deleting ServerFunction " << func->getName()
+                     << " from SingletonList." << endl);
+            delete func;
+        }
+
+        d_func_list.clear();
     }
 
-public:
-
-    static SingletonList * TheList()
+    static SingletonList *TheList()
     {
-        pthread_once(&instance_control, initialize_instance);
+        if (d_instance == nullptr) {
+            std::call_once(d_init_once, []() {
+                d_instance.reset(new SingletonList);
+            });
+        }
 
-        return d_instance;
+        return d_instance.get();
     }
 
     virtual void add_function(libdap::ServerFunction *func)
@@ -108,36 +87,34 @@ public:
         d_func_list.insert(std::make_pair(func->getName(), func));
     }
 
-    void getFunctionNames(vector<string> *names)
+    void getFunctionNames(vector<string> *names) const
     {
         if (d_func_list.empty()) {
             DBG(cerr << "SingletonList::getFunctionNames() - Function list is empty." << endl);
             return;
         }
-        std::multimap<string, libdap::ServerFunction *>::iterator fit;
-        for (fit = d_func_list.begin(); fit != d_func_list.end(); fit++) {
-            libdap::ServerFunction *func = fit->second;
-            DBG(
-                cerr << "SingletonList::getFunctionNames() - Adding function '" << func->getName() << "' to names list."
-                    << endl);
+
+        for (const auto& fit: d_func_list) {
+            libdap::ServerFunction *func = fit.second;
+            DBG(cerr << "SingletonList::getFunctionNames() - Adding function '" << func->getName()
+                << "' to names list.\n");
             names->push_back(func->getName());
         }
     }
 
 };
 
-SingletonList *SingletonList::d_instance = 0;
+std::once_flag SingletonList::d_init_once;
+std::unique_ptr<SingletonList> SingletonList::d_instance = nullptr;
 
 void possibly_lost_function(int /*argc*/, libdap::BaseType */*argv*/[], libdap::DDS &/*dds*/, libdap::BaseType **btpp)
 {
     string info = string("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n") + "<function name=\"ugr4\" version=\"0.1\">\n"
         + "Valgrind Possibly Lost Error Test.\n" + "usage: possibly_lost_test()" + "\n" + "</function>";
 
-    libdap::Str *response = new libdap::Str("info");
+    auto response = make_unique<libdap::Str>("info");
     response->set_value(info);
-    *btpp = response;
-    return;
-
+    *btpp = response.release();
 }
 
 class PLTF: public libdap::ServerFunction {
@@ -148,70 +125,22 @@ public:
         setDescriptionString(
             "This is a unit test to determine why valgrind is returning possibly lost errors on this code pattern.");
         setUsageString("pltf()");
-        setRole("http://services.opendap.org/dap4/unit-tests/possibly_lost_test");
-        setDocUrl("http://docs.opendap.org/index.php/unit-tests");
+        setRole("https://services.opendap.org/dap4/unit-tests/possibly_lost_test");
+        setDocUrl("https://docs.opendap.org/index.php/unit-tests");
         setFunction(possibly_lost_function);
         setVersion("1.0");
-
     }
 };
 
 class PossiblyLost: public CppUnit::TestFixture {
 
 public:
+    PossiblyLost() = default;
+    ~PossiblyLost() override = default;
 
-    // Called once before everything gets tested
-    PossiblyLost()
-    {
-        //    DBG(cerr << " BindTest - Constructor" << endl);
+    // setUp and tearDown are not used by this fixture. jhrg 5/25/23
 
-    }
-
-    // Called at the end of the test
-    ~PossiblyLost()
-    {
-        //    DBG(cerr << " BindTest - Destructor" << endl);
-    }
-
-    // Called before each test
-    void setup()
-    {
-        //    DBG(cerr << " BindTest - setup()" << endl);
-    }
-
-    // Called after each test
-    void tearDown()
-    {
-        //    DBG(cerr << " tearDown()" << endl);
-    }
-
-CPPUNIT_TEST_SUITE( PossiblyLost );
-
-    CPPUNIT_TEST(possibly_lost_fail);
-    CPPUNIT_TEST(possibly_lost_solution);
-
-    CPPUNIT_TEST_SUITE_END()
-    ;
-
-    void possibly_lost_fail()
-    {
-        DBG(cerr << endl);
-
-        PLTF *ssf = new PLTF();
-        ssf->setName("Possibly_Lost_FAIL");
-
-        //printFunctionNames();
-
-        DBG(
-            cerr << "PossiblyLost::possibly_lost_solution() - Adding function(): " << ssf->getDescriptionString()
-                << endl);
-        SingletonList::TheList()->add_function(ssf);
-
-        printFunctionNames();
-
-    }
-
-    void printFunctionNames()
+    static void printFunctionNames()
     {
         vector<string> names;
         SingletonList::TheList()->getFunctionNames(&names);
@@ -219,81 +148,27 @@ CPPUNIT_TEST_SUITE( PossiblyLost );
         DBG(copy(names.begin(), names.end(), ostream_iterator<string>(cerr, ", ")));
     }
 
-    void possibly_lost_solution()
+    CPPUNIT_TEST_SUITE(PossiblyLost);
+
+    CPPUNIT_TEST(possibly_lost_fail);
+
+    CPPUNIT_TEST_SUITE_END();
+
+    void possibly_lost_fail()
     {
-        DBG(cerr << endl);
+        auto ssf = std::make_unique<PLTF>();
+        ssf->setName("possibly_lost_fail");
 
-        PLTF *ssf = new PLTF();
-        ssf->setName("Possibly_Lost_Solution");
-
-        printFunctionNames();
-
-        DBG(
-            cerr << "PossiblyLost::possibly_lost_solution() - Adding function(): " << ssf->getDescriptionString()
-                << endl);
-        SingletonList::TheList()->add_function(ssf);
-
-        printFunctionNames();
-
-        DBG(cerr << "PossiblyLost::possibly_lost_solution() - Deleting the List." << endl);
-        SingletonList::delete_instance();
-
-        // This is needed because we used pthread_once to ensure that
-        // initialize_instance() is called at most once. We manually call
-        // the delete method, so the object must be remade. This would never
-        // be done by non-test code. jhrg 5/2/13
-        SingletonList::initialize_instance();
+        DBG(cerr << "PossiblyLost::possibly_lost_fail() - Adding function(): " << ssf->getDescriptionString() << "\n");
+        SingletonList::TheList()->add_function(ssf.release());
 
         printFunctionNames();
     }
-
 };
-// BindTest
 
 CPPUNIT_TEST_SUITE_REGISTRATION(PossiblyLost);
 
-int main(int argc, char*argv[])
+int main(int argc, char *argv[])
 {
-    int option_char;
-    while ((option_char = getopt(argc, argv, "dh")) != -1)
-        switch (option_char) {
-        case 'd':
-            debug = 1;  // debug is a static global
-            break;
-        case 'h': {     // help - show test names
-            std::cerr << "Usage: PossiblyLost has the following tests:" << std::endl;
-            const std::vector<CppUnit::Test*> &tests = PossiblyLost::suite()->getTests();
-            unsigned int prefix_len = PossiblyLost::suite()->getName().append("::").size();
-            for (std::vector<CppUnit::Test*>::const_iterator i = tests.begin(), e = tests.end(); i != e; ++i) {
-                std::cerr << (*i)->getName().replace(0, prefix_len, "") << std::endl;
-            }
-            break;
-        }
-        default:
-            break;
-        }
-
-    argc -= optind;
-    argv += optind;
-
-    CppUnit::TextTestRunner runner;
-    runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
-
-    bool wasSuccessful = true;
-    string test = "";
-    if (0 == argc) {
-        // run them all
-        wasSuccessful = runner.run("");
-    }
-    else {
-        int i = 0;
-        while (i < argc) {
-            if (debug) cerr << "Running " << argv[i] << endl;
-            test = PossiblyLost::suite()->getName().append("::").append(argv[i]);
-            wasSuccessful = wasSuccessful && runner.run(test);
-        }
-    }
-
-    return wasSuccessful ? 0 : 1;
+    return bes_run_tests<PossiblyLost>(argc, argv, "cerr,bes") ? 0: 1;
 }
-

--- a/modules/usage/BESUsageResponseHandler.cc
+++ b/modules/usage/BESUsageResponseHandler.cc
@@ -75,7 +75,7 @@ BESUsageResponseHandler::execute( BESDataHandlerInterface &dhi )
     dhi.action_name = Usage_RESPONSE_STR ;
 
     // Create the DDS.
-    // NOTE: It is the responsbility of the specific request handler to set
+    // NOTE: It is the responsibility of the specific request handler to set
     // the BaseTypeFactory. It is set to NULL here
     DDS *dds = new DDS( NULL, "virtual" ) ;
     BESDDSResponse *bdds = new BESDDSResponse( dds ) ;

--- a/modules/usage/usage.cc
+++ b/modules/usage/usage.cc
@@ -44,8 +44,7 @@
 #include <fstream>
 #include <string>
 #include <sstream>
-
-#include "BESRegex.h"
+// #include <thread>
 
 #include <libdap/Array.h>
 #include <libdap/Structure.h>
@@ -54,7 +53,10 @@
 #include <libdap/Ancillary.h>
 #include <libdap/DAS.h>
 #include <libdap/util.h>
-#include <libdap/Error.h>
+// #include <libdap/Error.h>
+
+#include "BESRegex.h"
+
 
 #include "usage.h"
 
@@ -62,96 +64,20 @@ using namespace std;
 using namespace libdap;
 using namespace dap_usage;
 
-#ifdef WIN32
-#define popen _popen
-#define pclose _pclose
-#include <io.h>
-#include <fcntl.h>
-#endif
-
-#ifdef WIN32
-#define RETURN_TYPE void
-#else
-#define RETURN_TYPE int
-#endif
-
 namespace dap_usage {
 
-// This code could use a real `kill-file' some day - about the same time that
-// the rest of the server gets a `rc' file... For the present just see if a
-// small collection of regexs match the name.
+static const BESRegex dim(".*_dim_[0-9]*", 1); // HDF dim attributes.
+static const BESRegex global("(.*global.*)|(.*dods.*)", 1);
 
-// The pthread code here is used to ensure that the static objects dim and
-// global (in name_in_kill_file() and name_is_global()) are initialized only
-// once. If the pthread package is not present when libdap++ is built, this
-// code is *not* MT-Safe.
-
-static BESRegex *dim_ptr = nullptr;
-#if HAVE_PTHREAD_H
-static pthread_once_t dim_once_control = PTHREAD_ONCE_INIT;
-#endif
-
-// TODO std::once_flag TheBESKeys::d_euc_init_once;
-
-static void
-init_dim_regex()
-{
-    // MT-Safe if called via pthread_once or similar
-    static BESRegex dim(".*_dim_[0-9]*", 1); // HDF `dim' attributes.
-    dim_ptr = &dim;
+static bool
+name_in_kill_file(const string &name) {
+    return dim.match(name.c_str(), (int)name.size()) != -1;
 }
 
 static bool
-name_in_kill_file(const string &name)
-{
-#if HAVE_PTHREAD_H
-    pthread_once(&dim_once_control, init_dim_regex);
-#else
-    if (!dim_ptr)
-    {
-	init_dim_regex();
-    }
-#endif
-
-    bool ret = dim_ptr->match(name.c_str(), name.size()) != -1;
-    return ret ;
-
-#ifdef TODO
-    if (d_instance == nullptr) {
-        std::call_once(d_euc_init_once, []() {
-            d_instance.reset(new TheBESKeys(get_the_config_filename()));
-        });
-    }
-
-    return d_instance.get();
-#endif
-}
-
-static BESRegex *global_ptr = nullptr;
-#if HAVE_PTHREAD_H
-static pthread_once_t global_once_control = PTHREAD_ONCE_INIT;
-#endif
-
-static void
-init_global_regex()
-{
-    // MT-Safe if called via pthread_once or similar
-    static BESRegex global("(.*global.*)|(.*dods.*)", 1);
-    global_ptr = &global;
-}
-
-static bool
-name_is_global(string &name)
-{
-#if HAVE_PTHREAD_H
-    pthread_once(&global_once_control, init_global_regex);
-#else
-    if (!global_ptr)
-	init_global_regex();
-#endif
-
+name_is_global(string &name) {
     downcase(name);
-    return global_ptr->match(name.c_str(), name.size()) != -1;
+    return global.match(name.c_str(), (int)name.size()) != -1;
 }
 
 // write_global_attributes and write_attributes are almost the same except
@@ -160,56 +86,54 @@ name_is_global(string &name)
 // understand. So, I'm keeping this as two separate functions even though
 // there's some duplication... 3/27/2002 jhrg
 static void
-write_global_attributes(ostringstream &oss, AttrTable *attr, const string prefix = "")
-{
+write_global_attributes(ostringstream &oss, AttrTable *attr, const string prefix = "") {
     if (attr) {
-	AttrTable::Attr_iter a;
-	for (a = attr->attr_begin(); a != attr->attr_end(); a++) {
-	    if (attr->is_container(a))
-		write_global_attributes(oss, attr->get_attr_table(a),
-					(prefix == "") ? attr->get_name(a)
-					: prefix + string(".") + attr->get_name(a));
-	    else {
-		oss << "\n<tr><td align=right valign=top><b>";
-		if (prefix != "")
-		    oss << prefix << "." << attr->get_name(a);
-		else
-		    oss << attr->get_name(a);
-		oss << "</b>:</td>\n";
+        AttrTable::Attr_iter a;
+        for (a = attr->attr_begin(); a != attr->attr_end(); a++) {
+            if (attr->is_container(a))
+                write_global_attributes(oss, attr->get_attr_table(a),
+                                        (prefix == "") ? attr->get_name(a)
+                                                       : prefix + string(".") + attr->get_name(a));
+            else {
+                oss << "\n<tr><td align=right valign=top><b>";
+                if (prefix != "")
+                    oss << prefix << "." << attr->get_name(a);
+                else
+                    oss << attr->get_name(a);
+                oss << "</b>:</td>\n";
 
-		int num_attr = attr->get_attr_num(a) - 1;
-		oss << "<td align=left>";
-		for (int i = 0; i < num_attr; ++i)
-		    oss << attr->get_attr(a, i) << ", ";
-		oss << attr->get_attr(a, num_attr) << "<br></td></tr>\n";
-	    }
-	}
+                int num_attr = attr->get_attr_num(a) - 1;
+                oss << "<td align=left>";
+                for (int i = 0; i < num_attr; ++i)
+                    oss << attr->get_attr(a, i) << ", ";
+                oss << attr->get_attr(a, num_attr) << "<br></td></tr>\n";
+            }
+        }
     }
 }
 
 static void
-write_attributes(ostringstream &oss, AttrTable *attr, const string prefix = "")
-{
+write_attributes(ostringstream &oss, AttrTable *attr, const string prefix = "") {
     if (attr) {
-	AttrTable::Attr_iter a;
-	for (a = attr->attr_begin(); a != attr->attr_end(); a++) {
-	    if (attr->is_container(a))
-		write_attributes(oss, attr->get_attr_table(a),
-				 (prefix == "") ? attr->get_name(a)
-				 : prefix + string(".") + attr->get_name(a));
-	    else {
-		if (prefix != "")
-		    oss << prefix << "." << attr->get_name(a);
-		else
-		    oss << attr->get_name(a);
-		oss << ": ";
+        for (auto a = attr->attr_begin(); a != attr->attr_end(); a++) {
+            if (attr->is_container(a)) {
+                write_attributes(oss, attr->get_attr_table(a),
+                                 (prefix == "") ? attr->get_name(a)
+                                                : prefix + string(".") + attr->get_name(a));
+            }
+            else {
+                if (!prefix.empty())
+                    oss << prefix << "." << attr->get_name(a);
+                else
+                    oss << attr->get_name(a);
+                oss << ": ";
 
-		int num_attr = attr->get_attr_num(a) - 1 ;
-		for (int i = 0; i < num_attr; ++i)
-		    oss << attr->get_attr(a, i) << ", ";
-		oss << attr->get_attr(a, num_attr) << "<br>\n";
-	    }
-	}
+                unsigned int num_attr = attr->get_attr_num(a) - 1;
+                for (int i = 0; i < num_attr; ++i)
+                    oss << attr->get_attr(a, i) << ", ";
+                oss << attr->get_attr(a, num_attr) << "<br>\n";
+            }
+        }
     }
 }
 
@@ -226,86 +150,82 @@ write_attributes(ostringstream &oss, AttrTable *attr, const string prefix = "")
     readable form (as an HTML* document).
 */
 static string
-build_global_attributes(DAS &das, DDS &)
-{
+build_global_attributes(DAS &das, DDS &) {
     bool found = false;
     ostringstream ga;
 
     ga << "<h3>Dataset Information</h3>\n<center>\n<table>\n";
 
-    for (AttrTable::Attr_iter p = das.var_begin(); p != das.var_end(); p++) {
-	string name = das.get_name(p);
+    for (auto p = das.var_begin(); p != das.var_end(); p++) {
+        string name = das.get_name(p);
 
-	// I used `name_in_dds' originally, but changed to `name_is_global'
-	// because aliases between groups of attributes can result in
-	// attribute group names which are not in the DDS and are *not*
-	// global attributes. jhrg. 5/22/97
-	if (!name_in_kill_file(name) )
-	{
-	    if( name_is_global(name)) {
-		AttrTable *attr = das.get_table(p);
-		found = true;
-		write_global_attributes(ga, attr, "");
-	    }
-	}
+        // I used `name_in_dds' originally, but changed to `name_is_global'
+        // because aliases between groups of attributes can result in
+        // attribute group names which are not in the DDS and are *not*
+        // global attributes. jhrg. 5/22/97
+        if (!name_in_kill_file(name)) {
+            if (name_is_global(name)) {
+                AttrTable *attr = das.get_table(p);
+                found = true;
+                write_global_attributes(ga, attr, "");
+            }
+        }
     }
 
     ga << "</table>\n</center><p>\n";
 
     if (found)
-	return ga.str();
+        return ga.str();
 
     return "";
 }
 
 static string
-fancy_typename(BaseType *v)
-{
+fancy_typename(BaseType *v) {
     string fancy;
     switch (v->type()) {
-      case dods_byte_c:
-	return "Byte";
-      case dods_int16_c:
-	return "16 bit Integer";
-      case dods_uint16_c:
-	return "16 bit Unsigned integer";
-      case dods_int32_c:
-	return "32 bit Integer";
-      case dods_uint32_c:
-	return "32 bit Unsigned integer";
-      case dods_float32_c:
-	return "32 bit Real";
-      case dods_float64_c:
-	return "64 bit Real";
-      case dods_str_c:
-	return "String";
-      case dods_url_c:
-	return "URL";
-      case dods_array_c: {
-	  ostringstream type;
-	  Array *a = (Array *)v;
-	  type << "Array of " << fancy_typename(a->var()) <<"s ";
-	  for (Array::Dim_iter p = a->dim_begin(); p != a->dim_end(); p++) {
-	      type << "[" << a->dimension_name(p) << " = 0.."
-		   << a->dimension_size(p, false)-1 << "]";
-	  }
-	  return type.str();
-      }
+        case dods_byte_c:
+            return "Byte";
+        case dods_int16_c:
+            return "16 bit Integer";
+        case dods_uint16_c:
+            return "16 bit Unsigned integer";
+        case dods_int32_c:
+            return "32 bit Integer";
+        case dods_uint32_c:
+            return "32 bit Unsigned integer";
+        case dods_float32_c:
+            return "32 bit Real";
+        case dods_float64_c:
+            return "64 bit Real";
+        case dods_str_c:
+            return "String";
+        case dods_url_c:
+            return "URL";
+        case dods_array_c: {
+            ostringstream type;
+            Array *a = (Array *) v;
+            type << "Array of " << fancy_typename(a->var()) << "s ";
+            for (Array::Dim_iter p = a->dim_begin(); p != a->dim_end(); p++) {
+                type << "[" << a->dimension_name(p) << " = 0.."
+                     << a->dimension_size(p, false) - 1 << "]";
+            }
+            return type.str();
+        }
 
-      case dods_structure_c:
-	return "Structure";
-      case dods_sequence_c:
-	return "Sequence";
-      case dods_grid_c:
-	return "Grid";
-      default:
-	return "Unknown";
+        case dods_structure_c:
+            return "Structure";
+        case dods_sequence_c:
+            return "Sequence";
+        case dods_grid_c:
+            return "Grid";
+        default:
+            return "Unknown";
     }
 }
 
 static void
-write_variable(BaseType *btp, DAS &das, ostringstream &vs)
-{
+write_variable(BaseType *btp, DAS &das, ostringstream &vs) {
     vs << "<td align=right valign=top><b>" << btp->name()
        << "</b>:</td>\n"
        << "<td align=left valign=top>" << fancy_typename(btp)
@@ -316,61 +236,59 @@ write_variable(BaseType *btp, DAS &das, ostringstream &vs)
     write_attributes(vs, attr, "");
 
     switch (btp->type()) {
-      case dods_byte_c:
-      case dods_int16_c:
-      case dods_uint16_c:
-      case dods_int32_c:
-      case dods_uint32_c:
-      case dods_float32_c:
-      case dods_float64_c:
-      case dods_str_c:
-      case dods_url_c:
-      case dods_array_c:
-	vs << "</td>\n";
-	break;
+        case dods_byte_c:
+        case dods_int16_c:
+        case dods_uint16_c:
+        case dods_int32_c:
+        case dods_uint32_c:
+        case dods_float32_c:
+        case dods_float64_c:
+        case dods_str_c:
+        case dods_url_c:
+        case dods_array_c:
+            vs << "</td>\n";
+            break;
 
-      case dods_structure_c: {
-	vs << "<table>\n";
-	Structure *sp = dynamic_cast<Structure *>(btp);
-	for (Constructor::Vars_iter p = sp->var_begin(); p != sp->var_end(); p++)
-	{
-	    vs << "<tr>";
-	    write_variable((*p), das, vs);
-	    vs << "</tr>";
-	}
-	vs << "</table>\n";
-	break;
-      }
+        case dods_structure_c: {
+            vs << "<table>\n";
+            Structure *sp = dynamic_cast<Structure *>(btp);
+            for (Constructor::Vars_iter p = sp->var_begin(); p != sp->var_end(); p++) {
+                vs << "<tr>";
+                write_variable((*p), das, vs);
+                vs << "</tr>";
+            }
+            vs << "</table>\n";
+            break;
+        }
 
-      case dods_sequence_c: {
-	vs << "<table>\n";
-	Sequence *sp = dynamic_cast<Sequence *>(btp);
-	for (Constructor::Vars_iter p = sp->var_begin(); p != sp->var_end(); p++)
-	{
-	    vs << "<tr>";
-	    write_variable((*p), das, vs);
-	    vs << "</tr>";
-	}
-	vs << "</table>\n";
-	break;
-      }
+        case dods_sequence_c: {
+            vs << "<table>\n";
+            Sequence *sp = dynamic_cast<Sequence *>(btp);
+            for (Constructor::Vars_iter p = sp->var_begin(); p != sp->var_end(); p++) {
+                vs << "<tr>";
+                write_variable((*p), das, vs);
+                vs << "</tr>";
+            }
+            vs << "</table>\n";
+            break;
+        }
 
-      case dods_grid_c: {
-	  vs << "<table>\n";
-	  Grid *gp = dynamic_cast<Grid *>(btp);
-	  write_variable(gp->array_var(), das, vs);
-	  Grid::Map_iter p;
-	  for (p = gp->map_begin(); p != gp->map_end(); p++) {
-	      vs << "<tr>";
-	      write_variable((*p), das, vs);
-	      vs << "</tr>";
-	  }
-	  vs << "</table>\n";
-	  break;
-      }
+        case dods_grid_c: {
+            vs << "<table>\n";
+            Grid *gp = dynamic_cast<Grid *>(btp);
+            write_variable(gp->array_var(), das, vs);
+            Grid::Map_iter p;
+            for (p = gp->map_begin(); p != gp->map_end(); p++) {
+                vs << "<tr>";
+                write_variable((*p), das, vs);
+                vs << "</tr>";
+            }
+            vs << "</table>\n";
+            break;
+        }
 
-      default:
-	throw InternalErr(__FILE__, __LINE__, "Unknown type");
+        default:
+            throw InternalErr(__FILE__, __LINE__, "Unknown type");
     }
 }
 
@@ -383,16 +301,15 @@ write_variable(BaseType *btp, DAS &das, ostringstream &vs)
 */
 
 static string
-build_variable_summaries(DAS &das, DDS &dds)
-{
+build_variable_summaries(DAS &das, DDS &dds) {
     ostringstream vs;
     vs << "<h3>Variables in this Dataset</h3>\n<center>\n<table>\n";
     //    vs << "<tr><th>Variable</th><th>Information</th></tr>\n";
 
     for (DDS::Vars_iter p = dds.var_begin(); p != dds.var_end(); p++) {
-	vs << "<tr>";
-	write_variable((*p), das, vs);
-	vs << "</tr>";
+        vs << "<tr>";
+        write_variable((*p), das, vs);
+        vs << "</tr>";
     }
 
     vs << "</table>\n</center><p>\n";
@@ -401,14 +318,13 @@ build_variable_summaries(DAS &das, DDS &dds)
 }
 
 void
-html_header( ostream &strm )
-{
-    strm << "HTTP/1.0 200 OK\r\n" ;
-    strm << "XDODS-Server: " << PACKAGE_VERSION << "\r\n" ;
-    strm << "XDAP: " << DAP_PROTOCOL_VERSION << "\r\n" ;
-    strm << "Content-type: text/html\r\n" ;
-    strm << "Content-Description: dods_description\r\n" ;
-    strm << "\r\n" ;	// MIME header ends with a blank line
+html_header(ostream &strm) {
+    strm << "HTTP/1.0 200 OK\r\n";
+    strm << "XDODS-Server: " << PACKAGE_VERSION << "\r\n";
+    strm << "XDAP: " << DAP_PROTOCOL_VERSION << "\r\n";
+    strm << "Content-type: text/html\r\n";
+    strm << "Content-Description: dods_description\r\n";
+    strm << "\r\n";    // MIME header ends with a blank line
 }
 
 /** Build an HTML page that summarizes the information held int eh DDS/DAS.
@@ -429,36 +345,34 @@ html_header( ostream &strm )
     @param server_name Use this name to find server-specific info. */
 void
 write_usage_response(ostream &strm, DDS &dds, DAS &das, const string &dataset_name, const string &server_name,
-                     bool httpheader)
-{
-        // This will require some hacking in libdap; maybe that code should
-        // move here? jhrg
-        string user_html = get_user_supplied_docs(dataset_name, server_name);
+                     bool httpheader) {
+    // This will require some hacking in libdap; maybe that code should
+    // move here? jhrg
+    string user_html = get_user_supplied_docs(dataset_name, server_name);
 
-        string global_attrs = build_global_attributes(das, dds);
+    string global_attrs = build_global_attributes(das, dds);
 
-        string variable_sum = build_variable_summaries(das, dds);
+    string variable_sum = build_variable_summaries(das, dds);
 
-        // Write out the HTML document.
+    // Write out the HTML document.
 
-	if( httpheader )
-	    html_header( strm );
+    if (httpheader)
+        html_header(strm);
 
-	strm << "<html><head><title>Dataset Information</title></head>"
-	     << "\n" << "<body>" << "\n" ;
+    strm << "<html><head><title>Dataset Information</title></head>"
+         << "\n" << "<body>" << "\n";
 
-        if (global_attrs.size())
-	{
-	    strm << global_attrs.c_str() << "\n" << "<hr>" << "\n" ;
-        }
+    if (global_attrs.size()) {
+        strm << global_attrs.c_str() << "\n" << "<hr>" << "\n";
+    }
 
-        strm << variable_sum.c_str() << "\n" ;
+    strm << variable_sum.c_str() << "\n";
 
-        strm << "<hr>\n" ;
+    strm << "<hr>\n";
 
-        strm << user_html.c_str() << "\n" ;
+    strm << user_html.c_str() << "\n";
 
-        strm << "</body>\n</html>\n" ;
+    strm << "</body>\n</html>\n";
 }
 
 /** Look in the CGI directory (given by \c cgi) for a per-cgi HTML* file.
@@ -484,8 +398,7 @@ write_usage_response(ostream &strm, DDS &dds, DAS &das, const string &dataset_na
     that don't exist are treated as `empty'.  */
 
 string
-get_user_supplied_docs(string name, string cgi)
-{
+get_user_supplied_docs(string name, string cgi) {
     char tmp[256];
     ostringstream oss;
     ifstream ifs((cgi + ".html").c_str());

--- a/modules/usage/usage.cc
+++ b/modules/usage/usage.cc
@@ -38,13 +38,10 @@
 
 #include "config.h"
 
-#include <cstdio>
-
 #include <iostream>
 #include <fstream>
 #include <string>
 #include <sstream>
-// #include <thread>
 
 #include <libdap/Array.h>
 #include <libdap/Structure.h>
@@ -53,7 +50,6 @@
 #include <libdap/Ancillary.h>
 #include <libdap/DAS.h>
 #include <libdap/util.h>
-// #include <libdap/Error.h>
 
 #include "BESRegex.h"
 
@@ -86,7 +82,7 @@ name_is_global(string &name) {
 // understand. So, I'm keeping this as two separate functions even though
 // there's some duplication... 3/27/2002 jhrg
 static void
-write_global_attributes(ostringstream &oss, AttrTable *attr, const string prefix = "") {
+write_global_attributes(ostringstream &oss, AttrTable *attr, const string &prefix = "") {
     if (attr) {
         AttrTable::Attr_iter a;
         for (a = attr->attr_begin(); a != attr->attr_end(); a++) {
@@ -113,7 +109,7 @@ write_global_attributes(ostringstream &oss, AttrTable *attr, const string prefix
 }
 
 static void
-write_attributes(ostringstream &oss, AttrTable *attr, const string prefix = "") {
+write_attributes(ostringstream &oss, AttrTable *attr, const string &prefix = "") {
     if (attr) {
         for (auto a = attr->attr_begin(); a != attr->attr_end(); a++) {
             if (attr->is_container(a)) {
@@ -150,7 +146,7 @@ write_attributes(ostringstream &oss, AttrTable *attr, const string prefix = "") 
     readable form (as an HTML* document).
 */
 static string
-build_global_attributes(DAS &das, DDS &) {
+build_global_attributes(DAS &das, const DDS &) {
     bool found = false;
     ostringstream ga;
 
@@ -376,10 +372,10 @@ write_usage_response(ostream &strm, DDS &dds, DAS &das, const string &dataset_na
 }
 
 /** Look in the CGI directory (given by \c cgi) for a per-cgi HTML* file.
-    Also look for a dataset-specific HTML* document. Catenate the documents
+    Also look for a dataset-specific HTML* document. Concatenate the documents
     and return them in a single String variable.
 
-    Similarly, to locate the dataset-specific HTML* file it catenates `.html'
+    Similarly, to locate the dataset-specific HTML* file it concatenates `.html'
     to \c name, where \c name is the name of the dataset. If the filename
     part of \c name is of the form [A-Za-z]+[0-9]*.* then this function also
     looks for a file whose name is [A-Za-z]+.html For example, if \c name is
@@ -394,11 +390,11 @@ write_usage_response(ostream &strm, DDS &dds, DAS &das, const string &dataset_na
     @brief Look for the user supplied CGI- and dataset-specific HTML*
     documents.
 
-    @return A String which contains these two documents catenated. Documents
+    @return A String which contains these two documents concatenated. Documents
     that don't exist are treated as `empty'.  */
 
 string
-get_user_supplied_docs(string name, string cgi) {
+get_user_supplied_docs(const string &name, const string &cgi) {
     char tmp[256];
     ostringstream oss;
     ifstream ifs((cgi + ".html").c_str());

--- a/modules/usage/usage.h
+++ b/modules/usage/usage.h
@@ -22,12 +22,10 @@
 //
 // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
 
-#include <libdap/Error.h>
-
 namespace dap_usage {
 
 void write_usage_response(std::ostream &strm, libdap::DDS &dds, libdap::DAS &das, const std::string &dataset_name = "",
-    const std::string &server_name = "", bool httpheader = true) throw (libdap::Error);
+    const std::string &server_name = "", bool httpheader = true);
 
 void html_header(std::ostream &strm);
 

--- a/modules/usage/usage.h
+++ b/modules/usage/usage.h
@@ -29,7 +29,7 @@ void write_usage_response(std::ostream &strm, libdap::DDS &dds, libdap::DAS &das
 
 void html_header(std::ostream &strm);
 
-std::string get_user_supplied_docs(std::string name, std::string cgi);
+std::string get_user_supplied_docs(const std::string &name, const std::string &cgi);
 
 }
 


### PR DESCRIPTION
This completes the removal of any use of pthread in the BES
    
There are some source files in old or unused directories
that still have the include, and there one place in BESInterface
where it's part of a large comment. But pthreads are out AFAIK.
