### PR TITLE
Max Variable Size Checking

### DIFF
--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -288,12 +288,11 @@ uint64_t process_variable(BaseType *var, const uint64_t &max_var_size, std::unor
         uint64_t vsize = var->width_ll(true);
         response_size += vsize;
 
-        string vdecl = get_dap_decl(var);
-        BESDEBUG(MODULE_VERBOSE, prolog << "  " << vdecl << "(" << vsize << " bytes)" << endl);
+        BESDEBUG(MODULE_VERBOSE, prolog << "  " << get_dap_decl(var) << "(" << vsize << " bytes)" << endl);
         if (vsize > max_var_size) {
-            too_big.emplace(pair<string, uint64_t>(vdecl, vsize));
+            too_big.emplace(pair<string, uint64_t>(get_dap_decl(var), vsize));
             BESDEBUG(MODULE,
-                     prolog << vdecl << "(" << vsize << " bytes) is bigger than the max_var_size of "
+                     prolog << get_dap_decl(var) << "(" << vsize << " bytes) is bigger than the max_var_size of "
                             << max_var_size << " bytes. too_big.size(): " << too_big.size() << endl);
         }
     }

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -253,15 +253,16 @@ std::string get_dap_decl(libdap::BaseType *var) {
  * @param max_var_size Size threshold for the inclusion of variables in the inventory.
  * @param too_big An unordered_map fo variable descriptions and their constrained sizes.
  */
-uint64_t compute_response_size_and_inv_big_vars( libdap::Constructor *constrctr, const uint64_t &max_var_size, std::unordered_map<std::string,int64_t> &too_big)
+uint64_t compute_response_size_and_inv_big_vars(
+        libdap::Constructor *constrctr,
+        const uint64_t &max_var_size,
+        std::unordered_map<std::string,int64_t> &too_big)
 {
 
     BESDEBUG(MODULE_VERBOSE, prolog << "BEGIN " << constrctr->type_name() << "(FQN: " << constrctr->FQN() << ")" << endl);
 
     uint64_t response_size = 0;
-    auto varitr=constrctr->var_begin();
-    for(; varitr != constrctr->var_end(); varitr++){
-        auto var = *varitr;
+    for(auto var: constrctr->variables()){
         BESDEBUG(MODULE_VERBOSE, prolog << "BEGIN " << var->type_name() << "(FQN: " << var->FQN() << ")" << endl);
         if(var->is_constructor_type()){
             auto some_constrctr = dynamic_cast<libdap::Constructor *>(var);
@@ -283,7 +284,7 @@ uint64_t compute_response_size_and_inv_big_vars( libdap::Constructor *constrctr,
                     too_big.emplace(pair<string, uint64_t>(vdecl, vsize));
                     BESDEBUG(MODULE,
                              prolog << vdecl << "(" << vsize << " bytes) is bigger than the max_var_size of "
-                             << max_var_size << " bytes. too_big.size(): " << too_big.size() << endl);
+                                    << max_var_size << " bytes. too_big.size(): " << too_big.size() << endl);
                 }
             }
         }

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <sstream>
 #include <unordered_map>
+#include <cmath> /* floor */
 
 #include <libdap/DDS.h>
 #include <libdap/DMR.h>

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -189,7 +189,7 @@ uint64_t count_requested_elements(const D4Dimension *d4dim){
     if(d4dim->constrained()){
         elements = (d4dim->c_stop() - d4dim->c_start());
         if(d4dim->c_stride()){
-            double num = (static_cast<double>(elements)) / d4dim->c_stride();
+            auto num = elements / d4dim->c_stride();
             elements  = floor(num);
         }
     } else{
@@ -208,7 +208,7 @@ uint64_t count_requested_elements(const D4Dimension *d4dim){
  */
 uint64_t count_requested_elements(const Array::dimension &dim){
     uint64_t elements = 0;
-    double num = (static_cast<double>(dim.stop) - static_cast<double>(dim.start)) / static_cast<double>(dim.stride);
+    auto num = (dim.stop - dim.start) / dim.stride;
     elements  = floor(num);
     if(!elements)
         elements = 1;

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -27,7 +27,6 @@
 #include <iostream>
 #include <sstream>
 #include <unordered_map>
-#include <cmath> /* floor */
 
 #include <libdap/DDS.h>
 #include <libdap/DMR.h>
@@ -42,8 +41,9 @@
 #include "BESSyntaxUserError.h"
 #include "DapUtils.h"
 
-#define MODULE "dap_utils"
-#define MODULE_VERBOSE "dap_utils_verbose"
+constexpr auto MODULE = "dap_utils";
+constexpr auto MODULE_VERBOSE = "dap_utils_verbose";
+
 #define prolog std::string("dap_utils::").append(__func__).append("() - ")
 
 using namespace libdap;
@@ -369,12 +369,10 @@ uint64_t compute_response_size_and_inv_big_vars(
 uint64_t compute_response_size_and_inv_big_vars( libdap::D4Group *grp, const uint64_t &max_var_size, std::unordered_map<std::string,int64_t> &too_big)
 {
     uint64_t response_size = 0;
-    auto cnstrctr = dynamic_cast<libdap::Constructor *>(grp);
-    if (cnstrctr) {
-        // This is basically always going to be the result since libdap::D4Group is a child of libdap::Constructor,
-        // And importantly for this code the actual size computation is handle in thie the follwing call.
-        response_size += compute_response_size_and_inv_big_vars(cnstrctr, max_var_size, too_big);
-    }
+    auto cnstrctr = static_cast<libdap::Constructor *>(grp);
+    // Since Group is a child of Constructor we can use the Constructor version of this method to handle the variables
+    // in the Group. Nifty, Right?
+    response_size += compute_response_size_and_inv_big_vars(cnstrctr, max_var_size, too_big);
 
     // Process child groups.
     for (auto child_grp: grp->groups()) {
@@ -398,7 +396,7 @@ uint64_t compute_response_size_and_inv_big_vars( libdap::D4Group *grp, const uin
  */
 uint64_t compute_response_size_and_inv_big_vars(libdap::DMR &dmr, const uint64_t &max_var_size, std::unordered_map<std::string,int64_t> &too_big)
 {
-    // TODO: Rather than an unordered_map, or even map, we might consider using vector like this:
+    // Consider if something other than an unordered_map, or even map, we might consider using vector like this:
     //  std::vector<std::pair<std::string,int64_t>> foo;
     //  Is that better? It preserves to order of addition and we don't ever need any of the map api features
     //  in the usage of the inventory. In fact we might consider just making this a vector<string> and building

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -189,8 +189,7 @@ uint64_t count_requested_elements(const D4Dimension *d4dim){
     if(d4dim->constrained()){
         elements = (d4dim->c_stop() - d4dim->c_start());
         if(d4dim->c_stride()){
-            auto num = elements / d4dim->c_stride();
-            elements  = floor(num);
+            elements =  elements / d4dim->c_stride();
         }
     } else{
         elements = d4dim->size();
@@ -207,12 +206,10 @@ uint64_t count_requested_elements(const D4Dimension *d4dim){
  * @return The number elements marked for transmission.
  */
 uint64_t count_requested_elements(const Array::dimension &dim){
-    uint64_t elements = 0;
-    auto num = (dim.stop - dim.start) / dim.stride;
-    elements  = floor(num);
+    uint64_t elements;
+    elements = (dim.stop - dim.start) / dim.stride;
     if(!elements)
         elements = 1;
-
     return elements;
 }
 

--- a/dap/DapUtils.h
+++ b/dap/DapUtils.h
@@ -50,5 +50,10 @@ void throw_for_dap4_typed_vars_or_attrs(libdap::DDS *dds, const std::string &fil
 void throw_if_dap2_response_too_big(libdap::DDS *dds, const std::string &file, unsigned int line);
 void throw_if_dap4_response_too_big(libdap::DMR &dmr, const std::string &file, unsigned int line);
 
+
+void find_too_big_vars( libdap::Constructor *constrctr, const uint64_t &max_size, std::unordered_map<std::string,int64_t> &too_big);
+void find_too_big_vars( libdap::D4Group *grp, const uint64_t &max_size, std::unordered_map<std::string,int64_t> &too_big);
+void find_too_big_vars( libdap::DMR &dmr, const uint64_t &max_size, std::unordered_map<std::string,int64_t> &too_big);
+
 }
 #endif //BES_DAPUTILS_H

--- a/dap/DapUtils.h
+++ b/dap/DapUtils.h
@@ -52,7 +52,7 @@ void throw_if_dap2_response_too_big(libdap::DDS *dds, const std::string &file, u
 void throw_if_dap4_response_too_big(libdap::DMR &dmr, const std::string &file, unsigned int line);
 
 
-uint64_t compute_response_size_and_inv_big_vars( libdap::Constructor *constrctr, const uint64_t &max_var_size, std::unordered_map<std::string,int64_t> &too_big);
+uint64_t compute_response_size_and_inv_big_vars(const libdap::Constructor *constrctr, const uint64_t &max_var_size, std::unordered_map<std::string,int64_t> &too_big);
 uint64_t compute_response_size_and_inv_big_vars( libdap::D4Group *grp, const uint64_t &max_var_size, std::unordered_map<std::string,int64_t> &too_big);
 uint64_t compute_response_size_and_inv_big_vars(libdap::DMR &dmr, const uint64_t &max_var_size, std::unordered_map<std::string,int64_t> &too_big);
 

--- a/dap/DapUtils.h
+++ b/dap/DapUtils.h
@@ -28,6 +28,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <unordered_map>
 
 #include "AttrTable.h"
 #include "DDS.h"

--- a/dap/DapUtils.h
+++ b/dap/DapUtils.h
@@ -51,9 +51,9 @@ void throw_if_dap2_response_too_big(libdap::DDS *dds, const std::string &file, u
 void throw_if_dap4_response_too_big(libdap::DMR &dmr, const std::string &file, unsigned int line);
 
 
-void find_too_big_vars( libdap::Constructor *constrctr, const uint64_t &max_size, std::unordered_map<std::string,int64_t> &too_big);
-void find_too_big_vars( libdap::D4Group *grp, const uint64_t &max_size, std::unordered_map<std::string,int64_t> &too_big);
-void find_too_big_vars( libdap::DMR &dmr, const uint64_t &max_size, std::unordered_map<std::string,int64_t> &too_big);
+uint64_t compute_response_size_and_inv_big_vars( libdap::Constructor *constrctr, const uint64_t &max_var_size, std::unordered_map<std::string,int64_t> &too_big);
+uint64_t compute_response_size_and_inv_big_vars( libdap::D4Group *grp, const uint64_t &max_var_size, std::unordered_map<std::string,int64_t> &too_big);
+uint64_t compute_response_size_and_inv_big_vars(libdap::DMR &dmr, const uint64_t &max_var_size, std::unordered_map<std::string,int64_t> &too_big);
 
 }
 #endif //BES_DAPUTILS_H

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <iostream>
 #include <fstream>
+#include <sstream>
 
 
 #include "BESError.h"
@@ -102,6 +103,9 @@ public:
         d_test_dmr = new DMR(&d_d4f);
         D4ParserSax2 dp;
         uint64_t response_size = 0;
+        stringstream msg;
+
+        uint64_t expected_response_size = 1016;
 
         string file_name=BESUtil::pathConcat(TEST_SRC_DIR,"input-files/test_01.dmr");
         DBG(cerr << prolog << "DMR file to be parsed: " << file_name << endl);
@@ -113,8 +117,11 @@ public:
         uint64_t max_size = 200;
         std::unordered_map<std::string,int64_t> too_big;
         response_size =  dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
-        DBG( cerr << prolog << "response_size: " << response_size << endl);
-        CPPUNIT_ASSERT_MESSAGE("ERROR Unexpected response size!", response_size == 1016);
+        msg << prolog << "response_size: " << response_size << endl;
+        DBG( cerr << msg.str());
+        msg.str(string());
+        msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
+        CPPUNIT_ASSERT_MESSAGE(msg.str(), response_size == expected_response_size);
 
         if(!too_big.empty()){
             cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -114,7 +114,8 @@ public:
         std::unordered_map<std::string,int64_t> too_big;
         response_size =  dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
         DBG( cerr << prolog << "response_size: " << response_size << endl);
-        
+        CPPUNIT_ASSERT_MESSAGE("ERROR Unexpected response size!", response_size == 1016);
+
         if(!too_big.empty()){
             cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
             for(auto apair:too_big){
@@ -147,6 +148,8 @@ public:
 
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
         DBG( cerr << prolog << "response_size: " << response_size << endl);
+
+        CPPUNIT_ASSERT_MESSAGE("ERROR Unexpected response size!", response_size == 180356500);
 
         if(!too_big.empty()){
             cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
@@ -182,6 +185,9 @@ public:
 
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
         DBG( cerr << prolog << "response_size: " << response_size << endl);
+
+        CPPUNIT_ASSERT_MESSAGE("ERROR Unexpected response size!", response_size == 140378112);
+
 
         if(!too_big.empty()){
             cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
@@ -220,6 +226,8 @@ public:
 
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
         DBG( cerr << prolog << "response_size: " << response_size << endl);
+
+        CPPUNIT_ASSERT_MESSAGE("ERROR Unexpected response size!", response_size == 1179648);
 
         if(!too_big.empty()){
             DBG( cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -120,14 +120,9 @@ public:
         response_size =  dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
-        if(hack_bug) cerr << msg.str();
 
-        d_test_dmr->root()->print_decl(cerr, "", true, true, true);
-
-
-        msg.str(string());
-        msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
-        // CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);
+        // We can't test response size because the response contains arrays of strings and the string sizes
+        // differ from one system to the next, example OS-X: 24 bytes, centos-8: 32 bytes
 
         if(!too_big.empty()){
             cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
@@ -164,11 +159,10 @@ public:
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
-        if(hack_bug) cerr << msg.str();
 
         msg.str(string());
         msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
-        // CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);
 
         if(!too_big.empty()){
             cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
@@ -207,11 +201,10 @@ public:
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
-        if(hack_bug) cerr << msg.str();
 
         msg.str(string());
         msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
-        // CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);
 
 
         if(!too_big.empty()){
@@ -254,11 +247,10 @@ public:
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
-        if(hack_bug) cerr << msg.str();
 
         msg.str(string());
         msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
-        // CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);
 
         if(!too_big.empty()){
             DBG( cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -79,7 +79,7 @@ public:
                 show_file(bes_conf);
             }
 
-            cerr << "Ingested debug options: " << BESDebug::GetOptionsString() << endl;
+            cerr << "Ingested BESDebug options: " << BESDebug::GetOptionsString() << endl;
         }
 
         TheBESKeys::ConfigFile = bes_conf;
@@ -102,9 +102,8 @@ public:
         DMR *d_test_dmr;
         d_test_dmr = new DMR(&d_d4f);
         D4ParserSax2 dp;
-        uint64_t response_size = 0;
         stringstream msg;
-
+        uint64_t response_size = 0;
         uint64_t expected_response_size = 1016;
 
         string file_name=BESUtil::pathConcat(TEST_SRC_DIR,"input-files/test_01.dmr");
@@ -117,8 +116,9 @@ public:
         uint64_t max_size = 200;
         std::unordered_map<std::string,int64_t> too_big;
         response_size =  dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
-        msg << prolog << "response_size: " << response_size << endl;
+        msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
+
         msg.str(string());
         msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
         CPPUNIT_ASSERT_MESSAGE(msg.str(), response_size == expected_response_size);
@@ -141,7 +141,9 @@ public:
         D4BaseTypeFactory d_d4f;
         d_test_dmr = new DMR(&d_d4f);
         D4ParserSax2 dp;
+        stringstream msg;
         uint64_t response_size = 0;
+        uint64_t expected_response_size = 180356500;
 
         string file_name=BESUtil::pathConcat(TEST_SRC_DIR,"input-files/tempo_l2.nc.dmrpp");
         DBG(cerr << prolog << "DMR file to be parsed: " << file_name << endl);
@@ -154,9 +156,12 @@ public:
         std::unordered_map<std::string,int64_t> too_big;
 
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
-        DBG( cerr << prolog << "response_size: " << response_size << endl);
+        msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
+        DBG( cerr << msg.str());
 
-        CPPUNIT_ASSERT_MESSAGE("ERROR Unexpected response size!", response_size == 180356500);
+        msg.str(string());
+        msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
+        CPPUNIT_ASSERT_MESSAGE(msg.str(), response_size == expected_response_size);
 
         if(!too_big.empty()){
             cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
@@ -176,7 +181,9 @@ public:
         D4BaseTypeFactory d_d4f;
         d_test_dmr = new DMR(&d_d4f);
         D4ParserSax2 dp;
+        stringstream msg;
         uint64_t response_size = 0;
+        uint64_t expected_response_size = 140378112;
 
         string file_name=BESUtil::pathConcat(TEST_SRC_DIR,"input-files/tempo_l2.nc.dmrpp");
         DBG(cerr << prolog << "DMR file to be parsed: " << file_name << endl);
@@ -191,9 +198,12 @@ public:
         d4ce.parse("/support_data/gas_profile;/support_data/scattering_weights");
 
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
-        DBG( cerr << prolog << "response_size: " << response_size << endl);
+        msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
+        DBG( cerr << msg.str());
 
-        CPPUNIT_ASSERT_MESSAGE("ERROR Unexpected response size!", response_size == 140378112);
+        msg.str(string());
+        msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
+        CPPUNIT_ASSERT_MESSAGE(msg.str(), response_size == expected_response_size);
 
 
         if(!too_big.empty()){
@@ -217,7 +227,9 @@ public:
         D4BaseTypeFactory d_d4f;
         d_test_dmr = new DMR(&d_d4f);
         D4ParserSax2 dp;
+        stringstream msg;
         uint64_t response_size = 0;
+        uint64_t expected_response_size = 1179648;
 
         string file_name=BESUtil::pathConcat(TEST_SRC_DIR,"input-files/tempo_l2.nc.dmrpp");
         DBG(cerr << prolog << "DMR file to be parsed: " << file_name << endl);
@@ -232,9 +244,12 @@ public:
         d4ce.parse("/support_data/gas_profile[1][][];/support_data/scattering_weights[3][][]");
 
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
-        DBG( cerr << prolog << "response_size: " << response_size << endl);
+        msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
+        DBG( cerr << msg.str());
 
-        CPPUNIT_ASSERT_MESSAGE("ERROR Unexpected response size!", response_size == 1179648);
+        msg.str(string());
+        msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
+        CPPUNIT_ASSERT_MESSAGE(msg.str(), response_size == expected_response_size);
 
         if(!too_big.empty()){
             DBG( cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -66,6 +66,8 @@ public:
     // Called at the end of the test
     ~DapUtilsTest() = default;
 
+    bool hack_bug = true;
+
     // Called before each test
     void setUp()  {
         string bes_conf = BESUtil::assemblePath(TEST_BUILD_DIR, "bes.conf");
@@ -118,10 +120,11 @@ public:
         response_size =  dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
+        if(hack_bug) cerr << msg.str();
 
         msg.str(string());
         msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
-        CPPUNIT_ASSERT_MESSAGE(msg.str(), response_size == expected_response_size);
+        // CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);
 
         if(!too_big.empty()){
             cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
@@ -158,10 +161,11 @@ public:
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
+        if(hack_bug) cerr << msg.str();
 
         msg.str(string());
         msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
-        CPPUNIT_ASSERT_MESSAGE(msg.str(), response_size == expected_response_size);
+        // CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);
 
         if(!too_big.empty()){
             cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
@@ -200,10 +204,11 @@ public:
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
+        if(hack_bug) cerr << msg.str();
 
         msg.str(string());
         msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
-        CPPUNIT_ASSERT_MESSAGE(msg.str(), response_size == expected_response_size);
+        // CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);
 
 
         if(!too_big.empty()){
@@ -246,10 +251,11 @@ public:
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
+        if(hack_bug) cerr << msg.str();
 
         msg.str(string());
         msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
-        CPPUNIT_ASSERT_MESSAGE(msg.str(), response_size == expected_response_size);
+        // CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);
 
         if(!too_big.empty()){
             DBG( cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -1,0 +1,168 @@
+// -*- mode: c++; c-basic-offset:4 -*-
+
+// This file is part of the BES component of the Hyrax Data Server.
+
+// Copyright (c) 2020 OPeNDAP, Inc.
+// Author: Nathan Potter <ndp@opendap.org>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+// You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+
+#include "test_config.h"
+
+#include <memory>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+
+
+#include "BESError.h"
+#include "BESDebug.h"
+#include "BESUtil.h"
+#include "BESCatalogList.h"
+#include "TheBESKeys.h"
+#include "BESContextManager.h"
+#include "BESForbiddenError.h"
+#include "DapUtils.h"
+#include "libdap/DMR.h"
+#include "libdap/D4BaseTypeFactory.h"
+#include "libdap/D4ParserSax2.h"
+
+
+// Maybe the common testing code in modules should be moved up one level? jhrg 11/3/22
+#include "modules/common/run_tests_cppunit.h"
+
+using namespace std;
+using namespace libdap;
+
+#define prolog std::string("DapUtilsTest::").append(__func__).append("() - ")
+
+namespace http {
+
+class DapUtilsTest : public CppUnit::TestFixture {
+
+public:
+
+    // bool debug=true;
+
+    // Called once before everything gets tested
+    DapUtilsTest() = default;
+
+    // Called at the end of the test
+    ~DapUtilsTest() = default;
+
+    // Called before each test
+    void setUp()  {
+        string bes_conf = BESUtil::assemblePath(TEST_BUILD_DIR, "bes.conf");
+
+        if (debug) {
+            cerr << endl;
+            cerr << "setUp() - BEGIN" << endl;
+
+            cerr << "setUp() - Using BES configuration file: " << bes_conf << endl;
+            if (debug2) {
+                show_file(bes_conf);
+            }
+
+            cerr << "Ingested debug options: " << BESDebug::GetOptionsString() << endl;
+        }
+
+        TheBESKeys::ConfigFile = bes_conf;
+
+        if (debug) cerr << "setUp() - END" << endl;
+    }
+
+    // Called after each test
+    void tearDown()  {
+    }
+
+
+
+/*##################################################################################################*/
+/* TESTS BEGIN */
+
+    void var_too_big_test() {
+
+        DMR *d_test_dmr;
+        D4BaseTypeFactory d_d4f;
+        d_test_dmr = new DMR(&d_d4f);
+        D4ParserSax2 dp;
+
+        string file_name=BESUtil::pathConcat(TEST_SRC_DIR,"input-files/test_01.dmr");
+        DBG(cerr << prolog << "DMR file to be parsed: " << file_name << endl);
+
+        fstream in(file_name.c_str(), ios::in|ios::binary);
+        dp.intern(in, d_test_dmr);
+
+        std::unordered_map<std::string,int64_t> too_big;
+        dap_utils::find_too_big_vars( *d_test_dmr, 200, too_big);
+        if(!too_big.empty()){
+            cerr << prolog << "Rejected vars: " << endl;
+            for(auto apair:too_big){
+                cerr << prolog << apair.first << " size: " << apair.second << endl;
+            }
+        }
+        else {
+            cerr << "No variables were deemed to big" << endl;
+        }
+    }
+
+    void dmrpp_var_too_big_test() {
+
+        DMR *d_test_dmr;
+        D4BaseTypeFactory d_d4f;
+        d_test_dmr = new DMR(&d_d4f);
+        D4ParserSax2 dp;
+
+        string file_name=BESUtil::pathConcat(TEST_SRC_DIR,"input-files/tempo_l2.nc.dmrpp");
+        DBG(cerr << prolog << "DMR file to be parsed: " << file_name << endl);
+
+        fstream in(file_name.c_str(), ios::in|ios::binary);
+        dp.intern(in, d_test_dmr);
+
+        uint64_t max_size = 1000000;
+        std::unordered_map<std::string,int64_t> too_big;
+        dap_utils::find_too_big_vars( *d_test_dmr, max_size, too_big);
+        if(!too_big.empty()){
+            cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
+            for(auto apair:too_big){
+                cerr << prolog << "  " << apair.first << " (size: " << apair.second << ")" <<  endl;
+            }
+            CPPUNIT_ASSERT(too_big.size() == 10 );
+        }
+        else {
+            CPPUNIT_FAIL("ERROR: No variables were deemed to big" );
+        }
+    }
+
+/* TESTS END */
+/*##################################################################################################*/
+
+    CPPUNIT_TEST_SUITE(DapUtilsTest);
+
+    CPPUNIT_TEST(var_too_big_test);
+    CPPUNIT_TEST(dmrpp_var_too_big_test);
+
+    CPPUNIT_TEST_SUITE_END();
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(DapUtilsTest);
+
+} // namespace http
+
+int main(int argc, char *argv[]) {
+    return bes_run_tests<http::DapUtilsTest>(argc, argv, "bes,dap_utils") ? 0 : 1;
+}

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -107,16 +107,19 @@ public:
         fstream in(file_name.c_str(), ios::in|ios::binary);
         dp.intern(in, d_test_dmr);
 
+        uint64_t max_size = 200;
+
         std::unordered_map<std::string,int64_t> too_big;
-        dap_utils::find_too_big_vars( *d_test_dmr, 200, too_big);
+        dap_utils::find_too_big_vars( *d_test_dmr, max_size, too_big);
         if(!too_big.empty()){
-            cerr << prolog << "Rejected vars: " << endl;
+            cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
             for(auto apair:too_big){
-                cerr << prolog << apair.first << " size: " << apair.second << endl;
+                cerr << prolog << "  " << apair.first << " (size: " << apair.second << ")" <<  endl;
             }
+            CPPUNIT_ASSERT( too_big.size() == 2 );
         }
         else {
-            cerr << "No variables were deemed to big" << endl;
+            CPPUNIT_FAIL("ERROR: No variables were deemed too big!");
         }
     }
 
@@ -144,7 +147,7 @@ public:
             CPPUNIT_ASSERT(too_big.size() == 10 );
         }
         else {
-            CPPUNIT_FAIL("ERROR: No variables were deemed to big" );
+            CPPUNIT_FAIL("ERROR: No variables were deemed too big!");
         }
     }
 

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -125,9 +125,9 @@ public:
         // differ from one system to the next, example OS-X: 24 bytes, centos-8: 32 bytes
 
         if(!too_big.empty()){
-            cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
+            DBG( cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);
             for(auto apair:too_big){
-                cerr << prolog << "  " << apair.first << " (size: " << apair.second << ")" <<  endl;
+                DBG(cerr << prolog << "  " << apair.first << " (size: " << apair.second << ")" <<  endl);
             }
             CPPUNIT_ASSERT( too_big.size() == 2 );
         }
@@ -165,9 +165,9 @@ public:
         CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);
 
         if(!too_big.empty()){
-            cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
+            DBG(cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);
             for(auto apair:too_big){
-                cerr << prolog << "  " << apair.first << " (size: " << apair.second << ")" <<  endl;
+                DBG(cerr << prolog << "  " << apair.first << " (size: " << apair.second << ")" <<  endl);
             }
             CPPUNIT_ASSERT(too_big.size() == 10 );
         }
@@ -208,9 +208,9 @@ public:
 
 
         if(!too_big.empty()){
-            cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl;
+            DBG(cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);
             for(auto apair:too_big){
-                cerr << prolog << "  " << apair.first << "(" << apair.second << " bytes)" <<  endl;
+                DBG(cerr << prolog << "  " << apair.first << "(" << apair.second << " bytes)" <<  endl);
             }
             CPPUNIT_ASSERT( too_big.size() == 2);
         }

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -122,6 +122,9 @@ public:
         DBG( cerr << msg.str());
         if(hack_bug) cerr << msg.str();
 
+        d_test_dmr->root()->print_decl(cerr, "", true, true, true);
+
+
         msg.str(string());
         msg  << prolog << "ERROR: Unexpected response_size. expected: " << expected_response_size << " got response_size: " << response_size << endl;
         // CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str(), response_size, expected_response_size);

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -101,8 +101,8 @@ public:
     void var_too_big_test() {
 
         D4BaseTypeFactory d_d4f;
-        DMR *d_test_dmr;
-        d_test_dmr = new DMR(&d_d4f);
+        auto d_test_dmr = std::unique_ptr<DMR>(new DMR(&d_d4f));
+
         D4ParserSax2 dp;
         stringstream msg;
         uint64_t response_size = 0;
@@ -112,12 +112,12 @@ public:
         DBG(cerr << prolog << "DMR file to be parsed: " << file_name << endl);
 
         fstream in(file_name.c_str(), ios::in|ios::binary);
-        dp.intern(in, d_test_dmr);
+        dp.intern(in, d_test_dmr.get());
         d_test_dmr->root()->set_send_p(true);
 
         uint64_t max_size = 200;
         std::unordered_map<std::string,int64_t> too_big;
-        response_size =  dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
+        response_size =  dap_utils::compute_response_size_and_inv_big_vars( *(d_test_dmr.get()), max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
 
@@ -138,9 +138,9 @@ public:
 
     void dmrpp_var_too_big_test() {
 
-        DMR *d_test_dmr;
         D4BaseTypeFactory d_d4f;
-        d_test_dmr = new DMR(&d_d4f);
+        auto d_test_dmr = std::unique_ptr<DMR>(new DMR(&d_d4f));
+
         D4ParserSax2 dp;
         stringstream msg;
         uint64_t response_size = 0;
@@ -150,13 +150,13 @@ public:
         DBG(cerr << prolog << "DMR file to be parsed: " << file_name << endl);
 
         fstream in(file_name.c_str(), ios::in|ios::binary);
-        dp.intern(in, d_test_dmr);
+        dp.intern(in, d_test_dmr.get());
         d_test_dmr->root()->set_send_p(true);
 
         uint64_t max_size = 1000000;
         std::unordered_map<std::string,int64_t> too_big;
 
-        response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
+        response_size = dap_utils::compute_response_size_and_inv_big_vars( *(d_test_dmr.get()), max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
 
@@ -178,9 +178,9 @@ public:
 
     void dmrpp_constrained_var_too_big_test() {
 
-        DMR *d_test_dmr;
         D4BaseTypeFactory d_d4f;
-        d_test_dmr = new DMR(&d_d4f);
+        auto d_test_dmr = std::unique_ptr<DMR>(new DMR(&d_d4f));
+
         D4ParserSax2 dp;
         stringstream msg;
         uint64_t response_size = 0;
@@ -190,15 +190,15 @@ public:
         DBG(cerr << prolog << "DMR file to be parsed: " << file_name << endl);
 
         fstream in(file_name.c_str(), ios::in|ios::binary);
-        dp.intern(in, d_test_dmr);
-        D4ConstraintEvaluator d4ce(d_test_dmr);
+        dp.intern(in, d_test_dmr.get());
+        D4ConstraintEvaluator d4ce(d_test_dmr.get());
 
         uint64_t max_size = 1000000;
         std::unordered_map<std::string,int64_t> too_big;
 
         d4ce.parse("/support_data/gas_profile;/support_data/scattering_weights");
 
-        response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
+        response_size = dap_utils::compute_response_size_and_inv_big_vars( *(d_test_dmr.get()), max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
 
@@ -224,9 +224,9 @@ public:
 
     void dmrpp_constrained_var_ok_test() {
 
-        DMR *d_test_dmr;
         D4BaseTypeFactory d_d4f;
-        d_test_dmr = new DMR(&d_d4f);
+        auto d_test_dmr = std::unique_ptr<DMR>(new DMR(&d_d4f));
+
         D4ParserSax2 dp;
         stringstream msg;
         uint64_t response_size = 0;
@@ -236,15 +236,15 @@ public:
         DBG(cerr << prolog << "DMR file to be parsed: " << file_name << endl);
 
         fstream in(file_name.c_str(), ios::in|ios::binary);
-        dp.intern(in, d_test_dmr);
-        D4ConstraintEvaluator d4ce(d_test_dmr);
+        dp.intern(in, d_test_dmr.get());
+        D4ConstraintEvaluator d4ce(d_test_dmr.get());
 
         uint64_t max_size = 1000000;
         std::unordered_map<std::string,int64_t> too_big;
 
         d4ce.parse("/support_data/gas_profile[1][][];/support_data/scattering_weights[3][][]");
 
-        response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
+        response_size = dap_utils::compute_response_size_and_inv_big_vars( *(d_test_dmr.get()), max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
 
@@ -268,9 +268,9 @@ public:
 
     void dmrpp_root_group_var_too_big_test() {
 
-        DMR *d_test_dmr;
         D4BaseTypeFactory d_d4f;
-        d_test_dmr = new DMR(&d_d4f);
+        auto d_test_dmr = std::unique_ptr<DMR>(new DMR(&d_d4f));
+
         D4ParserSax2 dp;
         stringstream msg;
         uint64_t response_size = 0;
@@ -280,15 +280,15 @@ public:
         DBG(cerr << prolog << "DMR file to be parsed: " << file_name << endl);
 
         fstream in(file_name.c_str(), ios::in|ios::binary);
-        dp.intern(in, d_test_dmr);
-        D4ConstraintEvaluator d4ce(d_test_dmr);
+        dp.intern(in, d_test_dmr.get());
+        D4ConstraintEvaluator d4ce(d_test_dmr.get());
 
         uint64_t max_size = 8000;
         std::unordered_map<std::string,int64_t> too_big;
 
         d4ce.parse("/xtrack;/mirror_step");
 
-        response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
+        response_size = dap_utils::compute_response_size_and_inv_big_vars( *(d_test_dmr.get()), max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
 
@@ -313,9 +313,9 @@ public:
 
     void dmrpp_constrained_root_group_var_ok_test() {
 
-        DMR *d_test_dmr;
         D4BaseTypeFactory d_d4f;
-        d_test_dmr = new DMR(&d_d4f);
+        auto d_test_dmr = std::unique_ptr<DMR>(new DMR(&d_d4f));
+
         D4ParserSax2 dp;
         stringstream msg;
         uint64_t response_size = 0;
@@ -325,15 +325,15 @@ public:
         DBG(cerr << prolog << "DMR file to be parsed: " << file_name << endl);
 
         fstream in(file_name.c_str(), ios::in|ios::binary);
-        dp.intern(in, d_test_dmr);
-        D4ConstraintEvaluator d4ce(d_test_dmr);
+        dp.intern(in, d_test_dmr.get());
+        D4ConstraintEvaluator d4ce(d_test_dmr.get());
 
         uint64_t max_size = 8000;
         std::unordered_map<std::string,int64_t> too_big;
 
         d4ce.parse("/xtrack[1:4:2047];/mirror_step");
 
-        response_size = dap_utils::compute_response_size_and_inv_big_vars( *d_test_dmr, max_size, too_big);
+        response_size = dap_utils::compute_response_size_and_inv_big_vars( *(d_test_dmr.get()), max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
 

--- a/dap/unit-tests/Makefile.am
+++ b/dap/unit-tests/Makefile.am
@@ -91,7 +91,7 @@ bes.conf: $(srcdir)/$(BES_CONF_IN) $(top_srcdir)/configure.ac
 
 if CPPUNIT
 UNIT_TESTS = ResponseBuilderTest ObjMemCacheTest FunctionResponseCacheTest \
-ShowPathInfoTest TemporaryFileTest GlobalMetadataStoreTest
+ShowPathInfoTest TemporaryFileTest GlobalMetadataStoreTest DapUtilsTest
 
 else
 UNIT_TESTS =
@@ -126,6 +126,10 @@ ObjMemCacheTest_LDADD = $(ObjMemCacheTest_OBJS) $(LDADD)
 ShowPathInfoTest_SOURCES = ShowPathInfoTest.cc
 ShowPathInfoTest_OBJS = ../ShowPathInfoResponseHandler.o 
 ShowPathInfoTest_LDADD = $(ShowPathInfoTest_OBJS) $(LDADD)
+
+DapUtilsTest_SOURCES = DapUtilsTest.cc
+DapUtilsTest_OBJS = ../DapUtils.o
+DapUtilsTest_LDADD = $(DapUtilsTest_OBJS) $(LDADD)
 
 TemporaryFileTest_SOURCES = TemporaryFileTest.cc
 TemporaryFileTest_OBJS = ../TempFile.o

--- a/dap/unit-tests/input-files/tempo_l2.nc.dmrpp
+++ b/dap/unit-tests/input-files/tempo_l2.nc.dmrpp
@@ -1,0 +1,1377 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="TEMPO_NO2_L2_V01_20130701T225352Z_S010G10.nc" dmrpp:href="file:///Users/ndp/OPeNDAP/hyrax/build/share/hyrax/nasa_ngap/larc/TEMPO_NO2_L2_V01_20130701T225352Z_S010G10.nc" dmrpp:version="3.20.13-0">
+    <Dimension name="xtrack" size="2048"/>
+    <Dimension name="corner" size="4"/>
+    <Dimension name="mirror_step" size="119"/>
+    <Dimension name="swt_level" size="72"/>
+    <Int32 name="xtrack">
+        <Dim name="/xtrack"/>
+        <Attribute name="long_name" type="String">
+            <Value>pixel index along slit</Value>
+        </Attribute>
+        <dmrpp:chunks fillValue="-2147483647" byteOrder="LE">
+            <dmrpp:chunk offset="4228" nBytes="8192"/>
+        </dmrpp:chunks>
+    </Int32>
+    <Int32 name="mirror_step">
+        <Dim name="/mirror_step"/>
+        <Attribute name="long_name" type="String">
+            <Value>scan mirror position index</Value>
+        </Attribute>
+        <dmrpp:chunks fillValue="-2147483647" byteOrder="LE">
+            <dmrpp:chunk offset="3752" nBytes="476"/>
+        </dmrpp:chunks>
+    </Int32>
+    <Attribute name="tio_commit" type="String">
+        <Value>1b3ce915d3a7f4141abd6b9c2e9a6730a402654e</Value>
+    </Attribute>
+    <Attribute name="product_type" type="String">
+        <Value>NO2</Value>
+    </Attribute>
+    <Attribute name="processing_level" type="String">
+        <Value>2</Value>
+    </Attribute>
+    <Attribute name="processing_version" type="Int32">
+        <Value>1</Value>
+    </Attribute>
+    <Attribute name="scan_num" type="Int32">
+        <Value>10</Value>
+    </Attribute>
+    <Attribute name="granule_num" type="Int32">
+        <Value>10</Value>
+    </Attribute>
+    <Attribute name="time_coverage_start" type="String">
+        <Value>2013-07-01T22:53:52Z</Value>
+    </Attribute>
+    <Attribute name="time_coverage_end" type="String">
+        <Value>2013-07-01T22:59:40Z</Value>
+    </Attribute>
+    <Attribute name="time_coverage_start_since_epoch" type="Float64">
+        <Value>425991235.8754034</Value>
+    </Attribute>
+    <Attribute name="time_coverage_end_since_epoch" type="Float64">
+        <Value>425991583.6147908</Value>
+    </Attribute>
+    <Attribute name="time_reference" type="String">
+        <Value>2000-01-01T12:00:00Z</Value>
+    </Attribute>
+    <Attribute name="apriori_source" type="String">
+        <Value>GEOSCF:forecast</Value>
+    </Attribute>
+    <Attribute name="geospatial_bounds" type="String">
+        <Value>POLYGON((61.3899 -151.2300,61.1368 -151.4991,60.9190 -151.9736,60.6650 -152.1609,60.4524 -152.6574,59.6671 -152.9274,59.4797 -153.5263,58.2747 -154.2986,57.8502 -154.9298,57.5735 -154.7373,57.1609 -155.3746,56.8987 -155.2473,56.7026 -155.6106,56.4489 -155.5197,56.0579 -156.1919,55.6990 -155.2474,54.4887 -151.2052,53.4643 -148.3972,52.2454 -145.5493,50.6053 -142.3214,48.8744 -139.4597,46.8421 -136.6235,44.5652 -133.9502,42.2700 -131.6681,39.7784 -129.5572,37.1184 -127.6393,34.3108 -125.9184,31.2275 -124.3215,28.1711 -122.9890,24.9957 -121.8264,21.8271 -120.8590,17.9381 -119.8732,17.7894 -114.0513,22.2553 -114.8969,26.4402 -115.9171,30.4696 -117.1468,34.3356 -118.5982,38.0407 -120.3075,41.3709 -122.1648,44.1072 -124.0048,46.4500 -125.8333,49.2064 -128.3723,51.5418 -130.9466,53.6000 -133.6374,55.6015 -136.7560,57.5469 -140.4361,59.0402 -143.8709,60.3507 -147.5160,61.4046 -151.0704))</Value>
+    </Attribute>
+    <Attribute name="geospatial_bounds_crs" type="String">
+        <Value>EPSG:4326</Value>
+    </Attribute>
+    <Attribute name="geospatial_lon_min" type="Float32">
+        <Value>-156.1919098</Value>
+    </Attribute>
+    <Attribute name="geospatial_lon_max" type="Float32">
+        <Value>-114.0513306</Value>
+    </Attribute>
+    <Attribute name="geospatial_lat_min" type="Float32">
+        <Value>17.78942299</Value>
+    </Attribute>
+    <Attribute name="geospatial_lat_max" type="Float32">
+        <Value>61.40460587</Value>
+    </Attribute>
+    <Attribute name="input_files" type="String">
+        <Value>TEMPO_RAD_L1_V01_20130701T225352Z_S010G10.nc, TEMPO_IRR_L1_V01_20130701T042530Z.nc, TEMPO_CLDO4_L2_V01_20130701T225352Z_S010G10.nc</Value>
+    </Attribute>
+    <Attribute name="local_granule_id" type="String">
+        <Value>TEMPO_NO2_L2_V01_20130701T225352Z_S010G10.nc</Value>
+    </Attribute>
+    <Attribute name="version_id" type="Int32">
+        <Value>1</Value>
+    </Attribute>
+    <Attribute name="production_date_time" type="String">
+        <Value>2023-03-16T21:41:13.060 UTC-0400</Value>
+    </Attribute>
+    <Attribute name="day_of_year" type="Int64">
+        <Value>182</Value>
+    </Attribute>
+    <Attribute name="project" type="String">
+        <Value>TEMPO</Value>
+    </Attribute>
+    <Attribute name="platform" type="String">
+        <Value>Intelsat 40e</Value>
+    </Attribute>
+    <Attribute name="source" type="String">
+        <Value>UV-VIS hyperspectral imaging</Value>
+    </Attribute>
+    <Attribute name="institution" type="String">
+        <Value>Smithsonian Astrophysical Observatory</Value>
+    </Attribute>
+    <Attribute name="creator_url" type="String">
+        <Value>http://tempo.si.edu</Value>
+    </Attribute>
+    <Attribute name="access_description" type="String">
+        <Value>Test data, not for public release. Numerical access_values not yet defined.</Value>
+    </Attribute>
+    <Attribute name="access_value" type="Int64">
+        <Value>0</Value>
+    </Attribute>
+    <Attribute name="Conventions" type="String">
+        <Value>CF-1.6, ACDD-1.3</Value>
+    </Attribute>
+    <Attribute name="title" type="String">
+        <Value>TEMPO Level 2 nitrogen dioxide product</Value>
+    </Attribute>
+    <Attribute name="collection_shortname" type="String">
+        <Value>TEMPO_NO2_L2</Value>
+    </Attribute>
+    <Attribute name="collection_version" type="Int64">
+        <Value>1</Value>
+    </Attribute>
+    <Attribute name="keywords" type="String">
+        <Value>EARTH SCIENCE&gt;ATMOSPHERE&gt;AIR QUALITY&gt;NITROGEN OXIDES, EARTH SCIENCE&gt;ATMOSPHERE&gt;ATMOSPHERIC CHEMISTRY&gt;NITROGEN COMPOUNDS&gt;NITROGEN DIOXIDE</Value>
+    </Attribute>
+    <Attribute name="summary" type="String">
+        <Value>Nitrogen dioxide Level 2 files provide trace gas information at TEMPO&#8217;s native spatial resolution, ~10 km^2 at the center of the Field of Regard (FOR), for individual granules. Each granule covers the entire North-South TEMPO FOR but only a portion of the East-West FOR. The files are provided in netCDF4 format, and contain information on tropospheric, stratospheric and total nitrogen dioxide vertical columns, ancillary data used in air mass factor and stratospheric/tropospheric separation calculations, and retrieval quality flags. The retrieval uses a three-step approach: (1) spectral fitting of slant columns, (2) air mass factor calculation and derivation of vertical columns, and (3) stratospheric/tropospheric separation. For further details, please refer to the ATBD.</Value>
+    </Attribute>
+    <Attribute name="coremetadata" type="String">
+        <Value>
+GROUP                  = INVENTORYMETADATA
+  GROUPTYPE            = MASTERGROUP
+
+  GROUP                  = ECSDATAGRANULE
+
+    OBJECT                 = LOCALGRANULEID
+      NUM_VAL              = 1
+      VALUE                = &quot;TEMPO_NO2_L2_V01_20130701T225352Z_S010G10.nc&quot;
+    END_OBJECT             = LOCALGRANULEID
+
+    OBJECT                 = LOCALVERSIONID
+      NUM_VAL              = 1
+      VALUE                = (&quot;RFC1321 MD5 = not yet calculated&quot;)
+    END_OBJECT             = LOCALVERSIONID
+
+    OBJECT                 = PRODUCTIONDATETIME
+      NUM_VAL              = 1
+      VALUE                = &quot;2023-03-17T01:41:13.000Z&quot;
+    END_OBJECT             = PRODUCTIONDATETIME
+
+  END_GROUP              = ECSDATAGRANULE
+
+  GROUP                  = COLLECTIONDESCRIPTIONCLASS
+
+    OBJECT                 = SHORTNAME
+      NUM_VAL              = 1
+      VALUE                = &quot;TEMPO_NO2_L2&quot;
+    END_OBJECT             = SHORTNAME
+
+    OBJECT                 = VERSIONID
+      NUM_VAL              = 1
+      VALUE                = (1)
+    END_OBJECT             = VERSIONID
+
+  END_GROUP              = COLLECTIONDESCRIPTIONCLASS
+
+  GROUP                  = INPUTGRANULE
+
+    OBJECT                 = INPUTPOINTER
+      NUM_VAL              = 3
+      VALUE                = (&quot;TEMPO_RAD_L1_V01_20130701T225352Z_S010G10.nc&quot;, &quot;TEMPO_IRR_L1_V01_20130701T042530Z.nc&quot;, &quot;TEMPO_CLDO4_L2_V01_20130701T225352Z_S010G10.nc&quot;)
+    END_OBJECT             = INPUTPOINTER
+
+  END_GROUP              = INPUTGRANULE
+
+  GROUP                  = SPATIALDOMAINCONTAINER
+
+    GROUP                  = HORIZONTALSPATIALDOMAINCONTAINER
+
+      GROUP                  = GPOLYGON
+
+        OBJECT                 = GPOLYGONCONTAINER
+          CLASS                = &quot;1&quot;
+
+          GROUP                  = GRINGPOINT
+            CLASS                = &quot;1&quot;
+
+            OBJECT                 = GRINGPOINTLONGITUDE
+              NUM_VAL              = 49
+              CLASS                = &quot;1&quot;
+              VALUE                = (-151.230041503906, -151.499053955078, -151.973571777344, -152.160858154297, -152.657440185547, -152.92741394043, -153.526336669922, -154.298614501953, -154.929840087891, -154.7373046875, -155.374572753906, -155.247283935547, -155.610641479492, -155.519653320312, 
+                                      -156.191909790039, -155.247436523438, -151.205200195312, -148.397186279297, -145.549255371094, -142.321365356445, -139.459701538086, -136.62353515625, -133.950225830078, -131.668121337891, -129.557220458984, -127.639266967773, -125.918418884277, 
+                                      -124.321533203125, -122.989028930664, -121.826416015625, -120.859039306641, -119.873237609863, -114.051330566406, -114.896896362305, -115.917068481445, -117.146820068359, -118.598236083984, -120.307495117188, -122.164825439453, -124.004768371582, 
+                                      -125.833290100098, -128.372283935547, -130.946624755859, -133.637390136719, -136.756042480469, -140.436050415039, -143.870941162109, -147.515991210938, -151.070404052734)
+            END_OBJECT             = GRINGPOINTLONGITUDE
+
+            OBJECT                 = GRINGPOINTLATITUDE
+              NUM_VAL              = 49
+              CLASS                = &quot;1&quot;
+              VALUE                = (61.3898696899414, 61.1368026733398, 60.9190139770508, 60.6650085449219, 60.4524230957031, 59.6670608520508, 59.479736328125, 58.2746543884277, 57.8501815795898, 57.5735092163086, 57.1609001159668, 56.8986663818359, 56.7026443481445, 56.448917388916, 
+                                      56.0578765869141, 55.6990432739258, 54.4887084960938, 53.4643173217773, 52.2453918457031, 50.6053237915039, 48.8744163513184, 46.842113494873, 44.5652198791504, 42.2700309753418, 39.7784118652344, 37.1184158325195, 34.3108291625977, 31.2275409698486, 
+                                      28.171085357666, 24.9957008361816, 21.8270568847656, 17.9381160736084, 17.7894229888916, 22.2553482055664, 26.4402351379395, 30.4696483612061, 34.3356170654297, 38.0407333374023, 41.3709487915039, 44.1072235107422, 46.4499740600586, 49.2064437866211, 
+                                      51.5417709350586, 53.6000289916992, 55.6015243530273, 57.5468711853027, 59.0401916503906, 60.3507461547852, 61.4046058654785)
+            END_OBJECT             = GRINGPOINTLATITUDE
+
+            OBJECT                 = GRINGPOINTSEQUENCENO
+              NUM_VAL              = 49
+              CLASS                = &quot;1&quot;
+              VALUE                = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49)
+            END_OBJECT             = GRINGPOINTSEQUENCENO
+
+          END_GROUP              = GRINGPOINT
+
+          GROUP                  = GRING
+            CLASS                = &quot;1&quot;
+
+            OBJECT                 = EXCLUSIONGRINGFLAG
+              NUM_VAL              = 1
+              VALUE                = &quot;N&quot;
+              CLASS                = &quot;1&quot;
+            END_OBJECT             = EXCLUSIONGRINGFLAG
+
+          END_GROUP              = GRING
+
+        END_OBJECT             = GPOLYGONCONTAINER
+
+      END_GROUP              = GPOLYGON
+
+    END_GROUP              = HORIZONTALSPATIALDOMAINCONTAINER
+
+  END_GROUP              = SPATIALDOMAINCONTAINER
+
+  GROUP                  = RANGEDATETIME
+
+    OBJECT                 = RANGEENDINGDATE
+      NUM_VAL              = 1
+      VALUE                = &quot;2013-07-01&quot;
+    END_OBJECT             = RANGEENDINGDATE
+
+    OBJECT                 = RANGEENDINGTIME
+      NUM_VAL              = 1
+      VALUE                = &quot;22:59:40&quot;
+    END_OBJECT             = RANGEENDINGTIME
+
+    OBJECT                 = RANGEBEGINNINGDATE
+      NUM_VAL              = 1
+      VALUE                = &quot;2013-07-01&quot;
+    END_OBJECT             = RANGEBEGINNINGDATE
+
+    OBJECT                 = RANGEBEGINNINGTIME
+      NUM_VAL              = 1
+      VALUE                = &quot;22:53:52&quot;
+    END_OBJECT             = RANGEBEGINNINGTIME
+
+  END_GROUP              = RANGEDATETIME
+
+  GROUP                  = PGEVERSIONCLASS
+
+    OBJECT                 = PGEVERSION
+      NUM_VAL              = 1
+      VALUE                = (&quot;3.0.0&quot;)
+    END_OBJECT             = PGEVERSION
+
+  END_GROUP              = PGEVERSIONCLASS
+
+END_GROUP              = INVENTORYMETADATA
+
+END
+</Value>
+    </Attribute>
+    <Attribute name="history" type="String">
+        <Value>2023-03-17T01:06:24Z:/tempo/nas0/sdpc_soft/install/gnu-rh8/sdpc/v4/bin/L1_trace_gas -tempo -wrt_odl
+2023-03-17T01:45:50Z: L2_split -v -c /tempo/nas0/sdpc/liveroot/temposdpc/SDPCST6/etc/l2_split.cfg /tempo/nas0/sdpc_archive/temposdpc/SDPCST6/L2/RAD/D04930/S010/G01/NO2/TEMPO_NO2_L2_V01_20130701T215955Z_S010G01.nc /tempo/nas0/sdpc_archive/temposdpc/SDPCST6/L2/RAD/D04930/S010/G02/NO2/TEMPO_NO2_L2_V01_20130701T220554Z_S010G02.nc /tempo/nas0/sdpc_archive/temposdpc/SDPCST6/L2/RAD/D04930/S010/G03/NO2/TEMPO_NO2_L2_V01_20130701T221154Z_S010G03.nc /tempo/nas0/sdpc_archive/temposdpc/SDPCST6/L2/RAD/D04930/S010/G04/NO2/TEMPO_NO2_L2_V01_20130701T221754Z_S010G04.nc /tempo/nas0/sdpc_archive/temposdpc/SDPCST6/L2/RAD/D04930/S010/G05/NO2/TEMPO_NO2_L2_V01_20130701T222354Z_S010G05.nc /tempo/nas0/sdpc_archive/temposdpc/SDPCST6/L2/RAD/D04930/S010/G06/NO2/TEMPO_NO2_L2_V01_20130701T222953Z_S010G06.nc /tempo/nas0/sdpc_archive/temposdpc/SDPCST6/L2/RAD/D04930/S010/G07/NO2/TEMPO_NO2_L2_V01_20130701T223553Z_S010G07.nc /tempo/nas0/sdpc_archive/temposdpc/SDPCST6/L2/RAD/D04930/S010/G08/NO2/TEMPO_NO2_L2_V01_20130701T224153Z_S010G08.nc /tempo/nas0/sdpc_archive/temposdpc/SDPCST6/L2/RAD/D04930/S010/G09/NO2/TEMPO_NO2_L2_V01_20130701T224753Z_S010G09.nc /tempo/nas0/sdpc_archive/temposdpc/SDPCST6/L2/RAD/D04930/S010/G10/NO2/TEMPO_NO2_L2_V01_20130701T225352Z_S010G10.nc
+</Value>
+    </Attribute>
+    <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="build_dmrpp" type="String">
+            <Value>3.20.13-0</Value>
+        </Attribute>
+        <Attribute name="bes" type="String">
+            <Value>3.20.13-0</Value>
+        </Attribute>
+        <Attribute name="libdap" type="String">
+            <Value>libdap-3.20.11-0</Value>
+        </Attribute>
+        <Attribute name="configuration" type="String">
+            <Value>
+# TheBESKeys::get_as_config()
+AllowedHosts=^https?:\/\/
+BES.Catalog.catalog.FollowSymLinks=Yes
+BES.Catalog.catalog.RootDirectory=.
+BES.Catalog.catalog.TypeMatch=dmrpp:.*\.(dmrpp)$;
+BES.Catalog.catalog.TypeMatch+=h5:.*(\.bz2|\.gz|\.Z)?$;
+BES.Data.RootDirectory=/dev/null
+BES.LogName=./bes.log
+BES.UncompressCache.dir=/tmp/hyrax_ux
+BES.UncompressCache.prefix=ux_
+BES.UncompressCache.size=500
+BES.module.cmd=/usr/lib64/bes/libdap_xml_module.so
+BES.module.dap=/usr/lib64/bes/libdap_module.so
+BES.module.dmrpp=/usr/lib64/bes/libdmrpp_module.so
+BES.module.fonc=/usr/lib64/bes/libfonc_module.so
+BES.module.h5=/usr/lib64/bes/libhdf5_module.so
+BES.module.nc=/usr/lib64/bes/libnc_module.so
+BES.modules=dap,cmd,h5,dmrpp,nc,fonc
+FONc.ClassicModel=false
+FONc.NoGlobalAttrs=true
+H5.EnableCF=false
+H5.EnableCheckNameClashing=true
+</Value>
+        </Attribute>
+        <Attribute name="invocation" type="String">
+            <Value>build_dmrpp -c /tmp/bes_conf_JXN7 -f ./TEMPO_NO2_L2_V01_20130701T225352Z_S010G10.nc -r /tmp/dmr__ogt33z -u https://opendap-dev.larc.nasa.gov/opendap/TEMPO/TEMPO_NO2_L2_V01/TEMPO_NO2_L2_V01_20130701T225352Z_S010G10.nc -M</Value>
+        </Attribute>
+    </Attribute>
+    <Group name="product">
+        <Float64 name="vertical_column_total">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>nitrogen dioxide vertical column</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>nitrogen dioxide vertical column determined from fitted slant column and total AMF calculated from surface to top of atmosphere</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>molecules/cm^2</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float64">
+                <Value>-1e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="73255838" nBytes="1949696"/>
+            </dmrpp:chunks>
+        </Float64>
+        <Float64 name="vertical_column_total_uncertainty">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>nitrogen dioxide vertical column uncertainty</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>molecules/cm^2</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float64">
+                <Value>-1e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="75205534" nBytes="1949696"/>
+            </dmrpp:chunks>
+        </Float64>
+        <Int16 name="main_data_quality_flag">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>main data quality flag</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Int16">
+                <Value>0</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Int16">
+                <Value>2</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>-1</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>normal suspicious bad</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int32">
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>2</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1" byteOrder="LE">
+                <dmrpp:chunk offset="77158302" nBytes="487424"/>
+            </dmrpp:chunks>
+        </Int16>
+        <Float64 name="vertical_column_stratosphere">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="_FillValue" type="Float64">
+                <Value>-1e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>stratosphere nitrogen dioxide vertical column</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>molecules/cm^2</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="79612045" nBytes="1949696"/>
+            </dmrpp:chunks>
+        </Float64>
+        <Float64 name="vertical_column_troposphere">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="_FillValue" type="Float64">
+                <Value>-1e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>troposphere nitrogen dioxide vertical column</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>molecules/cm^2</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="77662349" nBytes="1949696"/>
+            </dmrpp:chunks>
+        </Float64>
+    </Group>
+    <Group name="geolocation">
+        <Float64 name="time">
+            <Dim name="/mirror_step"/>
+            <Attribute name="standard_name" type="String">
+                <Value>time</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>radiance exposure start time</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>seconds since 2000-01-01T12:00:00Z</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float64">
+                <Value>-1e+30</Value>
+            </Attribute>
+            <Attribute name="calendar" type="String">
+                <Value>gregorian</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="5413219" nBytes="952"/>
+            </dmrpp:chunks>
+        </Float64>
+        <Float32 name="solar_azimuth_angle">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>solar azimuth angle at pixel center</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>degrees</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>-180.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>180.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="8338715" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="solar_zenith_angle">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>solar zenith angle at pixel center</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>degrees</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>90.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="7363867" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="longitude">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="standard_name" type="String">
+                <Value>longitude</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>pixel center longitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>longitude at pixel center</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>degrees_east</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>-180.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>180.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="bounds" type="String">
+                <Value>longitude_bounds</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="5414171" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="longitude_bounds">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Dim name="/corner"/>
+            <Attribute name="long_name" type="String">
+                <Value>pixel corner longitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>longitude at pixel corners (SW,SE,NE,NW)</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>-180.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>180.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="18587235" nBytes="3899392"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="latitude">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="standard_name" type="String">
+                <Value>latitude</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>pixel center latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>latitude at pixel center</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>degrees_north</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>-90.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>90.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="bounds" type="String">
+                <Value>latitude_bounds</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="6389019" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="viewing_zenith_angle">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>viewing zenith angle at pixel center</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>degrees</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>90.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="9313563" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="latitude_bounds">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Dim name="/corner"/>
+            <Attribute name="long_name" type="String">
+                <Value>pixel corner latitude</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>latitude at pixel corners (SW,SE,NE,NW)</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>-90.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>90.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="14687843" nBytes="3899392"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="relative_azimuth_angle">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>relative azimuth angle at pixel center</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>degrees</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>-180.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>180.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="11263259" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="viewing_azimuth_angle">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>viewing azimuth angle at pixel center</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>degrees</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>-180.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>180.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="10288411" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+    </Group>
+    <Group name="support_data">
+        <Float32 name="surface_pressure">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>surface pressure</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>hPa</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>1200.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <Attribute name="Eta_A" type="Float32">
+                <Value>0.</Value>
+                <Value>0.04804826155</Value>
+                <Value>6.593751907</Value>
+                <Value>13.13479996</Value>
+                <Value>19.61310959</Value>
+                <Value>26.0920105</Value>
+                <Value>32.57080841</Value>
+                <Value>38.98200989</Value>
+                <Value>45.33900833</Value>
+                <Value>51.69610977</Value>
+                <Value>58.05321121</Value>
+                <Value>64.36264038</Value>
+                <Value>70.62197876</Value>
+                <Value>78.83422089</Value>
+                <Value>89.09992218</Value>
+                <Value>99.36521149</Value>
+                <Value>109.1817017</Value>
+                <Value>118.9586029</Value>
+                <Value>128.6959076</Value>
+                <Value>142.9100037</Value>
+                <Value>156.2599945</Value>
+                <Value>169.6089935</Value>
+                <Value>181.6190033</Value>
+                <Value>193.0970001</Value>
+                <Value>203.2590027</Value>
+                <Value>212.1499939</Value>
+                <Value>218.776001</Value>
+                <Value>223.897995</Value>
+                <Value>224.3630066</Value>
+                <Value>216.8650055</Value>
+                <Value>201.1920013</Value>
+                <Value>176.9299927</Value>
+                <Value>150.3930054</Value>
+                <Value>127.836998</Value>
+                <Value>108.663002</Value>
+                <Value>92.36572266</Value>
+                <Value>78.51230621</Value>
+                <Value>66.60340881</Value>
+                <Value>56.38790894</Value>
+                <Value>47.64390945</Value>
+                <Value>40.17541122</Value>
+                <Value>33.810009</Value>
+                <Value>28.3678093</Value>
+                <Value>23.73040962</Value>
+                <Value>19.79159927</Value>
+                <Value>16.45709991</Value>
+                <Value>13.64340019</Value>
+                <Value>11.27690029</Value>
+                <Value>9.292942047</Value>
+                <Value>7.619842052</Value>
+                <Value>6.216801167</Value>
+                <Value>5.04680109</Value>
+                <Value>4.076570988</Value>
+                <Value>3.276431084</Value>
+                <Value>2.620210886</Value>
+                <Value>2.084969997</Value>
+                <Value>1.650789976</Value>
+                <Value>1.300510049</Value>
+                <Value>1.019440055</Value>
+                <Value>0.7951341271</Value>
+                <Value>0.616779089</Value>
+                <Value>0.4758060873</Value>
+                <Value>0.3650411069</Value>
+                <Value>0.2785260975</Value>
+                <Value>0.2113489956</Value>
+                <Value>0.1594949961</Value>
+                <Value>0.1197030023</Value>
+                <Value>0.08934502304</Value>
+                <Value>0.06600000709</Value>
+                <Value>0.04758501053</Value>
+                <Value>0.03269999847</Value>
+                <Value>0.01999999955</Value>
+                <Value>0.009999999776</Value>
+            </Attribute>
+            <Attribute name="Eta_B" type="Float32">
+                <Value>1.</Value>
+                <Value>0.984951973</Value>
+                <Value>0.9634060264</Value>
+                <Value>0.941865027</Value>
+                <Value>0.9203870296</Value>
+                <Value>0.8989080191</Value>
+                <Value>0.8774290085</Value>
+                <Value>0.8560180068</Value>
+                <Value>0.8346608877</Value>
+                <Value>0.8133038878</Value>
+                <Value>0.791946888</Value>
+                <Value>0.7706375122</Value>
+                <Value>0.7493782043</Value>
+                <Value>0.7211660147</Value>
+                <Value>0.6858999133</Value>
+                <Value>0.6506348848</Value>
+                <Value>0.6158183813</Value>
+                <Value>0.5810415149</Value>
+                <Value>0.5463042259</Value>
+                <Value>0.494590193</Value>
+                <Value>0.4437401891</Value>
+                <Value>0.392891109</Value>
+                <Value>0.3433811069</Value>
+                <Value>0.294403106</Value>
+                <Value>0.2467411011</Value>
+                <Value>0.2003501058</Value>
+                <Value>0.1562241018</Value>
+                <Value>0.1136021018</Value>
+                <Value>0.06372006238</Value>
+                <Value>0.02801004052</Value>
+                <Value>0.006960025057</Value>
+                <Value>8.175413235e-09</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+                <Value>0.</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="46262445" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="amf_cloud_pressure">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>cloud pressure</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>cloud pressure for AMF computation</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>hPa</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>1200.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="45287597" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Int16 name="terrain_height">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>terrain height</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>m</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Int16">
+                <Value>-1000</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Int16">
+                <Value>10000</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>-30000</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-30000" byteOrder="LE">
+                <dmrpp:chunk offset="13212955" nBytes="487424"/>
+            </dmrpp:chunks>
+        </Int16>
+        <Float64 name="fitted_slant_column_uncertainty">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>nitrogen dioxide fitted slant column uncertainty</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>molecules/cm^2</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float64">
+                <Value>-1e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="2001251" nBytes="1949696"/>
+            </dmrpp:chunks>
+        </Float64>
+        <Float32 name="amf_troposphere">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>nitrogen dioxide tropospheric air mass factor</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="42363053" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float64 name="fitted_slant_column">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>nitrogen dioxide fitted slant column</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>molecules/cm^2</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float64">
+                <Value>-1e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="51555" nBytes="1949696"/>
+            </dmrpp:chunks>
+        </Float64>
+        <Float32 name="gas_profile">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Dim name="/swt_level"/>
+            <Attribute name="long_name" type="String">
+                <Value>vertical profile of nitrogen dioxide partial column</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>molecules/cm^2</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks compressionType="shuffle deflate" fillValue="9.96921e+36" byteOrder="LE">
+                <dmrpp:chunkDimensionSizes>119 128 72</dmrpp:chunkDimensionSizes>
+                <dmrpp:chunk offset="22489763" nBytes="508748" chunkPositionInArray="[0,0,0]"/>
+                <dmrpp:chunk offset="22998511" nBytes="1176688" chunkPositionInArray="[0,128,0]"/>
+                <dmrpp:chunk offset="24175199" nBytes="800771" chunkPositionInArray="[0,256,0]"/>
+                <dmrpp:chunk offset="24975970" nBytes="585495" chunkPositionInArray="[0,384,0]"/>
+                <dmrpp:chunk offset="25561465" nBytes="484449" chunkPositionInArray="[0,512,0]"/>
+                <dmrpp:chunk offset="26045914" nBytes="420875" chunkPositionInArray="[0,640,0]"/>
+                <dmrpp:chunk offset="69465052" nBytes="370566" chunkPositionInArray="[0,768,0]"/>
+                <dmrpp:chunk offset="69835618" nBytes="344408" chunkPositionInArray="[0,896,0]"/>
+                <dmrpp:chunk offset="70180026" nBytes="307198" chunkPositionInArray="[0,1024,0]"/>
+                <dmrpp:chunk offset="70487224" nBytes="288063" chunkPositionInArray="[0,1152,0]"/>
+                <dmrpp:chunk offset="70775287" nBytes="275120" chunkPositionInArray="[0,1280,0]"/>
+                <dmrpp:chunk offset="71050407" nBytes="261663" chunkPositionInArray="[0,1408,0]"/>
+                <dmrpp:chunk offset="71312070" nBytes="254266" chunkPositionInArray="[0,1536,0]"/>
+                <dmrpp:chunk offset="71566336" nBytes="244881" chunkPositionInArray="[0,1664,0]"/>
+                <dmrpp:chunk offset="71811217" nBytes="240126" chunkPositionInArray="[0,1792,0]"/>
+                <dmrpp:chunk offset="72051343" nBytes="227599" chunkPositionInArray="[0,1920,0]"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="amf_cloud_fraction">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>cloud fraction</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>cloud radiance fraction for AMF computation</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>1.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1" byteOrder="LE">
+                <dmrpp:chunk offset="43337901" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="snow_ice_fraction">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>fraction of pixel area covered by snow and/or ice</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>1.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="12238107" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Int16 name="amf_diagnostic_flag">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>nitrogen dioxide air mass factor diagnostic flag</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>-1</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>geometric_AMF glint snow_correction no_cloud_pressure adjusted_surface_pressure adjusted_cloud_pressure no_albedo no_cloud_fraction no_gas_climatology no_scattering_weights AMF_disabled</Value>
+            </Attribute>
+            <Attribute name="flag_masks" type="Int32">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>4</Value>
+                <Value>8</Value>
+                <Value>16</Value>
+                <Value>32</Value>
+                <Value>2048</Value>
+                <Value>4096</Value>
+                <Value>8192</Value>
+                <Value>16384</Value>
+                <Value>32768</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1" byteOrder="LE">
+                <dmrpp:chunk offset="39925933" nBytes="487424"/>
+            </dmrpp:chunks>
+        </Int16>
+        <Float32 name="albedo">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>surface albedo</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>1.</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="9.96921e+36" byteOrder="LE">
+                <dmrpp:chunk offset="26466789" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="amf_total">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>nitrogen dioxide air mass factor</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>total nitrogen dioxide air mass factor (AMF) calculated from surface to top of atmosphere</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="40413357" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="scattering_weights">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Dim name="/swt_level"/>
+            <Attribute name="long_name" type="String">
+                <Value>scattering weights</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>vertical profile of scattering weights</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks compressionType="shuffle deflate" fillValue="9.96921e+36" byteOrder="LE">
+                <dmrpp:chunkDimensionSizes>119 128 72</dmrpp:chunkDimensionSizes>
+                <dmrpp:chunk offset="27444773" nBytes="713801" chunkPositionInArray="[0,0,0]"/>
+                <dmrpp:chunk offset="28158574" nBytes="2286040" chunkPositionInArray="[0,128,0]"/>
+                <dmrpp:chunk offset="30444614" nBytes="2389382" chunkPositionInArray="[0,256,0]"/>
+                <dmrpp:chunk offset="32833996" nBytes="2377033" chunkPositionInArray="[0,384,0]"/>
+                <dmrpp:chunk offset="35211029" nBytes="2348266" chunkPositionInArray="[0,512,0]"/>
+                <dmrpp:chunk offset="37559295" nBytes="2366638" chunkPositionInArray="[0,640,0]"/>
+                <dmrpp:chunk offset="47239341" nBytes="2346272" chunkPositionInArray="[0,768,0]"/>
+                <dmrpp:chunk offset="49585613" nBytes="2278260" chunkPositionInArray="[0,896,0]"/>
+                <dmrpp:chunk offset="51863873" nBytes="2286365" chunkPositionInArray="[0,1024,0]"/>
+                <dmrpp:chunk offset="54150238" nBytes="2307993" chunkPositionInArray="[0,1152,0]"/>
+                <dmrpp:chunk offset="56458231" nBytes="2330798" chunkPositionInArray="[0,1280,0]"/>
+                <dmrpp:chunk offset="58789029" nBytes="2293152" chunkPositionInArray="[0,1408,0]"/>
+                <dmrpp:chunk offset="61082181" nBytes="2219737" chunkPositionInArray="[0,1536,0]"/>
+                <dmrpp:chunk offset="63301918" nBytes="2095770" chunkPositionInArray="[0,1664,0]"/>
+                <dmrpp:chunk offset="65397688" nBytes="2050993" chunkPositionInArray="[0,1792,0]"/>
+                <dmrpp:chunk offset="67448681" nBytes="2016371" chunkPositionInArray="[0,1920,0]"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="tropopause_pressure">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>tropopause pressure</Value>
+            </Attribute>
+            <Attribute name="units" type="String">
+                <Value>hPa</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>1200.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="72280990" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="eff_cloud_fraction">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>effective cloud fraction</Value>
+            </Attribute>
+            <Attribute name="comment" type="String">
+                <Value>effective cloud fraction from cloud retrieval</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>1.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1" byteOrder="LE">
+                <dmrpp:chunk offset="44312749" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Float32 name="amf_stratosphere">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>nitrogen dioxide stratospheric air mass factor</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="41388205" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Int32 name="ground_pixel_quality_flag">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <Attribute name="long_name" type="String">
+                <Value>ground pixel quality flag</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>shallow_ocean land shallow_inland_water shoreline intermittent_water deep_inland_water continental_shelf_ocean deep_ocean land_water_error sun_glint_possibility solar_eclipse_possibility water evergreen_needleleaf_forest evergreen_broadleaf_forest deciduous_needleleaf_forest deciduous_broadleaf_forest mixed_forest closed_shrublands open_shrublands woody_savannas savannas grasslands permanent_wetlands croplands urban_and_built_up cropland_natural_vegetation_mosaic snow_and_ice barren_or_sparsely_vegetated unclassified fill_value</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="UInt32">
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+                <Value>5</Value>
+                <Value>6</Value>
+                <Value>7</Value>
+                <Value>15</Value>
+                <Value>16</Value>
+                <Value>32</Value>
+                <Value>0</Value>
+                <Value>65536</Value>
+                <Value>131072</Value>
+                <Value>196608</Value>
+                <Value>262144</Value>
+                <Value>327680</Value>
+                <Value>393216</Value>
+                <Value>458752</Value>
+                <Value>524288</Value>
+                <Value>589824</Value>
+                <Value>655360</Value>
+                <Value>720896</Value>
+                <Value>786432</Value>
+                <Value>851968</Value>
+                <Value>917504</Value>
+                <Value>983040</Value>
+                <Value>1048576</Value>
+                <Value>16646144</Value>
+                <Value>16711680</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-2147483647" byteOrder="LE">
+                <dmrpp:chunk offset="13700379" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Int32>
+    </Group>
+    <Group name="qa_statistics">
+        <Float32 name="fit_rms_residual">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>radiance fit RMS residual</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Float32">
+                <Value>0.</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Float32">
+                <Value>0.009999999776</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Float32">
+                <Value>-1.000000015e+30</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-1e+30" byteOrder="LE">
+                <dmrpp:chunk offset="3950947" nBytes="974848"/>
+            </dmrpp:chunks>
+        </Float32>
+        <Int16 name="fit_convergence_flag">
+            <Dim name="/mirror_step"/>
+            <Dim name="/xtrack"/>
+            <Attribute name="long_name" type="String">
+                <Value>radiance fit convergence flag</Value>
+            </Attribute>
+            <Attribute name="valid_min" type="Int16">
+                <Value>-10</Value>
+            </Attribute>
+            <Attribute name="valid_max" type="Int16">
+                <Value>12344</Value>
+            </Attribute>
+            <Attribute name="_FillValue" type="Int16">
+                <Value>-30000</Value>
+            </Attribute>
+            <Attribute name="coordinates" type="String">
+                <Value>time longitude latitude</Value>
+            </Attribute>
+            <Attribute name="flag_meanings" type="String">
+                <Value>failed maxiter_exceeded suspect good</Value>
+            </Attribute>
+            <Attribute name="flag_values" type="Int32">
+                <Value>-2</Value>
+                <Value>-1</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+            </Attribute>
+            <dmrpp:chunks fillValue="-30000" byteOrder="LE">
+                <dmrpp:chunk offset="4925795" nBytes="487424"/>
+            </dmrpp:chunks>
+        </Int16>
+        <Attribute name="num_crosstrack_pixels" type="Int32">
+            <Value>2048</Value>
+        </Attribute>
+        <Attribute name="num_scan_lines" type="Int32">
+            <Value>119</Value>
+        </Attribute>
+        <Attribute name="num_good_input" type="Int32">
+            <Value>243693</Value>
+        </Attribute>
+        <Attribute name="num_good_output" type="Int32">
+            <Value>55997</Value>
+        </Attribute>
+        <Attribute name="num_suspect_output" type="Int32">
+            <Value>1179</Value>
+        </Attribute>
+        <Attribute name="num_bad_output" type="Int32">
+            <Value>186517</Value>
+        </Attribute>
+        <Attribute name="num_converged" type="Int32">
+            <Value>55997</Value>
+        </Attribute>
+        <Attribute name="num_failed_convergence" type="Int32">
+            <Value>186059</Value>
+        </Attribute>
+        <Attribute name="num_exceeded_iterations" type="Int32">
+            <Value>184862</Value>
+        </Attribute>
+        <Attribute name="num_out_of_bounds" type="Int32">
+            <Value>458</Value>
+        </Attribute>
+        <Attribute name="percent_good_output" type="Float32">
+            <Value>22.97850227</Value>
+        </Attribute>
+        <Attribute name="percent_bad_output" type="Float32">
+            <Value>76.53768921</Value>
+        </Attribute>
+        <Attribute name="percent_suspect_output" type="Float32">
+            <Value>0.4838054478</Value>
+        </Attribute>
+    </Group>
+</Dataset>

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -353,7 +353,7 @@ CurlHandlePool::get_easy_handle(Chunk *chunk) {
                      prolog << "Got AccessCredentials instance: " << endl << credentials->to_json() << endl);
             // If there are available credentials, and they are S3 credentials then we need to sign
             // the request
-            const std::time_t request_time = std::time(0);
+            const std::time_t request_time = std::time(nullptr);
 
             const std::string auth_header =
                     AWSV4::compute_awsv4_signature(


### PR DESCRIPTION
This PR adds a new function `dap_utils::compute_response_size_and_inv_big_vars()` that inventories each constrained variable in the provided libdap object whose total size in bytes is in excess of a provided `max_size`. The call returns the total size, in bytes, of the constrained object(s).

The function is located in `bes/dap/DapUtils.cc` 

This is just the function for the calculation, not the application of it to determine if a request will be handled.  That is much more complex and I would like to separate that PR from this one.