### PR TITLE
Fixed the bug where a token is leaked when a Chunk gets an error from S3

### DIFF
--- a/modules/dmrpp_module/Chunk.cc
+++ b/modules/dmrpp_module/Chunk.cc
@@ -114,16 +114,17 @@ void process_s3_error_response(const shared_ptr<http::url> &data_url, const stri
 
     if (code == "AccessDenied") {
         stringstream msg;
-        msg << prolog << "ACCESS DENIED - The underlying object store has refused access to: ";
-        msg << data_url->str() << " Object Store Message: " << message;
+        msg << prolog << "ACCESS DENIED - The underlying object store has refused access to: "
+            << data_url->protocol() << "://" << data_url->host() << data_url->path() << ") Object Store Message: "
+            << message;
         BESDEBUG(MODULE, msg.str() << endl);
         VERBOSE(msg.str() << endl);
         throw BESForbiddenError(msg.str(), __FILE__, __LINE__);
     }
     else {
         stringstream msg;
-        msg << prolog << "ERROR - The underlying object store returned an error. ";
-        msg << "(Tried: " << data_url->str() << ") Object Store Message: " << message;
+        msg << prolog << "The underlying object store returned an error. " << "(Tried: " << data_url->protocol()
+            << "://" << data_url->host() << data_url->path() << ") Object Store Message: " << message;
         BESDEBUG(MODULE, msg.str() << endl);
         VERBOSE(msg.str() << endl);
         throw BESInternalError(msg.str(), __FILE__, __LINE__);

--- a/modules/dmrpp_module/unit-tests/ChunkTest.cc
+++ b/modules/dmrpp_module/unit-tests/ChunkTest.cc
@@ -60,7 +60,10 @@ class mock_url: public url {
 public:
     mock_url(): url() {
     }
-    string str() const { return "http://test.url.tld/"; }
+    string str() const { return "http://test.url.tld/file.ext?aws-token=secret_stuff"; }
+    string protocol() const { return "http"; }
+    string host() const { return "test.url.tld"; }
+    string path() const { return "/file.ext"; }
 };
 }
 
@@ -112,6 +115,8 @@ public:
         }
         catch(BESError &e) {
             DBG(cerr << "Caught a BESError: " << e.get_verbose_message() << endl);
+            CPPUNIT_ASSERT_MESSAGE("The message should not contain a token",
+                                  e.get_verbose_message().find("aws-token") == string::npos);
             CPPUNIT_ASSERT("Correctly caught a BESError");
         }
     }
@@ -134,6 +139,8 @@ public:
         }
         catch(BESError &e) {
             DBG(cerr << "Caught a BESError: " << e.get_verbose_message() << endl);
+            CPPUNIT_ASSERT_MESSAGE("The message should not contain a token",
+                                  e.get_verbose_message().find("aws-token") == string::npos);
             CPPUNIT_ASSERT("Correctly caught a BESError");
         }
     }
@@ -150,6 +157,8 @@ public:
         }
         catch(BESError &e) {
             DBG(cerr << "Caught a BESError: " << e.get_verbose_message() << endl);
+            CPPUNIT_ASSERT_MESSAGE("The message should not contain a token",
+                                  e.get_verbose_message().find("aws-token") == string::npos);
             CPPUNIT_ASSERT("Correctly caught a BESError");
         }
     }
@@ -170,6 +179,8 @@ public:
         }
         catch(BESError &e) {
             DBG(cerr << "Caught a BESError: " << e.get_verbose_message() << endl);
+            CPPUNIT_ASSERT_MESSAGE("The message should not contain a token",
+                                  e.get_verbose_message().find("aws-token") == string::npos);
             CPPUNIT_ASSERT("Correctly caught a BESError");
         }
     }

--- a/modules/ngap_module/NgapApi.cc
+++ b/modules/ngap_module/NgapApi.cc
@@ -435,6 +435,8 @@ string NgapApi::convert_ngap_resty_path_to_data_access_url(const std::string &re
  * @note This function is ony used in unit tests (jhrg 10/16/23)
  * @param signed_url
  * @return True if the signed URL has expired, false otherwise.
+ * @todo Remove this since it is only used by tests and duplicates http::url::is_expired(). jhrg 10/18/23
+ * @see http::url::is_expired()
  */
 bool NgapApi::signed_url_is_expired(const http::url &signed_url) {
     bool is_expired;


### PR DESCRIPTION
Fixed the bug where a token is leaked when a Chunk gets an error from S3

Also found and noted that the http::url::is_expired() code is duplicated by the unused method:
NgapApi::signed_url_is_expired(const http::url &signed_url).