### PR TITLE
First draft of unsupported fillValue handing

### DIFF
--- a/modules/dmrpp_module/DMZ.h
+++ b/modules/dmrpp_module/DMZ.h
@@ -132,6 +132,7 @@ public:
     virtual void load_chunks(libdap::BaseType *btp);
 
     virtual void load_all_attributes(libdap::DMR *dmr);
+
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppCommon.h
+++ b/modules/dmrpp_module/DmrppCommon.h
@@ -99,6 +99,10 @@ class DmrppCommon {
     friend class DmrppParserTest;
     friend class DMZTest;
 
+    // We use this to "turn-off" a variable. If this is set to true,
+    // Then the variable will
+    bool d_is_elided = false;
+
     bool d_compact = false;
 	std::string d_filters;
 	std::string d_byte_order;
@@ -254,7 +258,10 @@ public:
     /// @return Return true if this variable contains one chunk and the data are all 'fill value.'
     virtual bool get_one_chunk_fill_value() const { return d_one_chunk_fill_value; }
 
-    
+    void set_elided(bool is_eilided) { d_is_elided = is_eilided; }
+    bool get_elided() { return d_is_elided; }
+    bool is_elided() { return d_is_elided; }
+
     void print_chunks_element(libdap::XMLWriter &xml, const std::string &name_space = "");
 
     void print_compact_element(libdap::XMLWriter &xml, const std::string &name_space = "", const std::string &encoded = "");


### PR DESCRIPTION
This PR adds the function:
```
void check_fillValue_attribute_for_unsupported_types(xml_attribute attr);
```
To the DMZ.cc and it is called by DMZ::process_chunks(). 

This new function throws  an exception when the value  of  the `dmrpp/@fillValue` attribute is any of:
 * "`unsupported-string`"
 * "`unsupported-array`"
 * "`unsupported-compound`"
 * "`unsupported-variable-length-string`"
 
This causes 7 of the dmrpp_module/tests: 139, 140, 193, 194, 195, 196, 197 to fail. In every case the new function found "`unsupported-string`" 

I'm going to look at eliding the offending variable from the DMR.