### PR TITLE
Segfault fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,7 +82,7 @@ dnl it's actually used - not all the source files include config.h. jhrg 1/30/23
 
 AM_CONDITIONAL([BES_DEVELOPER], [test "x$enable_developer" = "xyes"])
 AM_COND_IF([BES_DEVELOPER],
-    [cxx_debug_flags="-g3 -O0 -fno-inline -Wall"
+    [cxx_debug_flags="-g3 -Og -Wall"
       AC_MSG_NOTICE([Developer Mode is enabled.]) ],
     [AC_DEFINE([NDEBUG], [1], [Define this to suppress assert() statements.])
       AC_MSG_NOTICE([Developer Mode is disabled.])])

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,7 @@ dnl will override these values
 cxx_debug_flags=
 
 dnl Removed "-g -O2" jhrg 2/8/22
+dnl Changed -O2 to -Og for --enable-developer jhrg 6/16/23
 
 AC_ARG_ENABLE([developer],
     [AS_HELP_STRING([--enable-developer],

--- a/http/CredentialsManager.h
+++ b/http/CredentialsManager.h
@@ -55,14 +55,10 @@ private:
 
     CredentialsManager() = default;   // only called here to build the singleton
     static void initialize_instance();
-
     static void delete_instance();
 
     AccessCredentials *load_credentials_from_env();
 
-#if 0
-    void load_ngap_s3_credentials();
-#endif
 public:
     static CredentialsManager *theMngr;
 

--- a/http/CredentialsManager.h
+++ b/http/CredentialsManager.h
@@ -28,15 +28,16 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 #include <mutex>
+
+#include "url_impl.h"
+#include "AccessCredentials.h"
 
 // These are the names of the bes keys used to configure the handler.
 #define CATALOG_MANAGER_CREDENTIALS "CredentialsManager.config"
 
 namespace http {
-
-class AccessCredentials;
-class url;
 
 class CredentialsManager {
 public:
@@ -50,31 +51,35 @@ private:
     std::recursive_mutex d_lock_mutex{};
 
     bool ngaps3CredentialsLoaded = false;
-    std::map<std::string, AccessCredentials *, std::less<>> creds{};
-
-    static std::unique_ptr<CredentialsManager> d_instance;
-    static std::once_flag d_init_once;
+    std::map<std::string, AccessCredentials *> creds;
 
     CredentialsManager() = default;   // only called here to build the singleton
+    static void initialize_instance();
 
-    void load_credentials();
-    static AccessCredentials *load_credentials_from_env();
+    static void delete_instance();
 
-    friend class CredentialsManagerTest;
-    friend class CurlUtilsTest;     // so that a test can call load_credentials() jhrg 5/16/23
+    AccessCredentials *load_credentials_from_env();
 
+#if 0
+    void load_ngap_s3_credentials();
+#endif
 public:
+    static CredentialsManager *theMngr;
+
     ~CredentialsManager();
 
     static CredentialsManager *theCM();
 
     void add(const std::string &url, AccessCredentials *ac);
-    AccessCredentials *get(const std::shared_ptr<http::url> &url);
+
+    void load_credentials();
 
     void clear() {
         creds.clear();
         ngaps3CredentialsLoaded = false;
     }
+
+    AccessCredentials *get(const std::shared_ptr<http::url> &url);
 
     size_t size() const {
         return creds.size();
@@ -87,4 +92,4 @@ public:
 
 }   // namespace http
 
-#endif // HYRAX_CREDENTIALSMANAGER_H
+#endif //HYRAX_CREDENTIALSMANAGER_H

--- a/http/tests/Makefile.am
+++ b/http/tests/Makefile.am
@@ -62,7 +62,6 @@ endif
 clean-local:
 	test ! -f '$(TESTSUITE)' || $(SHELL) '$(TESTSUITE)' --clean
 	test ! -f '$(TESTSUITE_S3)' || $(SHELL) '$(TESTSUITE_S3)' --clean
-	-curl -s http://localhost:8000/exit >/dev/null
 	-rm remote_resource_tester
 
 AUTOTEST = $(AUTOM4TE) --language=autotest

--- a/modules/s3_reader/S3Module.cc
+++ b/modules/s3_reader/S3Module.cc
@@ -56,6 +56,11 @@ void S3Module::terminate(const string &modname)
 {
     BESDEBUG(modname, "Cleaning s3 module " << modname << endl);
 
+    BESRequestHandler *rh = BESRequestHandlerList::TheList()->remove_handler(modname);
+    delete rh;
+
+    BESContainerStorageList::TheList()->deref_persistence(modname);
+
     BESDEBUG(modname, "Done Cleaning s3 module " << modname << endl);
 }
 


### PR DESCRIPTION
This branch contains a fix for the segmentation fault on exit we see from the CredentialsManager.

The 'fix' was to back the unique_ptr singleton class out and return to the 'at_exit' version.
I reverted just the Cred Mngr code to the version from 5/18/23 (commit 2d61577d) except
that I removed the load_ngap_s3_credentials() call and the NgapS3Credentials.h header
include.