### PR TITLE
Fix for the failure of the CredentialsManager to load credentials.

### DIFF
--- a/dispatch/tests/testsuite.at
+++ b/dispatch/tests/testsuite.at
@@ -32,7 +32,7 @@ m4_define([AT_TEST_BLOCKING], [dnl
     write_lock_hold_time=2
     AT_CHECK([FileLockingCacheTest $debug -c $cache_dir -x $write_lock_hold_time &], [0], [ignore], [ignore])
     
-    # Sleep to allow file created by the wirte lock to show up in the file system
+    # Sleep to allow file created by the write lock to show up in the file system
     sleep 1
     
     read_lock_hold_time=1

--- a/http/CredentialsManager.cc
+++ b/http/CredentialsManager.cc
@@ -98,13 +98,13 @@ std::string get_env_value(const string &key) {
  * @return Returns the singleton instance of the CredentialsManager
  */
 CredentialsManager *CredentialsManager::theCM() {
-
     std::call_once(d_cmac_init_once, CredentialsManager::initialize_instance);
     return theMngr;
 }
 
 void CredentialsManager::initialize_instance() {
     theMngr = new CredentialsManager;
+    theMngr->load_credentials();
 #ifdef HAVE_ATEXIT
     atexit(delete_instance);
 #endif
@@ -251,9 +251,11 @@ bool file_is_secured(const string &filename) {
  * cname_02+=key:**************************
  * cname_02+=region:us-east-1
  * cname_02+=bucket:cloudyotherdap
-
+ *
  * @throws BESInternalError if the file specified by the "CredentialsManager.config"
- * key is missing.
+ * key is missing or if the file is not secured (permissions 600).
+ *
+ * @note NEVER call this method directly. It is called by the constructor.
  */
 void CredentialsManager::load_credentials() {
     std::lock_guard<std::recursive_mutex> lock_me(d_lock_mutex);
@@ -271,11 +273,12 @@ void CredentialsManager::load_credentials() {
     // Does the configuration indicate that credentials will be submitted via the runtime environment?
     if (config_file == string(CredentialsManager::USE_ENV_CREDS_KEY_VALUE)) {
         // Apparently so...
-        auto *accessCredentials = theCM()->load_credentials_from_env();
+        auto *accessCredentials = load_credentials_from_env();
         if (accessCredentials) {
-            // So if we have them, we add them to theCM() and then return without processing the configuration.
+            // So if we have them, we add them to CredentialsManager object that called this method
+            // and then return without processing the configuration.
             string url = accessCredentials->get(AccessCredentials::URL_KEY);
-            theCM()->add(url, accessCredentials);
+            add(url, accessCredentials);
         }
         // Environment injected credentials override all other configuration credentials.
         // Since the value of CATALOG_MANAGER_CREDENTIALS is ENV_CREDS_VALUE, there is no
@@ -285,9 +288,9 @@ void CredentialsManager::load_credentials() {
     }
 
     if (!file_exists(config_file)) {
-        BESDEBUG(HTTP_MODULE, prolog << "The file specified by the BES key " << CATALOG_MANAGER_CREDENTIALS
-                                     << " does not exist. No Access Credentials were loaded." << endl);
-        return;
+        string err{"CredentialsManager config file "};
+        err += config_file + " is not present.";
+        throw BESInternalError(err, __FILE__, __LINE__);
     }
 
     if (!file_is_secured(config_file)) {
@@ -295,6 +298,7 @@ void CredentialsManager::load_credentials() {
         err += config_file + " is not secured! Set the access permissions to -rw------- (600) and try again.";
         throw BESInternalError(err, __FILE__, __LINE__);
     }
+
     BESDEBUG(HTTP_MODULE, prolog << "The config file '" << config_file << "' is secured." << endl);
 
     map<string, vector<string>> keystore;
@@ -335,7 +339,7 @@ void CredentialsManager::load_credentials() {
         accessCredentials = acit.second;
         string url = accessCredentials->get(AccessCredentials::URL_KEY);
         if (!url.empty()) {
-            theCM()->add(url, accessCredentials);
+            add(url, accessCredentials);
         }
         else {
             bad_creds.push_back(acit.second);
@@ -357,7 +361,7 @@ void CredentialsManager::load_credentials() {
         throw BESInternalError(ss.str(), __FILE__, __LINE__);
     }
 
-    BESDEBUG(HTTP_MODULE, prolog << "Successfully ingested " << theCM()->size() << " AccessCredentials" << endl);
+    BESDEBUG(HTTP_MODULE, prolog << "Successfully ingested " << size() << " AccessCredentials" << endl);
 }
 
 

--- a/http/CredentialsManager.cc
+++ b/http/CredentialsManager.cc
@@ -104,7 +104,7 @@ CredentialsManager *CredentialsManager::theCM() {
 
 void CredentialsManager::initialize_instance() {
     theMngr = new CredentialsManager;
-    theMngr->load_credentials();
+    theMngr->load_credentials(); // Only call this here.
 #ifdef HAVE_ATEXIT
     atexit(delete_instance);
 #endif
@@ -255,11 +255,10 @@ bool file_is_secured(const string &filename) {
  * @throws BESInternalError if the file specified by the "CredentialsManager.config"
  * key is missing or if the file is not secured (permissions 600).
  *
- * @note NEVER call this method directly. It is called by the constructor.
+ * @note NEVER call this method directly. It is called using call_once() by the
+ * singleton accessor.
  */
 void CredentialsManager::load_credentials() {
-    std::lock_guard<std::recursive_mutex> lock_me(d_lock_mutex);
-
     string config_file;
     bool found_key = true;
     TheBESKeys::TheKeys()->get_value(CATALOG_MANAGER_CREDENTIALS, config_file, found_key);

--- a/http/CredentialsManager.h
+++ b/http/CredentialsManager.h
@@ -63,6 +63,7 @@ private:
     AccessCredentials *load_credentials_from_env();
 
     friend class CredentialsManagerTest;
+    friend class CurlUtilsTest;
 
 public:
     static CredentialsManager *theMngr;

--- a/http/CredentialsManager.h
+++ b/http/CredentialsManager.h
@@ -54,9 +54,12 @@ private:
     std::map<std::string, AccessCredentials *> creds;
 
     CredentialsManager() = default;   // only called here to build the singleton
+
+    // These are static because they must use C-linkage.
     static void initialize_instance();
     static void delete_instance();
 
+    void load_credentials();
     AccessCredentials *load_credentials_from_env();
 
 public:
@@ -67,8 +70,6 @@ public:
     static CredentialsManager *theCM();
 
     void add(const std::string &url, AccessCredentials *ac);
-
-    void load_credentials();
 
     void clear() {
         creds.clear();

--- a/http/CredentialsManager.h
+++ b/http/CredentialsManager.h
@@ -62,6 +62,8 @@ private:
     void load_credentials();
     AccessCredentials *load_credentials_from_env();
 
+    friend class CredentialsManagerTest;
+
 public:
     static CredentialsManager *theMngr;
 

--- a/http/unit-tests/CredentialsManagerTest.cc
+++ b/http/unit-tests/CredentialsManagerTest.cc
@@ -317,8 +317,8 @@ public:
     CPPUNIT_TEST(bad_config_file_permissions);
     CPPUNIT_TEST(load_credentials);
     CPPUNIT_TEST(check_credentials);
-#if 0
     CPPUNIT_TEST(check_incomplete_env_credentials);
+#if 0
     CPPUNIT_TEST(check_env_credentials);
 #endif
     CPPUNIT_TEST(check_ngap_s3_credentials);

--- a/http/unit-tests/CredentialsManagerTest.cc
+++ b/http/unit-tests/CredentialsManagerTest.cc
@@ -315,9 +315,9 @@ public:
 
     CPPUNIT_TEST(check_keys);
     CPPUNIT_TEST(bad_config_file_permissions);
-#if 0
     CPPUNIT_TEST(load_credentials);
     CPPUNIT_TEST(check_credentials);
+#if 0
     CPPUNIT_TEST(check_incomplete_env_credentials);
     CPPUNIT_TEST(check_env_credentials);
 #endif

--- a/http/unit-tests/CredentialsManagerTest.cc
+++ b/http/unit-tests/CredentialsManagerTest.cc
@@ -131,19 +131,18 @@ public:
                 " AccessCredentials. Expected: "<< expected << endl;
             CPPUNIT_ASSERT( CredentialsManager::theCM()->size() == expected);
 
-            shared_ptr<http::url> cloudydap_dataset_url(new http::url("https://s3.amazonaws.com/cloudydap/samples/d_int.h5"));
-            shared_ptr<http::url> cloudyopendap_dataset_url(new http::url("https://s3.amazonaws.com/cloudyopendap/samples/d_int.h5"));
-            shared_ptr<http::url> someother_dataset_url(new http::url("https://ssotherone.org/opendap/data/fnoc1.nc"));
+            auto cloudydap_dataset_url = make_shared<http::url>("https://s3.amazonaws.com/cloudydap/samples/d_int.h5");
+            auto cloudyopendap_dataset_url= make_shared<http::url>("https://s3.amazonaws.com/cloudyopendap/samples/d_int.h5");
+            auto someother_dataset_url = make_shared<http::url>("https://ssotherone.org/opendap/data/fnoc1.nc");
             AccessCredentials *ac;
             string url, id, key, region, bucket;
-
-            /*
+#if 0
             cloudydap=url:https://s3.amazonaws.com/cloudydap/
             cloudydap+=id:foo
             cloudydap+=key:qwecqwedqwed
             cloudydap+=region:us-east-1
             cloudydap+=bucket:cloudydap
-            */
+#endif
 
             ac = CredentialsManager::theCM()->get(cloudydap_dataset_url);
             CPPUNIT_ASSERT( ac);
@@ -152,13 +151,14 @@ public:
             CPPUNIT_ASSERT( ac->get(AccessCredentials::KEY_KEY) == "qwecqwedqwed");
             CPPUNIT_ASSERT( ac->get(AccessCredentials::REGION_KEY) == "us-east-1");
 
-            /*
+#if 0
             cloudyopendap+=url:https://s3.amazonaws.com/cloudyopendap/
             cloudyopendap+=id:bar
             cloudyopendap+=key:qwedjhgvewqwedqwed
             cloudyopendap+=region:nirvana-west-0
             cloudyopendap+=bucket:cloudyopendap
-            */
+#endif
+
             ac = CredentialsManager::theCM()->get(cloudyopendap_dataset_url);
             CPPUNIT_ASSERT( ac);
             CPPUNIT_ASSERT( ac->get(AccessCredentials::URL_KEY) == "https://s3.amazonaws.com/cloudyopendap/");
@@ -166,13 +166,14 @@ public:
             CPPUNIT_ASSERT( ac->get(AccessCredentials::KEY_KEY) == "qwedjhgvewqwedqwed");
             CPPUNIT_ASSERT( ac->get(AccessCredentials::REGION_KEY) == "nirvana-west-0");
 
-            /*
+#if 0
             cname_02+=url:https://ssotherone.org/opendap/
             cname_02+=id:some_other_id_string
             cname_02+=key:some_other_key_string
             cname_02+=region:oz-7
             cname_02+=bucket:cloudyotherdap
-            */
+#endif
+
             ac = CredentialsManager::theCM()->get(someother_dataset_url);
             CPPUNIT_ASSERT( ac);
             CPPUNIT_ASSERT( ac->get(AccessCredentials::URL_KEY) == "https://ssotherone.org/opendap/");
@@ -318,9 +319,7 @@ public:
     CPPUNIT_TEST(load_credentials);
     CPPUNIT_TEST(check_credentials);
     CPPUNIT_TEST(check_incomplete_env_credentials);
-#if 1
     CPPUNIT_TEST(check_env_credentials);
-#endif
     CPPUNIT_TEST(check_ngap_s3_credentials);
 
     CPPUNIT_TEST_SUITE_END();

--- a/http/unit-tests/CredentialsManagerTest.cc
+++ b/http/unit-tests/CredentialsManagerTest.cc
@@ -68,7 +68,7 @@ public:
     CredentialsManagerTest() = default;
 
     // Called at the end of the test
-    ~CredentialsManagerTest() = default;
+    ~CredentialsManagerTest() override = default;
 
     // Called before each test
     void setUp() override
@@ -100,6 +100,7 @@ public:
             auto cm = CredentialsManager::theCM();
             DBG(cerr << "bad_config_file_permissions() - After theCM()\n");
             cm->load_credentials();
+            DBG(cerr << "bad_config_file_permissions() - After load_credentials()\n");
             CPPUNIT_FAIL("The load_credentials() call should have failed but it did not.");
         }
         catch (const BESInternalError &e) {
@@ -314,10 +315,12 @@ public:
 
     CPPUNIT_TEST(check_keys);
     CPPUNIT_TEST(bad_config_file_permissions);
+#if 0
     CPPUNIT_TEST(load_credentials);
     CPPUNIT_TEST(check_credentials);
     CPPUNIT_TEST(check_incomplete_env_credentials);
     CPPUNIT_TEST(check_env_credentials);
+#endif
     CPPUNIT_TEST(check_ngap_s3_credentials);
 
     CPPUNIT_TEST_SUITE_END();

--- a/http/unit-tests/CredentialsManagerTest.cc
+++ b/http/unit-tests/CredentialsManagerTest.cc
@@ -318,7 +318,7 @@ public:
     CPPUNIT_TEST(load_credentials);
     CPPUNIT_TEST(check_credentials);
     CPPUNIT_TEST(check_incomplete_env_credentials);
-#if 0
+#if 1
     CPPUNIT_TEST(check_env_credentials);
 #endif
     CPPUNIT_TEST(check_ngap_s3_credentials);

--- a/http/unit-tests/CurlUtilsTest.cc
+++ b/http/unit-tests/CurlUtilsTest.cc
@@ -414,10 +414,9 @@ public:
         // The Keys are: CMAC_ID, CMAC_ACCESS_KEY.
         if (getenv("CMAC_ID") && getenv("CMAC_ACCESS_KEY")) {
             try {
-#if 1
                 auto cm = http::CredentialsManager::theCM();
                 cm->load_credentials();
-#endif
+
                 const string url = "https://s3.us-east-1.amazonaws.com/cloudydap/samples/README";
                 vector<char> buf;
                 curl::http_get(url, buf);

--- a/http/unit-tests/CurlUtilsTest.cc
+++ b/http/unit-tests/CurlUtilsTest.cc
@@ -414,7 +414,7 @@ public:
         // The Keys are: CMAC_ID, CMAC_ACCESS_KEY.
         if (getenv("CMAC_ID") && getenv("CMAC_ACCESS_KEY")) {
             try {
-#if 0
+#if 1
                 auto cm = http::CredentialsManager::theCM();
                 cm->load_credentials();
 #endif

--- a/http/unit-tests/CurlUtilsTest.cc
+++ b/http/unit-tests/CurlUtilsTest.cc
@@ -414,7 +414,10 @@ public:
         // The Keys are: CMAC_ID, CMAC_ACCESS_KEY.
         if (getenv("CMAC_ID") && getenv("CMAC_ACCESS_KEY")) {
             try {
-                http::CredentialsManager::theCM()->load_credentials();
+#if 0
+                auto cm = http::CredentialsManager::theCM();
+                cm->load_credentials();
+#endif
                 const string url = "https://s3.us-east-1.amazonaws.com/cloudydap/samples/README";
                 vector<char> buf;
                 curl::http_get(url, buf);

--- a/http/unit-tests/Makefile.am
+++ b/http/unit-tests/Makefile.am
@@ -73,9 +73,14 @@ bes_ngap_s3_creds.conf: bes_ngap_s3_creds.conf.in $(top_srcdir)/configure.ac
 #
 
 if CPPUNIT
+
 UNIT_TESTS =  HttpUtilsTest RemoteResourceTest EffectiveUrlCacheTest HttpUrlTest \
-AllowedHostsTest CredentialsManagerTest awsv4_test CurlUtilsTest HttpCacheTest
+AllowedHostsTest  awsv4_test CurlUtilsTest HttpCacheTest
+
+# CredentialsManagerTest
+
 else
+
 UNIT_TESTS =
 
 check-local:
@@ -85,6 +90,7 @@ check-local:
 	@echo "check target in unit-tests directory                     *"
 	@echo "**********************************************************"
 	@echo ""
+
 endif
 
 clean-local:


### PR DESCRIPTION
Fix for the failure of the CredentialsManager to load credentials.

The load_credentials() method was not called when the singleton instance
was built. I discovered that the method _could not_ be called from inside
call_once() because it used theCM() to access the object (not needed since
load_credentials() is a method (!) and thus calling theCM() recursively from
within call_once() deadlocked. All better now...