### PR TITLE
Vls scalar

### DIFF
--- a/modules/dmrpp_module/DMZ.cc
+++ b/modules/dmrpp_module/DMZ.cc
@@ -221,7 +221,7 @@ bool flagged_as_unsupported_type(xml_node var_node, string &unsupported_flag) {
         return is_unsupported_type;
     }
 
-    xml_attribute fillValue_attr  = chunks.attribute("fillValue");
+    xml_attribute fillValue_attr = chunks.attribute("fillValue");
     if(!fillValue_attr) {
         // No fillValue attribute? Then we can be done, it's supported.
         return is_unsupported_type;
@@ -259,7 +259,17 @@ bool flagged_as_unsupported_type(xml_node var_node, string &unsupported_flag) {
     }
     else if(is_eq(fillValue_attr.value(),UNSUPPORTED_VARIABLE_LENGTH_STRING)) {
         unsupported_flag=fillValue_attr.value();
-        is_unsupported_type = true;
+
+        auto dim_node = var_node.child("Dim");
+        if(!dim_node) {
+            // No dims? Then this is a scalar String and it's cool.
+            // We dump the BS fillValue for one that makes some sense in Stringville
+            fillValue_attr.set_value("");
+            is_unsupported_type = false;
+        }
+        else {
+            is_unsupported_type = true;
+        }
     }
     else if(is_eq(fillValue_attr.value(),UNSUPPORTED_ARRAY)){
         unsupported_flag=fillValue_attr.value();

--- a/modules/dmrpp_module/DMZ.cc
+++ b/modules/dmrpp_module/DMZ.cc
@@ -221,7 +221,7 @@ bool flagged_as_unsupported_type(xml_node var_node, string &unsupported_flag) {
         return is_unsupported_type;
     }
 
-    xml_attribute fillValue_attr = chunks.attribute("fillValue");
+    xml_attribute fillValue_attr  = chunks.attribute("fillValue");
     if(!fillValue_attr) {
         // No fillValue attribute? Then we can be done, it's supported.
         return is_unsupported_type;
@@ -259,17 +259,7 @@ bool flagged_as_unsupported_type(xml_node var_node, string &unsupported_flag) {
     }
     else if(is_eq(fillValue_attr.value(),UNSUPPORTED_VARIABLE_LENGTH_STRING)) {
         unsupported_flag=fillValue_attr.value();
-
-        auto dim_node = var_node.child("Dim");
-        if(!dim_node) {
-            // No dims? Then this is a scalar String and it's cool.
-            // We dump the BS fillValue for one that makes some sense in Stringville
-            fillValue_attr.set_value("");
-            is_unsupported_type = false;
-        }
-        else {
-            is_unsupported_type = true;
-        }
+        is_unsupported_type = true;
     }
     else if(is_eq(fillValue_attr.value(),UNSUPPORTED_ARRAY)){
         unsupported_flag=fillValue_attr.value();

--- a/modules/dmrpp_module/build_dmrpp_util.cc
+++ b/modules/dmrpp_module/build_dmrpp_util.cc
@@ -1112,11 +1112,7 @@ bool is_unsupported_type(hid_t dataset_id, BaseType *btp, string &msg){
 bool process_variable_length_string_scalar(const hid_t dataset, BaseType *btp){
 
     // btp->type() == dods_str_c means a scalar string, if it was an
-    // array of strings the type would be dods_array_c
-
-    // I added the nested calls to the if statement so that they would
-    // only be executed for the scalar string case.
-
+    // array of strings then btp->type() == dods_array_c would be true
     if(btp->type() == dods_str_c) {
         auto h5_type_id = H5Dget_type(dataset);
         if(H5Tis_variable_str(h5_type_id) > 0) {


### PR DESCRIPTION
Adds an implementation for the variable length string scalar (vlss)  types.
This implementation reads the value from the hdf5 file, converts the associated DAP variable to "compact" and then sets the variables value and read_p flags.
Thus when the dmr++ is serialized the scale thing valued is carried to the runtime engine.