### PR TITLE
First pass at controlling max variable size and max response size for DAP2 requests

### DIFF
--- a/dap/BESDapResponseBuilder.cc
+++ b/dap/BESDapResponseBuilder.cc
@@ -958,7 +958,8 @@ BESDapResponseBuilder::intern_dap2_data(BESResponseObject *obj, BESDataHandlerIn
 
     dds->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
-    dap_utils::throw_if_dap2_response_too_big(dds, __FILE__, __LINE__);
+    dap_utils::throw_if_too_big(*dds, __FILE__, __LINE__);
+
 
     // Iterate through the variables in the DataDDS and read
     // in the data if the variable has its send flag set.
@@ -1034,7 +1035,7 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
 
         (*dds)->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
-        dap_utils::throw_if_dap2_response_too_big(*dds, __FILE__, __LINE__);
+        dap_utils::throw_if_too_big(**dds, __FILE__, __LINE__);
 
         if (with_mime_headers)
             set_mime_binary(data_stream, dods_data, x_plain, last_modified_time(d_dataset), (*dds)->get_dap_version());
@@ -1056,7 +1057,7 @@ void BESDapResponseBuilder::send_dap2_data(ostream &data_stream, DDS **dds, Cons
         (*dds)->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
         dap_utils::throw_for_dap4_typed_vars_or_attrs(*dds, __FILE__, __LINE__);
-        dap_utils::throw_if_dap2_response_too_big(*dds, __FILE__, __LINE__);
+        dap_utils::throw_if_too_big(**dds, __FILE__, __LINE__);
 
         if (with_mime_headers)
             set_mime_binary(data_stream, dods_data, x_plain, last_modified_time(d_dataset), (*dds)->get_dap_version());
@@ -1154,7 +1155,7 @@ void BESDapResponseBuilder::send_dap2_data(BESDataHandlerInterface &dhi, DDS **d
 
         (*dds)->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
-        dap_utils::throw_if_dap2_response_too_big(*dds, __FILE__, __LINE__);
+        dap_utils::throw_if_too_big(**dds, __FILE__, __LINE__);
 
         if (with_mime_headers)
             set_mime_binary(data_stream, dods_data, x_plain, last_modified_time(d_dataset), (*dds)->get_dap_version());
@@ -1176,7 +1177,7 @@ void BESDapResponseBuilder::send_dap2_data(BESDataHandlerInterface &dhi, DDS **d
         (*dds)->tag_nested_sequences(); // Tag Sequences as Parent or Leaf node.
 
         dap_utils::throw_for_dap4_typed_vars_or_attrs(*dds, __FILE__, __LINE__);
-        dap_utils::throw_if_dap2_response_too_big(*dds, __FILE__, __LINE__);
+        dap_utils::throw_if_too_big(**dds, __FILE__, __LINE__);
 
         if (with_mime_headers)
             set_mime_binary(data_stream, dods_data, x_plain, last_modified_time(d_dataset), (*dds)->get_dap_version());

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -159,25 +159,6 @@ void throw_for_dap4_typed_attrs(DAS *das, const std::string &file, unsigned int 
     }
 }
 
-#if 0
-/**
- * @brief convenience function for the response limit test.
- * The DDS stores the response size limit in Bytes even though the context
- * param uses KB. The DMR uses KB throughout.
- * @param dds
- */
-void throw_if_dap2_response_too_big(DDS *dds, const std::string &file, unsigned int line)
-{
-    if (dds->too_big()) {
-        stringstream msg;
-        msg << "The submitted DAP2 request will generate a " << dds->get_request_size_kb(true);
-        msg <<  " kilobyte response, which is too large. ";
-        msg << "The maximum response size for this server is limited to " << dds->get_response_limit_kb();
-        msg << " kilobytes.";
-        throw BESSyntaxUserError(msg.str(),file, line);
-    }
-}
-#endif
 
 /**
  * @brief - determines the number of requested elements for the D4Dimension d4dim.

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -271,7 +271,7 @@ std::string get_dap_decl(libdap::BaseType *var) {
  * Forward declaration
  */
 uint64_t crsaibv_process_ctor(const libdap::Constructor *ctor,
-                               const uint64_t &max_var_size,
+                               const uint64_t max_var_size,
                               std::vector<std::string> &too_big );
 
 /**
@@ -286,7 +286,7 @@ uint64_t crsaibv_process_ctor(const libdap::Constructor *ctor,
  */
 uint64_t crsaibv_process_variable(
         BaseType *var,
-        const uint64_t &max_var_size,
+        const uint64_t max_var_size,
         std::vector<std::string> &too_big
 ){
 
@@ -325,7 +325,7 @@ uint64_t crsaibv_process_variable(
  * @param too_big An unordered_map fo variable descriptions and their constrained sizes.
  */
  uint64_t crsaibv_process_ctor(const libdap::Constructor *ctor,
-                               const uint64_t &max_var_size,
+                               const uint64_t max_var_size,
                                std::vector<std::string> &too_big
     ){
     uint64_t response_size = 0;
@@ -354,7 +354,7 @@ uint64_t crsaibv_process_variable(
  */
 uint64_t compute_response_size_and_inv_big_vars(
         const libdap::D4Group *grp,
-        const uint64_t &max_var_size,
+        const uint64_t max_var_size,
         std::vector<std::string> &too_big)
 {
     BESDEBUG(MODULE_VERBOSE, prolog << "BEGIN " << grp->type_name() << " " << grp->FQN() << endl);
@@ -394,7 +394,7 @@ uint64_t compute_response_size_and_inv_big_vars(
  */
 uint64_t compute_response_size_and_inv_big_vars(
         libdap::DMR &dmr,
-        const uint64_t &max_var_size,
+        const uint64_t max_var_size,
         std::vector<std::string> &too_big)
 {
     return compute_response_size_and_inv_big_vars(dmr.root(), max_var_size,too_big);
@@ -412,7 +412,7 @@ uint64_t compute_response_size_and_inv_big_vars(
  */
 uint64_t compute_response_size_and_inv_big_vars(
         const libdap::DDS &dds,
-        const uint64_t &max_var_size,
+        const uint64_t max_var_size,
         std::vector<std::string> &too_big)
 {
     uint64_t response_size = 0;

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -302,7 +302,7 @@ uint64_t crsaibv_process_variable(
             response_size += vsize;
 
             BESDEBUG(MODULE_VERBOSE, prolog << "  " << get_dap_decl(var) << "(" << vsize << " bytes)" << endl);
-            if (max_var_size > 0 && vsize > max_var_size) {
+            if ( (max_var_size > 0) && (vsize > max_var_size) ) {
                 string entry = get_dap_decl(var) + " (" + to_string(vsize) + " bytes)";
                 too_big.emplace_back(entry);
                 BESDEBUG(MODULE,
@@ -613,8 +613,10 @@ bool its_too_big(
  */
 void throw_if_too_big(libdap::DMR &dmr, const string &file, const unsigned int line)
 {
+#ifndef NDEBUG
     BESStopWatch sw;
     sw.start(prolog + "DMR");
+#endif
 
     uint64_t max_var_size_bytes=0;
     uint64_t max_response_size_bytes=0;
@@ -650,8 +652,11 @@ void throw_if_too_big(libdap::DMR &dmr, const string &file, const unsigned int l
 */
 void throw_if_too_big(const libdap::DDS &dds, const std::string &file, const unsigned int line)
 {
+
+#ifndef NDEBUG
     BESStopWatch sw;
     sw.start(prolog + "DDS");
+#endif
 
     uint64_t max_var_size_bytes=0;
     uint64_t max_response_size_bytes=0;

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -397,6 +397,11 @@ uint64_t compute_response_size_and_inv_big_vars(
         const uint64_t max_var_size,
         std::vector<std::string> &too_big)
 {
+#ifndef NDEBUG
+    BESStopWatch sw;
+    sw.start(prolog + "DMR");
+#endif
+
     return compute_response_size_and_inv_big_vars(dmr.root(), max_var_size,too_big);
 }
 
@@ -415,6 +420,10 @@ uint64_t compute_response_size_and_inv_big_vars(
         const uint64_t max_var_size,
         std::vector<std::string> &too_big)
 {
+#ifndef NDEBUG
+    BESStopWatch sw;
+    sw.start(prolog + "DDS");
+#endif
     uint64_t response_size = 0;
     // Process child variables.
     for(auto dap_var:dds.variables()){
@@ -436,6 +445,11 @@ uint64_t compute_response_size_and_inv_big_vars(
  */
 void get_max_sizes_bytes(uint64_t &max_response_size_bytes, uint64_t &max_var_size_bytes,  bool is_dap2)
 {
+#ifndef NDEBUG
+    BESStopWatch sw;
+    sw.start(prolog + (is_dap2?"DAP2":"DAP4"));
+#endif
+
     // The BES configuration is help in TheBESKeys, so we read from there.
     uint64_t config_max_resp_size = TheBESKeys::TheKeys()->read_uint64_key(BES_KEYS_MAX_RESPONSE_SIZE_KEY, 0);
     BESDEBUG(MODULE, prolog << "config_max_resp_size: " << config_max_resp_size << "\n");

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -487,12 +487,9 @@ void get_max_sizes_bytes(uint64_t &max_response_size_bytes, uint64_t &max_var_si
     }
 
     // Enforce DAP2 limits?
-    if(is_dap2){
-        // Make sure the variable size is capped at 2GB
-        if(max_var_size_bytes == 0 || max_var_size_bytes > twoGB){
-            BESDEBUG(MODULE, prolog << "Adjusting max_var_size_bytes to DAP2 limits.\n");
-            max_var_size_bytes = twoGB;
-        }
+    if ( is_dap2 && (max_var_size_bytes == 0 || max_var_size_bytes > twoGB) ){
+        max_var_size_bytes = twoGB;
+        BESDEBUG(MODULE, prolog << "Adjusted max_var_size_bytes to DAP2 limit.\n");
     }
     BESDEBUG(MODULE, prolog << "max_var_size_bytes: " << max_var_size_bytes << "\n");
 }
@@ -648,7 +645,7 @@ void throw_if_too_big(libdap::DMR &dmr, const string &file, const unsigned int l
  * @param file The file of the calling code.
  * @param line The line in the calling code.
 */
-void throw_if_too_big(libdap::DDS &dds, const std::string &file, const unsigned int line)
+void throw_if_too_big(const libdap::DDS &dds, const std::string &file, const unsigned int line)
 {
     uint64_t max_var_size_bytes=0;
     uint64_t max_response_size_bytes=0;

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -592,7 +592,7 @@ bool its_too_big(
         if(is_dap2){
             msg << "You can find detailed information about DAP2 variable sub-setting\n";
             msg << "expressions in section 4.4 of the DAP2 User Guide located here:\n";
-            msg << "http://www.opendap.org/documentation/UserGuideComprehensive.pdf\n";
+            msg << "https://www.opendap.org/documentation/UserGuideComprehensive.pdf\n";
         }
         else {
             // It's a DAP4 thing...

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -557,24 +557,29 @@ bool its_too_big(
     bool response_too_big = (max_response_size_bytes > 0) && (response_size_bytes > max_response_size_bytes);
     if(response_too_big){
         msg << too_big_error_prolog(max_response_size_bytes, max_var_size_bytes);
-        msg << "The submitted DAP" << (is_dap2?"2":"4") << " request will generate a " << response_size_bytes;
-        msg <<  " byte response, which is too large.\n";
+        msg << "The submitted DAP" << (is_dap2?"2":"4") << " request will generate a ";
+        msg << response_size_bytes << " byte\n";
+        msg << "response, which is larger than the maximum allowed response size.\n";
     }
 
     // Was one or more of the constrained variables too big?
     if(!too_big_vars.empty()){
         if(response_too_big){
             // Is the whole thing too big? Continue message.
-            msg << "In addition to the overall response being to large for the service to produce,\n";
-            msg << "the request references the following variable(s) ";
+//          msg <<"- Consider asking for fewer variables (do you need them all?)"
+            msg << "\nIn addition to the overall response being too large for the\n";
+            msg << "service to produce, the request references the following\n";
+            msg << "variable(s) ";
         }
         else {
             // Start message
             msg << too_big_error_prolog(max_response_size_bytes, max_var_size_bytes);
-            msg << "The following is a list of variable(s), identified in the request,\n";
+            msg << "The following is a list of variable(s), identified\n";
+            msg << "in the request, ";
         }
         // Add oversoze variable info.
-        msg << "that are individually Too Large for the service to process.\n";
+        msg << "that are each too large for the service\n";
+        msg << "to process.\n";
         msg << "\nOversized Variable(s): \n";
         for(const auto& var_entry:too_big_vars){
             msg << "    " << var_entry << "\n";

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -129,8 +129,8 @@ std::string mk_model_incompatibility_message(const std::vector<std::string> &inv
     msg <<  "the DAP4 data model instead of the DAP2 model.\n";
     msg << "\n";
     msg << " - NetCDF If you wish to receive your response encoded as a\n";
-    msg << "   netcdf file please note that netcdf-3 has similar representational";
-    msg << "   constraints as DAP2, while netcdf-4 does not. In order to request";
+    msg << "   netcdf file please note that netcdf-3 has similar representational\n";
+    msg << "   constraints as DAP2, while netcdf-4 does not. In order to request\n";
     msg << "   a DAP4 model nectdf-4 response, change your request URL from \n";
     msg << "   dataset_url.nc to dataset_url.dap.nc4\n";
     msg << "\n";

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -614,7 +614,7 @@ bool its_too_big(
 void throw_if_too_big(libdap::DMR &dmr, const string &file, const unsigned int line)
 {
     BESStopWatch sw;
-    sw.start(prolog+"DMR");
+    sw.start(prolog + "DMR");
 
     uint64_t max_var_size_bytes=0;
     uint64_t max_response_size_bytes=0;

--- a/dap/DapUtils.h
+++ b/dap/DapUtils.h
@@ -47,15 +47,17 @@ void log_response_and_memory_size(const std::string &caller_id, /*const*/ libdap
 void throw_for_dap4_typed_attrs(libdap::DAS *das, const std::string &file, unsigned int line);
 void throw_for_dap4_typed_vars_or_attrs(libdap::DDS *dds, const std::string &file, unsigned int line);
 
-void throw_if_dap2_response_too_big(libdap::DDS *dds, const std::string &file, unsigned int line);
-void throw_if_dap4_response_too_big(libdap::DMR &dmr, const std::string &file, unsigned int line);
+// void throw_if_dap2_response_too_big(libdap::DDS *dds, const std::string &file, unsigned int line);
+// void throw_if_dap4_response_too_big(libdap::DMR &dmr, const std::string &file, unsigned int line);
 
 
 uint64_t compute_response_size_and_inv_big_vars(const libdap::Constructor *ctr, const uint64_t &max_var_size, std::vector< pair<std::string,int64_t> > &too_big);
 uint64_t compute_response_size_and_inv_big_vars(const libdap::D4Group *grp, const uint64_t &max_var_size, std::vector< pair<std::string,int64_t> > &too_big);
 uint64_t compute_response_size_and_inv_big_vars(libdap::DMR &dmr, const uint64_t &max_var_size, std::vector< pair<std::string,int64_t> > &too_big);
 
-void throw_if_too_big(libdap::DMR &dmr, const std::string &file, unsigned int line);
+void get_max_sizes_bytes(uint64_t &max_response_size_bytes, uint64_t &max_var_size_bytes,  bool is_dap2=false);
 
+void throw_if_too_big(libdap::DMR &dmr, const std::string &file, unsigned int line);
+void throw_if_too_big(libdap::DDS &dds, const std::string &file, unsigned int line);
 }
 #endif //BES_DAPUTILS_H

--- a/dap/DapUtils.h
+++ b/dap/DapUtils.h
@@ -47,9 +47,9 @@ void log_response_and_memory_size(const std::string &caller_id, /*const*/ libdap
 void throw_for_dap4_typed_attrs(libdap::DAS *das, const std::string &file, unsigned int line);
 void throw_for_dap4_typed_vars_or_attrs(libdap::DDS *dds, const std::string &file, unsigned int line);
 
-uint64_t compute_response_size_and_inv_big_vars(const libdap::Constructor *ctr, const uint64_t &max_var_size, std::vector<std::string> &too_big);
-uint64_t compute_response_size_and_inv_big_vars(const libdap::D4Group *grp, const uint64_t &max_var_size, std::vector<std::string> &too_big);
-uint64_t compute_response_size_and_inv_big_vars(libdap::DMR &dmr, const uint64_t &max_var_size, std::vector<std::string> &too_big);
+uint64_t compute_response_size_and_inv_big_vars(const libdap::Constructor *ctr, uint64_t max_var_size, std::vector<std::string> &too_big);
+uint64_t compute_response_size_and_inv_big_vars(const libdap::D4Group *grp, uint64_t max_var_size, std::vector<std::string> &too_big);
+uint64_t compute_response_size_and_inv_big_vars(libdap::DMR &dmr, uint64_t max_var_size, std::vector<std::string> &too_big);
 
 void get_max_sizes_bytes(uint64_t &max_response_size_bytes, uint64_t &max_var_size_bytes,  bool is_dap2=false);
 

--- a/dap/DapUtils.h
+++ b/dap/DapUtils.h
@@ -54,6 +54,6 @@ uint64_t compute_response_size_and_inv_big_vars(libdap::DMR &dmr, const uint64_t
 void get_max_sizes_bytes(uint64_t &max_response_size_bytes, uint64_t &max_var_size_bytes,  bool is_dap2=false);
 
 void throw_if_too_big(libdap::DMR &dmr, const std::string &file, unsigned int line);
-void throw_if_too_big(libdap::DDS &dds, const std::string &file, unsigned int line);
+void throw_if_too_big(const libdap::DDS &dds, const std::string &file, unsigned int line);
 }
 #endif //BES_DAPUTILS_H

--- a/dap/DapUtils.h
+++ b/dap/DapUtils.h
@@ -47,9 +47,9 @@ void log_response_and_memory_size(const std::string &caller_id, /*const*/ libdap
 void throw_for_dap4_typed_attrs(libdap::DAS *das, const std::string &file, unsigned int line);
 void throw_for_dap4_typed_vars_or_attrs(libdap::DDS *dds, const std::string &file, unsigned int line);
 
-uint64_t compute_response_size_and_inv_big_vars(const libdap::Constructor *ctr, const uint64_t &max_var_size, std::vector< pair<std::string,int64_t> > &too_big);
-uint64_t compute_response_size_and_inv_big_vars(const libdap::D4Group *grp, const uint64_t &max_var_size, std::vector< pair<std::string,int64_t> > &too_big);
-uint64_t compute_response_size_and_inv_big_vars(libdap::DMR &dmr, const uint64_t &max_var_size, std::vector< pair<std::string,int64_t> > &too_big);
+uint64_t compute_response_size_and_inv_big_vars(const libdap::Constructor *ctr, const uint64_t &max_var_size, std::vector<std::string> &too_big);
+uint64_t compute_response_size_and_inv_big_vars(const libdap::D4Group *grp, const uint64_t &max_var_size, std::vector<std::string> &too_big);
+uint64_t compute_response_size_and_inv_big_vars(libdap::DMR &dmr, const uint64_t &max_var_size, std::vector<std::string> &too_big);
 
 void get_max_sizes_bytes(uint64_t &max_response_size_bytes, uint64_t &max_var_size_bytes,  bool is_dap2=false);
 

--- a/dap/DapUtils.h
+++ b/dap/DapUtils.h
@@ -47,10 +47,6 @@ void log_response_and_memory_size(const std::string &caller_id, /*const*/ libdap
 void throw_for_dap4_typed_attrs(libdap::DAS *das, const std::string &file, unsigned int line);
 void throw_for_dap4_typed_vars_or_attrs(libdap::DDS *dds, const std::string &file, unsigned int line);
 
-// void throw_if_dap2_response_too_big(libdap::DDS *dds, const std::string &file, unsigned int line);
-// void throw_if_dap4_response_too_big(libdap::DMR &dmr, const std::string &file, unsigned int line);
-
-
 uint64_t compute_response_size_and_inv_big_vars(const libdap::Constructor *ctr, const uint64_t &max_var_size, std::vector< pair<std::string,int64_t> > &too_big);
 uint64_t compute_response_size_and_inv_big_vars(const libdap::D4Group *grp, const uint64_t &max_var_size, std::vector< pair<std::string,int64_t> > &too_big);
 uint64_t compute_response_size_and_inv_big_vars(libdap::DMR &dmr, const uint64_t &max_var_size, std::vector< pair<std::string,int64_t> > &too_big);

--- a/dap/tests/bescmd/dap4_response_too_big.bescmd.baseline
+++ b/dap/tests/bescmd/dap4_response_too_big.bescmd.baseline
@@ -7,7 +7,8 @@
 You asked for too much! 
     Maximum allowed response size: 10240 bytes.
     Maximum allowed variable size: unlimited
-The submitted DAP4 request will generate a 3112656 byte response, which is too large.
+The submitted DAP4 request will generate a 3112656 byte
+response, which is larger than the maximum allowed response size.
 You can resolve these issues by requesting less.
  - Consider asking for fewer variables (do you need them all?)
  - If individual variables are too large you can also subset

--- a/dap/tests/bescmd/dap4_var_and_response_too_big.bescmd.baseline
+++ b/dap/tests/bescmd/dap4_var_and_response_too_big.bescmd.baseline
@@ -7,9 +7,13 @@
 You asked for too much! 
     Maximum allowed response size: 10240 bytes.
     Maximum allowed variable size: 1024 bytes.
-The submitted DAP4 request will generate a 3112656 byte response, which is too large.
-In addition to the overall response being to large for the service to produce,
-the request references the following variable(s) that are individually Too Large for the service to process.
+The submitted DAP4 request will generate a 3112656 byte
+response, which is larger than the maximum allowed response size.
+
+In addition to the overall response being too large for the
+service to produce, the request references the following
+variable(s) that are each too large for the service
+to process.
 
 Oversized Variable(s): 
     Float64 /COADSX[180] (1440 bytes)

--- a/dap/tests/bescmd/dap4_variable_too_big.bescmd.baseline
+++ b/dap/tests/bescmd/dap4_variable_too_big.bescmd.baseline
@@ -7,8 +7,9 @@
 You asked for too much! 
     Maximum allowed response size: unlimited
     Maximum allowed variable size: 1024 bytes.
-The following is a list of variable(s), identified in the request,
-that are individually Too Large for the service to process.
+The following is a list of variable(s), identified
+in the request, that are each too large for the service
+to process.
 
 Oversized Variable(s): 
     Float64 /COADSX[180] (1440 bytes)

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -413,10 +413,10 @@ public:
         stringstream msg;
         uint64_t response_size = 0;
         uint64_t expected_response_size = 1016;
-        uint64_t max_size = 200;
-        std::vector< pair<std::string,int64_t> > too_big;
+        uint64_t max_var_size = 200;
+        std::vector<std::string> too_big;
 
-        response_size =  dap_utils::compute_response_size_and_inv_big_vars( *(d_test_dmr.get()), max_size, too_big);
+        response_size =  dap_utils::compute_response_size_and_inv_big_vars( *(d_test_dmr.get()), max_var_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
         DBG( cerr << msg.str());
 
@@ -424,9 +424,9 @@ public:
         // differ from one system to the next, example OS-X: 24 bytes, centos-8: 32 bytes
 
         if(!too_big.empty()){
-            DBG( cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);
-            for(auto apair:too_big){
-                DBG(cerr << prolog << "  " << apair.first << " (size: " << apair.second << ")" <<  endl);
+            DBG( cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_var_size << " bytes:" << endl);
+            for(auto entry:too_big){
+                DBG(cerr << prolog << "  " << entry <<  endl);
             }
             CPPUNIT_ASSERT( too_big.size() == 2 );
         }
@@ -451,7 +451,7 @@ public:
         uint64_t expected_response_size = 180356500;
 
         uint64_t max_size = 1000000;
-        std::vector< pair<std::string,int64_t> > too_big;
+        std::vector<std::string> too_big;
 
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *(d_test_dmr.get()), max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
@@ -463,8 +463,8 @@ public:
 
         if(!too_big.empty()){
             DBG(cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);
-            for(auto apair:too_big){
-                DBG(cerr << prolog << "  " << apair.first << " (size: " << apair.second << ")" <<  endl);
+            for(auto entry:too_big){
+                DBG(cerr << prolog << "  " << entry <<  endl);
             }
             CPPUNIT_ASSERT(too_big.size() == 10 );
         }
@@ -488,7 +488,7 @@ public:
         uint64_t response_size = 0;
         uint64_t expected_response_size = 140378112;
         uint64_t max_size = 1000000;
-        std::vector< pair<std::string,int64_t> > too_big;
+        std::vector<std::string> too_big;
 
 
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *(d_test_dmr.get()), max_size, too_big);
@@ -502,8 +502,8 @@ public:
 
         if(!too_big.empty()){
             DBG(cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);
-            for(auto apair:too_big){
-                DBG(cerr << prolog << "  " << apair.first << "(" << apair.second << " bytes)" <<  endl);
+            for(auto entry:too_big){
+                DBG(cerr << prolog << "  " << entry <<  endl);
             }
             CPPUNIT_ASSERT( too_big.size() == 2);
         }
@@ -530,7 +530,7 @@ public:
         uint64_t response_size = 0;
         uint64_t expected_response_size = 1179648;
         uint64_t max_size = 1000000;
-        std::vector< pair<std::string,int64_t> > too_big;
+        std::vector<std::string> too_big;
 
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *(d_test_dmr.get()), max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
@@ -542,8 +542,8 @@ public:
 
         if(!too_big.empty()){
             DBG( cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);
-            for(auto apair:too_big){
-                DBG( cerr << prolog << "  " << apair.first << "(" << apair.second << " bytes)" <<  endl);
+            for(auto entry:too_big){
+                DBG(cerr << prolog << "  " << entry <<  endl);
             }
             CPPUNIT_FAIL( prolog + "ERROR The applied constraint expression should have reduced the size of the "
                                    "requested variables so that they are no longer too big. That's not ok." );
@@ -568,7 +568,7 @@ public:
         uint64_t response_size = 0;
         uint64_t expected_response_size = 8668;
         uint64_t max_size = 8000;
-        std::vector< pair<std::string,int64_t> > too_big;
+        std::vector<std::string> too_big;
 
         response_size = dap_utils::compute_response_size_and_inv_big_vars( *(d_test_dmr.get()), max_size, too_big);
         msg << prolog << "response_size: " << response_size  << " (expected: " << expected_response_size << ")" << endl;
@@ -580,8 +580,8 @@ public:
 
         if(!too_big.empty()){
             DBG(cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);
-            for(auto apair:too_big){
-                DBG(cerr << prolog << "  " << apair.first << "(" << apair.second << " bytes)" <<  endl);
+            for(auto entry:too_big){
+                DBG(cerr << prolog << "  " << entry <<  endl);
             }
             CPPUNIT_ASSERT( too_big.size() == 1);
         }
@@ -611,7 +611,7 @@ public:
         D4ConstraintEvaluator d4ce(d_test_dmr.get());
 
         uint64_t max_size = 8000;
-        std::vector< pair<std::string,int64_t> > too_big;
+        std::vector<std::string> too_big;
 
         d4ce.parse("/xtrack[1:4:2047];/mirror_step");
 
@@ -626,7 +626,9 @@ public:
         if(!too_big.empty()){
             DBG( cerr << prolog << "Found " << too_big.size() <<  " variables larger than " << max_size << " bytes:" << endl);
             for(auto apair:too_big){
-                DBG( cerr << prolog << "  " << apair.first << "(" << apair.second << " bytes)" <<  endl);
+                for(auto entry:too_big){
+                    DBG(cerr << prolog << "  " << entry <<  endl);
+                }
             }
             CPPUNIT_FAIL( prolog + "ERROR The applied constraint expression should have reduced the size of the "
                                    "requested variables so that they are no longer too big. That's not ok." );

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -76,6 +76,10 @@ public:
 
     // Called before each test
     void setUp()  {
+        string bes_logfile = BESUtil::assemblePath(TEST_BUILD_DIR, "bes.log");
+        TheBESKeys::TheKeys()->set_key( "BES.LogName",bes_logfile);
+
+
         string bes_conf = BESUtil::assemblePath(TEST_BUILD_DIR, "bes.conf");
 
         TheBESKeys::TheKeys()->set_key(BES_KEYS_MAX_RESPONSE_SIZE_KEY,"0");
@@ -91,6 +95,7 @@ public:
             if (debug2) {
                 show_file(bes_conf);
             }
+
 
         }
         if(debug2) {
@@ -250,8 +255,10 @@ public:
         bool is_dap2 = false;
 
         dap_utils::get_max_sizes_bytes(max_response_size_bytes, max_var_size_bytes, true);
+        DBG( cerr << prolog << "max_response_size_bytes: " << max_response_size_bytes << "\n");
+        DBG( cerr << prolog << "     max_var_size_bytes: " << max_var_size_bytes << "\n");
 
-        CPPUNIT_ASSERT(max_response_size_bytes == 0);
+        CPPUNIT_ASSERT(max_response_size_bytes == fourGB);
         CPPUNIT_ASSERT(max_var_size_bytes == twoGB);
 
         // Setting these in TheBESKeys is like setting it in the bes configuration files.

--- a/dispatch/BESUtil.cc
+++ b/dispatch/BESUtil.cc
@@ -1311,7 +1311,9 @@ uint64_t BESUtil::file_to_stream_task(const std::string &file_name, std::atomic<
     stringstream msg;
     msg << prolog << "Using ostream: " << (void *) &o_strm << " cout: " << (void *) &cout << endl;
     BESDEBUG(MODULE, msg.str());
+#ifndef NDEBUG
     INFO_LOG(msg.str());
+#endif
 
     vector<char> rbuffer(OUTPUT_FILE_BLOCK_SIZE);
 
@@ -1365,13 +1367,17 @@ uint64_t BESUtil::file_to_stream_task(const std::string &file_name, std::atomic<
         auto crntpos = o_strm.tellp();
         msg << " current_position: " << crntpos << endl;
         BESDEBUG(MODULE, msg.str());
+#ifndef NDEBUG
         INFO_LOG(msg.str());
+#endif
     }
 
     msg.str(prolog);
     msg << "Sent "<< tcount << " bytes from file '" << file_name<< "'. " << endl;
     BESDEBUG(MODULE,msg.str());
+#ifndef NDEBUG
     INFO_LOG(msg.str());
+#endif
 
     return tcount;
 }
@@ -1493,7 +1499,7 @@ string BESUtil::file_to_string(const string &filename) {
     }
     std::stringstream buffer;
     buffer << t.rdbuf();
-    return {buffer.str()};
+    return buffer.str();
 }
 
 /**

--- a/modules/cmr_module/CmrApi.cc
+++ b/modules/cmr_module/CmrApi.cc
@@ -840,6 +840,7 @@ unsigned long int CmrApi::get_opendap_collections_count(const string &provider_i
 }
 
 
+
 void CmrApi::get_collections_worker( const std::string &provider_id,
                                     std::map<std::string, std::unique_ptr<cmr::Collection>> &collections,
                                     unsigned int page_size,

--- a/modules/dmrpp_module/tests/compact/float32_array_compact.das.baseline
+++ b/modules/dmrpp_module/tests/compact/float32_array_compact.das.baseline
@@ -4,10 +4,10 @@
         <BESError>
             <Type>3</Type>
             <Message>
-ERROR: Unable to convert a DAP4 DMR for this dataset to a DAP2 DDS object. 
-This dataset contains variables and/or attributes whose data types are not compatible 
-with the DAP2 data model.
-
+ERROR: Your have asked this service to utilize the DAP2 data model
+to process your request. Unfortunately the requested dataset contains
+data types that cannot be represented in DAP2.
+ 
 There are 4 incompatible variables and/or attributes referenced 
 in your request.
 Incompatible variables: 
@@ -16,6 +16,21 @@ Incompatible variables:
     Int8 tep_valid_spot@flag_values
     Int8 tep_valid_spot@valid_max
     Int8 tep_valid_spot@valid_min
+
+You may resolve these issues by asking the service to use
+the DAP4 data model instead of the DAP2 model.
+
+ - NetCDF If you wish to receive your response encoded as a
+   netcdf file please note that netcdf-3 has similar representational   constraints as DAP2, while netcdf-4 does not. In order to request   a DAP4 model nectdf-4 response, change your request URL from 
+   dataset_url.nc to dataset_url.dap.nc4
+
+ - DAP Clients If you are using a specific DAP client like pyDAP or
+   Panoply you may be able to signal the tool to use DAP4 by changing
+   the protocol of the dataset_url from https:// to dap4:// 
+
+ - If you are using the service's Data Request Form for your dataset
+   you can find the DAP4 version by changing form_url.html to form_url.dmr.html
+
 </Message>
             <Administrator>support@opendap.org</Administrator>
             <Location>

--- a/modules/dmrpp_module/tests/compact/float32_array_compact.das.baseline
+++ b/modules/dmrpp_module/tests/compact/float32_array_compact.das.baseline
@@ -21,7 +21,9 @@ You may resolve these issues by asking the service to use
 the DAP4 data model instead of the DAP2 model.
 
  - NetCDF If you wish to receive your response encoded as a
-   netcdf file please note that netcdf-3 has similar representational   constraints as DAP2, while netcdf-4 does not. In order to request   a DAP4 model nectdf-4 response, change your request URL from 
+   netcdf file please note that netcdf-3 has similar representational
+   constraints as DAP2, while netcdf-4 does not. In order to request
+   a DAP4 model nectdf-4 response, change your request URL from 
    dataset_url.nc to dataset_url.dap.nc4
 
  - DAP Clients If you are using a specific DAP client like pyDAP or

--- a/modules/dmrpp_module/tests/compact/float64_array_compact.das.baseline
+++ b/modules/dmrpp_module/tests/compact/float64_array_compact.das.baseline
@@ -4,10 +4,10 @@
         <BESError>
             <Type>3</Type>
             <Message>
-ERROR: Unable to convert a DAP4 DMR for this dataset to a DAP2 DDS object. 
-This dataset contains variables and/or attributes whose data types are not compatible 
-with the DAP2 data model.
-
+ERROR: Your have asked this service to utilize the DAP2 data model
+to process your request. Unfortunately the requested dataset contains
+data types that cannot be represented in DAP2.
+ 
 There are 4 incompatible variables and/or attributes referenced 
 in your request.
 Incompatible variables: 
@@ -16,6 +16,21 @@ Incompatible variables:
     Int8 tep_valid_spot@flag_values
     Int8 tep_valid_spot@valid_max
     Int8 tep_valid_spot@valid_min
+
+You may resolve these issues by asking the service to use
+the DAP4 data model instead of the DAP2 model.
+
+ - NetCDF If you wish to receive your response encoded as a
+   netcdf file please note that netcdf-3 has similar representational   constraints as DAP2, while netcdf-4 does not. In order to request   a DAP4 model nectdf-4 response, change your request URL from 
+   dataset_url.nc to dataset_url.dap.nc4
+
+ - DAP Clients If you are using a specific DAP client like pyDAP or
+   Panoply you may be able to signal the tool to use DAP4 by changing
+   the protocol of the dataset_url from https:// to dap4:// 
+
+ - If you are using the service's Data Request Form for your dataset
+   you can find the DAP4 version by changing form_url.html to form_url.dmr.html
+
 </Message>
             <Administrator>support@opendap.org</Administrator>
             <Location>

--- a/modules/dmrpp_module/tests/compact/float64_array_compact.das.baseline
+++ b/modules/dmrpp_module/tests/compact/float64_array_compact.das.baseline
@@ -21,7 +21,9 @@ You may resolve these issues by asking the service to use
 the DAP4 data model instead of the DAP2 model.
 
  - NetCDF If you wish to receive your response encoded as a
-   netcdf file please note that netcdf-3 has similar representational   constraints as DAP2, while netcdf-4 does not. In order to request   a DAP4 model nectdf-4 response, change your request URL from 
+   netcdf file please note that netcdf-3 has similar representational
+   constraints as DAP2, while netcdf-4 does not. In order to request
+   a DAP4 model nectdf-4 response, change your request URL from 
    dataset_url.nc to dataset_url.dap.nc4
 
  - DAP Clients If you are using a specific DAP client like pyDAP or

--- a/modules/dmrpp_module/tests/compact/int32_array_compact.das.baseline
+++ b/modules/dmrpp_module/tests/compact/int32_array_compact.das.baseline
@@ -4,10 +4,10 @@
         <BESError>
             <Type>3</Type>
             <Message>
-ERROR: Unable to convert a DAP4 DMR for this dataset to a DAP2 DDS object. 
-This dataset contains variables and/or attributes whose data types are not compatible 
-with the DAP2 data model.
-
+ERROR: Your have asked this service to utilize the DAP2 data model
+to process your request. Unfortunately the requested dataset contains
+data types that cannot be represented in DAP2.
+ 
 There are 4 incompatible variables and/or attributes referenced 
 in your request.
 Incompatible variables: 
@@ -16,6 +16,21 @@ Incompatible variables:
     Int8 tep_valid_spot@flag_values
     Int8 tep_valid_spot@valid_max
     Int8 tep_valid_spot@valid_min
+
+You may resolve these issues by asking the service to use
+the DAP4 data model instead of the DAP2 model.
+
+ - NetCDF If you wish to receive your response encoded as a
+   netcdf file please note that netcdf-3 has similar representational   constraints as DAP2, while netcdf-4 does not. In order to request   a DAP4 model nectdf-4 response, change your request URL from 
+   dataset_url.nc to dataset_url.dap.nc4
+
+ - DAP Clients If you are using a specific DAP client like pyDAP or
+   Panoply you may be able to signal the tool to use DAP4 by changing
+   the protocol of the dataset_url from https:// to dap4:// 
+
+ - If you are using the service's Data Request Form for your dataset
+   you can find the DAP4 version by changing form_url.html to form_url.dmr.html
+
 </Message>
             <Administrator>support@opendap.org</Administrator>
             <Location>

--- a/modules/dmrpp_module/tests/compact/int32_array_compact.das.baseline
+++ b/modules/dmrpp_module/tests/compact/int32_array_compact.das.baseline
@@ -21,7 +21,9 @@ You may resolve these issues by asking the service to use
 the DAP4 data model instead of the DAP2 model.
 
  - NetCDF If you wish to receive your response encoded as a
-   netcdf file please note that netcdf-3 has similar representational   constraints as DAP2, while netcdf-4 does not. In order to request   a DAP4 model nectdf-4 response, change your request URL from 
+   netcdf file please note that netcdf-3 has similar representational
+   constraints as DAP2, while netcdf-4 does not. In order to request
+   a DAP4 model nectdf-4 response, change your request URL from 
    dataset_url.nc to dataset_url.dap.nc4
 
  - DAP Clients If you are using a specific DAP client like pyDAP or

--- a/modules/dmrpp_module/tests/compact/string_array_compact_release.das.baseline
+++ b/modules/dmrpp_module/tests/compact/string_array_compact_release.das.baseline
@@ -4,10 +4,10 @@
         <BESError>
             <Type>3</Type>
             <Message>
-ERROR: Unable to convert a DAP4 DMR for this dataset to a DAP2 DDS object. 
-This dataset contains variables and/or attributes whose data types are not compatible 
-with the DAP2 data model.
-
+ERROR: Your have asked this service to utilize the DAP2 data model
+to process your request. Unfortunately the requested dataset contains
+data types that cannot be represented in DAP2.
+ 
 There are 4 incompatible variables and/or attributes referenced 
 in your request.
 Incompatible variables: 
@@ -16,6 +16,21 @@ Incompatible variables:
     Int8 tep_valid_spot@flag_values
     Int8 tep_valid_spot@valid_max
     Int8 tep_valid_spot@valid_min
+
+You may resolve these issues by asking the service to use
+the DAP4 data model instead of the DAP2 model.
+
+ - NetCDF If you wish to receive your response encoded as a
+   netcdf file please note that netcdf-3 has similar representational   constraints as DAP2, while netcdf-4 does not. In order to request   a DAP4 model nectdf-4 response, change your request URL from 
+   dataset_url.nc to dataset_url.dap.nc4
+
+ - DAP Clients If you are using a specific DAP client like pyDAP or
+   Panoply you may be able to signal the tool to use DAP4 by changing
+   the protocol of the dataset_url from https:// to dap4:// 
+
+ - If you are using the service's Data Request Form for your dataset
+   you can find the DAP4 version by changing form_url.html to form_url.dmr.html
+
 </Message>
             <Administrator>support@opendap.org</Administrator>
             <Location>

--- a/modules/dmrpp_module/tests/compact/string_array_compact_release.das.baseline
+++ b/modules/dmrpp_module/tests/compact/string_array_compact_release.das.baseline
@@ -21,7 +21,9 @@ You may resolve these issues by asking the service to use
 the DAP4 data model instead of the DAP2 model.
 
  - NetCDF If you wish to receive your response encoded as a
-   netcdf file please note that netcdf-3 has similar representational   constraints as DAP2, while netcdf-4 does not. In order to request   a DAP4 model nectdf-4 response, change your request URL from 
+   netcdf file please note that netcdf-3 has similar representational
+   constraints as DAP2, while netcdf-4 does not. In order to request
+   a DAP4 model nectdf-4 response, change your request URL from 
    dataset_url.nc to dataset_url.dap.nc4
 
  - DAP Clients If you are using a specific DAP client like pyDAP or

--- a/modules/dmrpp_module/tests/compact/string_array_compact_utc.das.baseline
+++ b/modules/dmrpp_module/tests/compact/string_array_compact_utc.das.baseline
@@ -4,10 +4,10 @@
         <BESError>
             <Type>3</Type>
             <Message>
-ERROR: Unable to convert a DAP4 DMR for this dataset to a DAP2 DDS object. 
-This dataset contains variables and/or attributes whose data types are not compatible 
-with the DAP2 data model.
-
+ERROR: Your have asked this service to utilize the DAP2 data model
+to process your request. Unfortunately the requested dataset contains
+data types that cannot be represented in DAP2.
+ 
 There are 4 incompatible variables and/or attributes referenced 
 in your request.
 Incompatible variables: 
@@ -16,6 +16,21 @@ Incompatible variables:
     Int8 tep_valid_spot@flag_values
     Int8 tep_valid_spot@valid_max
     Int8 tep_valid_spot@valid_min
+
+You may resolve these issues by asking the service to use
+the DAP4 data model instead of the DAP2 model.
+
+ - NetCDF If you wish to receive your response encoded as a
+   netcdf file please note that netcdf-3 has similar representational   constraints as DAP2, while netcdf-4 does not. In order to request   a DAP4 model nectdf-4 response, change your request URL from 
+   dataset_url.nc to dataset_url.dap.nc4
+
+ - DAP Clients If you are using a specific DAP client like pyDAP or
+   Panoply you may be able to signal the tool to use DAP4 by changing
+   the protocol of the dataset_url from https:// to dap4:// 
+
+ - If you are using the service's Data Request Form for your dataset
+   you can find the DAP4 version by changing form_url.html to form_url.dmr.html
+
 </Message>
             <Administrator>support@opendap.org</Administrator>
             <Location>

--- a/modules/dmrpp_module/tests/compact/string_array_compact_utc.das.baseline
+++ b/modules/dmrpp_module/tests/compact/string_array_compact_utc.das.baseline
@@ -21,7 +21,9 @@ You may resolve these issues by asking the service to use
 the DAP4 data model instead of the DAP2 model.
 
  - NetCDF If you wish to receive your response encoded as a
-   netcdf file please note that netcdf-3 has similar representational   constraints as DAP2, while netcdf-4 does not. In order to request   a DAP4 model nectdf-4 response, change your request URL from 
+   netcdf file please note that netcdf-3 has similar representational
+   constraints as DAP2, while netcdf-4 does not. In order to request
+   a DAP4 model nectdf-4 response, change your request URL from 
    dataset_url.nc to dataset_url.dap.nc4
 
  - DAP Clients If you are using a specific DAP client like pyDAP or

--- a/modules/dmrpp_module/tests/compact/string_array_compact_version.das.baseline
+++ b/modules/dmrpp_module/tests/compact/string_array_compact_version.das.baseline
@@ -4,10 +4,10 @@
         <BESError>
             <Type>3</Type>
             <Message>
-ERROR: Unable to convert a DAP4 DMR for this dataset to a DAP2 DDS object. 
-This dataset contains variables and/or attributes whose data types are not compatible 
-with the DAP2 data model.
-
+ERROR: Your have asked this service to utilize the DAP2 data model
+to process your request. Unfortunately the requested dataset contains
+data types that cannot be represented in DAP2.
+ 
 There are 4 incompatible variables and/or attributes referenced 
 in your request.
 Incompatible variables: 
@@ -16,6 +16,21 @@ Incompatible variables:
     Int8 tep_valid_spot@flag_values
     Int8 tep_valid_spot@valid_max
     Int8 tep_valid_spot@valid_min
+
+You may resolve these issues by asking the service to use
+the DAP4 data model instead of the DAP2 model.
+
+ - NetCDF If you wish to receive your response encoded as a
+   netcdf file please note that netcdf-3 has similar representational   constraints as DAP2, while netcdf-4 does not. In order to request   a DAP4 model nectdf-4 response, change your request URL from 
+   dataset_url.nc to dataset_url.dap.nc4
+
+ - DAP Clients If you are using a specific DAP client like pyDAP or
+   Panoply you may be able to signal the tool to use DAP4 by changing
+   the protocol of the dataset_url from https:// to dap4:// 
+
+ - If you are using the service's Data Request Form for your dataset
+   you can find the DAP4 version by changing form_url.html to form_url.dmr.html
+
 </Message>
             <Administrator>support@opendap.org</Administrator>
             <Location>

--- a/modules/dmrpp_module/tests/compact/string_array_compact_version.das.baseline
+++ b/modules/dmrpp_module/tests/compact/string_array_compact_version.das.baseline
@@ -21,7 +21,9 @@ You may resolve these issues by asking the service to use
 the DAP4 data model instead of the DAP2 model.
 
  - NetCDF If you wish to receive your response encoded as a
-   netcdf file please note that netcdf-3 has similar representational   constraints as DAP2, while netcdf-4 does not. In order to request   a DAP4 model nectdf-4 response, change your request URL from 
+   netcdf file please note that netcdf-3 has similar representational
+   constraints as DAP2, while netcdf-4 does not. In order to request
+   a DAP4 model nectdf-4 response, change your request URL from 
    dataset_url.nc to dataset_url.dap.nc4
 
  - DAP Clients If you are using a specific DAP client like pyDAP or


### PR DESCRIPTION

This PR adds code to inspect DAP2 requests and determine if:
- The response will be too larger than the configured maximum. 
- If any of the requested and constrained variable are larger than the configured maximum.
And if one or both are true it will write an error message explaining the situation and then throw `BESUserSyntaxError`