### PR TITLE
Removed exceptions thrown in CredentialsManager::load_credemtials().

### DIFF
--- a/http/CredentialsManager.cc
+++ b/http/CredentialsManager.cc
@@ -37,6 +37,7 @@
 #include "kvp_utils.h"
 #include "BESInternalError.h"
 #include "BESDebug.h"
+#include "BESLog.h"
 #include "HttpNames.h"
 
 #include "CredentialsManager.h"
@@ -287,15 +288,21 @@ void CredentialsManager::load_credentials() {
     }
 
     if (!file_exists(config_file)) {
-        string err{"CredentialsManager config file "};
-        err += config_file + " is not present.";
-        throw BESInternalError(err, __FILE__, __LINE__);
+        string err{prolog + "CredentialsManager config file "};
+        err += config_file + " was specified but is not present.";
+        ERROR_LOG(err);
+        BESDEBUG(HTTP_MODULE,err);
+        // throw BESInternalError(err, __FILE__, __LINE__);
+        return;
     }
 
     if (!file_is_secured(config_file)) {
-        string err{"CredentialsManager config file "};
+        string err{prolog + "CredentialsManager config file "};
         err += config_file + " is not secured! Set the access permissions to -rw------- (600) and try again.";
-        throw BESInternalError(err, __FILE__, __LINE__);
+        ERROR_LOG(err);
+        BESDEBUG(HTTP_MODULE,err);
+        // throw BESInternalError(err, __FILE__, __LINE__);
+        return;
     }
 
     BESDEBUG(HTTP_MODULE, prolog << "The config file '" << config_file << "' is secured." << endl);
@@ -380,6 +387,7 @@ AccessCredentials *CredentialsManager::load_credentials_from_env() {
     string env_region{get_env_value(CredentialsManager::ENV_REGION_KEY)};
     string env_url{get_env_value(CredentialsManager::ENV_URL_KEY)};
 
+    // evaluates to true iff none of the strings are empty. - ndp 08/07/23
     if (!(env_url.empty() || env_id.empty() || env_access_key.empty() || env_region.empty())) {
         auto ac = make_unique<AccessCredentials>();
         ac->add(AccessCredentials::URL_KEY, env_url);
@@ -388,7 +396,6 @@ AccessCredentials *CredentialsManager::load_credentials_from_env() {
         ac->add(AccessCredentials::REGION_KEY, env_region);
         return ac.release();
     }
-
     return nullptr;
 }
 

--- a/http/CredentialsManager.cc
+++ b/http/CredentialsManager.cc
@@ -292,7 +292,6 @@ void CredentialsManager::load_credentials() {
         err += config_file + " was specified but is not present.";
         ERROR_LOG(err);
         BESDEBUG(HTTP_MODULE,err);
-        // throw BESInternalError(err, __FILE__, __LINE__);
         return;
     }
 
@@ -301,7 +300,6 @@ void CredentialsManager::load_credentials() {
         err += config_file + " is not secured! Set the access permissions to -rw------- (600) and try again.";
         ERROR_LOG(err);
         BESDEBUG(HTTP_MODULE,err);
-        // throw BESInternalError(err, __FILE__, __LINE__);
         return;
     }
 
@@ -353,20 +351,19 @@ void CredentialsManager::load_credentials() {
     }
 
     if (!bad_creds.empty()) {
-        stringstream ss;
-
-        ss << "Encountered " << bad_creds.size() << " AccessCredentials "
+        stringstream err;
+        err << "Encountered " << bad_creds.size() << " AccessCredentials "
            << " definitions missing an associated URL. offenders: ";
 
         for (auto &bc: bad_creds) {
-            ss << bc->name() << "  ";
+            err << bc->name() << "  ";
             credential_sets.erase(bc->name());
             delete bc;
         }
-
-        throw BESInternalError(ss.str(), __FILE__, __LINE__);
+        ERROR_LOG(err.str());
+        BESDEBUG(HTTP_MODULE,err.str());
+        return;
     }
-
     BESDEBUG(HTTP_MODULE, prolog << "Successfully ingested " << size() << " AccessCredentials" << endl);
 }
 

--- a/http/CredentialsManager.config
+++ b/http/CredentialsManager.config
@@ -9,7 +9,7 @@
 # five strings together.
 #
 # cloudydap = url:https://s3.amazonaws.com/cloudydap/
-# cloudydap += id:foo
-# cloudydap += key:qwecqwedqwed
+# cloudydap += id:SOME_VALID_ID
+# cloudydap += key:SOME_VALID_KEY
 # cloudydap += region:us-east-1
 # cloudydap += bucket:cloudydap


### PR DESCRIPTION
Removed exceptions thrown in `CredentialsManager::load_credentials()` because `load_credentials() `is called from inside a `std::call_once()` and throwing exceptions in there is a bad bad plan. This was making many bad things happen.
In particular, the no more curl handles business.

Instead of throwing the exception I just write the message to the `ERROR_LOG` and to `BESDEBUG`. Which will only happen one time.
