### PR TITLE
Elide unsupported

### DIFF
--- a/modules/dmrpp_module/DMZ.cc
+++ b/modules/dmrpp_module/DMZ.cc
@@ -220,20 +220,14 @@ bool flagged_as_unsupported_type(xml_node var_node, string &unsupported_flag) {
         return is_unsupported_type;
     }
 
-    xml_attribute *fillValue = nullptr;
-    for (xml_attribute attr = chunks.first_attribute(); attr; attr = attr.next_attribute()) {
-        if (is_eq(attr.name(), "fillValue")) {
-            fillValue = &attr;
-        }
-    }
-
-    if(!fillValue) {
+    xml_attribute fillValue_attr  = chunks.attribute("fillValue");
+    if(!fillValue_attr) {
         // No fillValue attribute? Then we can be done, it's supported.
         return is_unsupported_type;
     }
 
     // We found th fillValue attribute, So now we have to deal with its various tragic values...
-    if(is_eq(fillValue->value(),UNSUPPORTED_STRING)){
+    if(is_eq(fillValue_attr.value(), UNSUPPORTED_STRING)){
         // UNSUPPORTED_STRING is the older, indeterminate, tag which might label a truly
         // unsupported VariableLengthString or it could be a labeling FixedLengthString.
         // In order to find out we need to look in XML DOM to determine if this is an Array, and
@@ -248,7 +242,7 @@ bool flagged_as_unsupported_type(xml_node var_node, string &unsupported_flag) {
         if(!dim_node) {
             // No dims? Then this is a scalar String and it's cool.
             // We dump the BS fillValue for one that makes some sense in Stringville
-            fillValue->set_value("");
+            fillValue_attr.set_value("");
             is_unsupported_type = false;
         }
         else {
@@ -257,22 +251,22 @@ bool flagged_as_unsupported_type(xml_node var_node, string &unsupported_flag) {
             if(flsa_node){
                 // FixedLengthStringArray arrays work!
                 // We dump the BS fillValue for one that makes some sense in Stringville
-                fillValue->set_value("");
+                fillValue_attr.set_value("");
                 is_unsupported_type = false;
             }
         }
     }
-    else if(is_eq(fillValue->value(),UNSUPPORTED_VARIABLE_LENGTH_STRING)) {
+    else if(is_eq(fillValue_attr.value(),UNSUPPORTED_VARIABLE_LENGTH_STRING)) {
         is_unsupported_type = true;
     }
-    else if(is_eq(fillValue->value(),UNSUPPORTED_ARRAY)){
+    else if(is_eq(fillValue_attr.value(),UNSUPPORTED_ARRAY)){
         is_unsupported_type =  true;
     }
-    else if(is_eq(fillValue->value(),UNSUPPORTED_COMPOUND)){
+    else if(is_eq(fillValue_attr.value(),UNSUPPORTED_COMPOUND)){
         is_unsupported_type =  true;
     }
 
-    if(is_unsupported_type) { unsupported_flag = fillValue->value(); }
+    if(is_unsupported_type) { unsupported_flag = fillValue_attr.value(); }
 
     return is_unsupported_type;
 }

--- a/modules/dmrpp_module/DMZ.cc
+++ b/modules/dmrpp_module/DMZ.cc
@@ -256,11 +256,12 @@ bool flagged_as_unsupported_type(xml_node var_node, string &unsupported_flag) {
     }
 
     xml_attribute *fillValue = nullptr;
-    for (xml_attribute attr = chunks.first_attribute(); attr && !fillValue; attr = attr.next_attribute()) {
+    for (xml_attribute attr = chunks.first_attribute(); attr; attr = attr.next_attribute()) {
         if (is_eq(attr.name(), "fillValue")) {
             fillValue = &attr;
         }
     }
+
     if(!fillValue) {
         // No fillValue attribute? Then we can be done, it's supported.
         return is_unsupported_type;

--- a/modules/dmrpp_module/DMZ.h
+++ b/modules/dmrpp_module/DMZ.h
@@ -81,7 +81,7 @@ private:
     void process_dataset(libdap::DMR *dmr, const pugi::xml_node &xml_root);
     static pugi::xml_node get_variable_xml_node(libdap::BaseType *btp);
     void process_chunk(dmrpp::DmrppCommon *dc, const pugi::xml_node &chunk) const;
-    void process_chunks(libdap::BaseType *btp, const pugi::xml_node &chunks) const;
+    bool process_chunks(libdap::BaseType *btp, const pugi::xml_node &chunks) const;
 
     static void process_fill_value_chunks(dmrpp::DmrppCommon *dc, const std::set<shape> &chunk_map, const shape &chunk_shape,
                                    const shape &array_shape, unsigned long long chunk_size);

--- a/modules/dmrpp_module/DMZ.h
+++ b/modules/dmrpp_module/DMZ.h
@@ -75,9 +75,15 @@ private:
     pugi::xml_document d_xml_doc;
     std::shared_ptr<http::url> d_dataset_elem_href;
 
+    // Controls if teh parser will drop variables that have been flagged
+    // with a dmrpp:chunks/@fillValue attribute value of "unsupported-*"
+    // This is set from TheBESKeys in the DMZ's constructor.
+    static bool d_elide_unsupported;
+
     /// Holds names of the XML elements that define variables (e.g., Byte)
     static const std::set<std::string> variable_elements;
 
+    static void load_config_from_keys();
     void process_dataset(libdap::DMR *dmr, const pugi::xml_node &xml_root);
     static pugi::xml_node get_variable_xml_node(libdap::BaseType *btp);
     void process_chunk(dmrpp::DmrppCommon *dc, const pugi::xml_node &chunk) const;
@@ -96,7 +102,7 @@ private:
     static void build_basetype_chain(libdap::BaseType *btp, std::stack<libdap::BaseType*> &bt);
 
     static void process_group(libdap::DMR *dmr, libdap::D4Group *parent, const pugi::xml_node &var_node);
-    static void  process_dimension(libdap::D4Group *grp, const pugi::xml_node &dimension_node);
+    static void process_dimension(libdap::D4Group *grp, const pugi::xml_node &dimension_node);
     static void process_variable(libdap::DMR *dmr, libdap::D4Group *grp, libdap::Constructor *parent, const pugi::xml_node &var_node);
     static void process_dim(libdap::DMR *dmr, libdap::D4Group *grp, libdap::Array *array, const pugi::xml_node &dim_node);
     static void process_map(libdap::DMR *dmr, libdap::D4Group *grp, libdap::Array *array, const pugi::xml_node &map_node);

--- a/modules/dmrpp_module/DMZ.h
+++ b/modules/dmrpp_module/DMZ.h
@@ -132,7 +132,6 @@ public:
     virtual void load_chunks(libdap::BaseType *btp);
 
     virtual void load_all_attributes(libdap::DMR *dmr);
-
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DMZ.h
+++ b/modules/dmrpp_module/DMZ.h
@@ -132,6 +132,7 @@ public:
     virtual void load_chunks(libdap::BaseType *btp);
 
     virtual void load_all_attributes(libdap::DMR *dmr);
+
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppCommon.h
+++ b/modules/dmrpp_module/DmrppCommon.h
@@ -99,6 +99,10 @@ class DmrppCommon {
     friend class DmrppParserTest;
     friend class DMZTest;
 
+    // We use this to "turn-off" a variable. If this is set to true,
+    // Then the variable will
+    bool d_is_elided = false;
+
     bool d_compact = false;
 	std::string d_filters;
 	std::string d_byte_order;
@@ -254,7 +258,10 @@ public:
     /// @return Return true if this variable contains one chunk and the data are all 'fill value.'
     virtual bool get_one_chunk_fill_value() const { return d_one_chunk_fill_value; }
 
-    
+    void set_elided(bool is_eilided) { d_is_elided = is_eilided; }
+    bool get_elided() { return d_is_elided; }
+    bool is_elided() { return d_is_elided; }
+
     void print_chunks_element(libdap::XMLWriter &xml, const std::string &name_space = "");
 
     void print_compact_element(libdap::XMLWriter &xml, const std::string &name_space = "", const std::string &encoded = "");

--- a/modules/dmrpp_module/DmrppCommon.h
+++ b/modules/dmrpp_module/DmrppCommon.h
@@ -99,10 +99,6 @@ class DmrppCommon {
     friend class DmrppParserTest;
     friend class DMZTest;
 
-    // We use this to "turn-off" a variable. If this is set to true,
-    // Then the variable will
-    bool d_is_elided = false;
-
     bool d_compact = false;
 	std::string d_filters;
 	std::string d_byte_order;
@@ -258,9 +254,6 @@ public:
     /// @return Return true if this variable contains one chunk and the data are all 'fill value.'
     virtual bool get_one_chunk_fill_value() const { return d_one_chunk_fill_value; }
 
-    void set_elided(bool is_eilided) { d_is_elided = is_eilided; }
-    bool get_elided() { return d_is_elided; }
-    bool is_elided() { return d_is_elided; }
 
     void print_chunks_element(libdap::XMLWriter &xml, const std::string &name_space = "");
 

--- a/modules/dmrpp_module/dmrpp.conf.in
+++ b/modules/dmrpp_module/dmrpp.conf.in
@@ -55,6 +55,12 @@ BES.Catalog.catalog.TypeMatch+=dmrpp:.*\.(dmrpp)(\.bz2|\.gz|\.Z)?$;
 # DMRPP.ObjectCacheEntries = 100
 # DMRPP.ObjectCachePurgeLevel = 0.2
 
+####################################################################################
+# By default the BES will attempt to elide unsupported types.
+# Disable at your own risk.
+# DMRPP.Elide.Unsupported = false
+
+
 # NB: Providing/Defining CredentialsManager.config will cause the CredentialsManager
 # to locate and read from that file. If the file does not exist, or if it cannot be
 # read from, the CredentialsManager will write a message to the ErrorLog and it will


### PR DESCRIPTION
Drops variables whose `dmrpp:chunks/@fillValue` attribute has a value of
* `unsupported-string`
* `unsupported-array`
* `unsupported-compound`
* `unsupported-variable-length-string`

The `unsupported-string` case is more complex as it is an indiscriminate label that was applied to both the ArraysOfFixedLengthStrings and ArraysOfVariableLengthStrings prior to the implementation of the ArraysOfFixedLengthStrings solution.