### PR TITLE
Fixes build_dmrpp Service logging , fileout_netcdf error message, etc

### DIFF
--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -35,6 +35,7 @@
 #include <libdap/Vector.h>
 #include <libdap/Array.h>
 #include <libdap/Constructor.h>
+#include <libdap/XMLWriter.h>
 
 #include "TheBESKeys.h"
 #include "BESContextManager.h"
@@ -105,6 +106,20 @@ void log_response_and_memory_size(const std::string &caller_id, /*const*/ DMR &d
 {
     // The request_size_kb() method is not marked const. Fix. jhrg 4/6/22
     auto response_size = (long)dmr.request_size_kb(true);
+    log_response_and_memory_size_helper(caller_id, response_size);
+}
+
+/**
+ * Log information about memory used by this request.
+ *
+ * Use the given DDS to log information about the request. As a bonus, log the
+ * RSS for this process.
+ *
+ * @param dds Use this DDS to get the size of the request.
+ */
+void log_response_and_memory_size(const std::string &caller_id, /*const*/ libdap::XMLWriter &dmrpp_writer)
+{
+    auto response_size = (long)dmrpp_writer.get_doc_size() / 1000;
     log_response_and_memory_size_helper(caller_id, response_size);
 }
 

--- a/dap/DapUtils.h
+++ b/dap/DapUtils.h
@@ -43,6 +43,7 @@ namespace dap_utils {
 void log_response_and_memory_size(const std::string &caller_id, libdap::DDS *const *dds);
 
 void log_response_and_memory_size(const std::string &caller_id, /*const*/ libdap::DMR &dmr);
+void log_response_and_memory_size(const std::string &caller_id, /*const*/ libdap::XMLWriter &dmrpp_writer);
 
 void throw_for_dap4_typed_attrs(libdap::DAS *das, const std::string &file, unsigned int line);
 void throw_for_dap4_typed_vars_or_attrs(libdap::DDS *dds, const std::string &file, unsigned int line);

--- a/dispatch/BESUtil.cc
+++ b/dispatch/BESUtil.cc
@@ -1128,8 +1128,9 @@ void ios_state_msg(std::ios &ios_ref, std::stringstream &msg) {
  * Thanks to O'Reilly: https://www.oreilly.com/library/view/c-cookbook/0596007612/ch10s08.html
  * @param file_name
  * @param o_strm
+ * @return The number of bytes read/written
  */
-void BESUtil::file_to_stream(const std::string &file_name, std::ostream &o_strm)
+uint64_t BESUtil::file_to_stream(const std::string &file_name, std::ostream &o_strm, uint64_t read_start_position)
 {
     stringstream msg;
     msg << prolog << "Using ostream: " << (void *) &o_strm << " cout: " << (void *) &cout << endl;
@@ -1159,6 +1160,8 @@ void BESUtil::file_to_stream(const std::string &file_name, std::ostream &o_strm)
         BESDEBUG(MODULE, msg.str() << endl);
         throw BESInternalError(msg.str(),__FILE__,__LINE__);
     }
+    // this is where we advance to the last byte that was read
+    i_stream.seekg(read_start_position);
 
     //vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
     // This is where the file is copied.
@@ -1210,228 +1213,8 @@ void BESUtil::file_to_stream(const std::string &file_name, std::ostream &o_strm)
 #ifndef NDEBUG
     INFO_LOG(msg.str());
 #endif
-    
-}
-
-uint64_t BESUtil::file_to_stream_helper(const std::string &file_name, std::ostream &o_strm, uint64_t byteCount){
-
-    stringstream msg;
-    msg << prolog << "Using ostream: " << (void *) &o_strm << " cout: " << (void *) &cout << endl;
-    BESDEBUG(MODULE,  msg.str());
-    INFO_LOG( msg.str());
-
-    vector<char> rbuffer(OUTPUT_FILE_BLOCK_SIZE);
-    std::ifstream i_stream(file_name, std::ios_base::in | std::ios_base::binary);  // Use binary mode so we can
-
-    // good() returns true if !(eofbit || badbit || failbit)
-    if(!i_stream.good()){
-        stringstream msg;
-        msg << prolog << "Failed to open file " << file_name;
-        ios_state_msg(i_stream, msg);
-        BESDEBUG(MODULE, msg.str() << endl);
-        throw BESInternalError(msg.str(),__FILE__,__LINE__);
-    }
-
-    // good() returns true if !(eofbit || badbit || failbit)
-    if(!o_strm.good()){
-        stringstream msg;
-        msg << prolog << "Problem with ostream. " << file_name;
-        ios_state_msg(i_stream, msg);
-        BESDEBUG(MODULE, msg.str() << endl);
-        throw BESInternalError(msg.str(),__FILE__,__LINE__);
-    }
-
-    // this is where we advance to the last byte that was read
-    i_stream.seekg(byteCount);
-
-    //vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-    // This is where the file is copied.
-    while (i_stream.good() && o_strm.good()){
-        i_stream.read(rbuffer.data(), OUTPUT_FILE_BLOCK_SIZE);      // Read at most n bytes into
-        o_strm.write(rbuffer.data(), i_stream.gcount()); // buf, then write the buf to
-        BESDEBUG(MODULE, "i_stream: " << i_stream.gcount() << endl);
-        byteCount += i_stream.gcount();
-    }
-    o_strm.flush();
-
-    // fail() is true if failbit || badbit got set, but does not consider eofbit
-    if(i_stream.fail() && !i_stream.eof()){
-        stringstream msg;
-        msg << prolog << "There was an ifstream error when reading from: " << file_name;
-        ios_state_msg(i_stream, msg);
-        msg << " last_lap: " << i_stream.gcount() << " bytes";
-        msg << " total_read: " << byteCount << " bytes";
-        BESDEBUG(MODULE, msg.str() << endl);
-        throw BESInternalError(msg.str(),__FILE__,__LINE__);
-    }
-
-    // If we're not at the eof of the input stream then we have failed.
-    if (!i_stream.eof()){
-        stringstream msg;
-        msg << prolog << "Failed to reach EOF on source file: " << file_name;
-        ios_state_msg(i_stream, msg);
-        msg << " last_lap: " << i_stream.gcount() << " bytes";
-        msg << " total_read: " << byteCount << " bytes";
-        BESDEBUG(MODULE, msg.str() << endl);
-        throw BESInternalError(msg.str(),__FILE__,__LINE__);
-    }
-
-    // And if something went wrong on the output stream we have failed.
-    if(!o_strm.good()){
-        stringstream msg;
-        msg << prolog << "There was an ostream error during transmit. Transmitted " << byteCount  << " bytes.";
-        ios_state_msg(o_strm, msg);
-        auto crntpos = o_strm.tellp();
-        msg << " current_position: " << crntpos << endl;
-        BESDEBUG(MODULE, msg.str());
-        ERROR_LOG(msg.str());
-    }
-
-    msg.str(prolog);
-    msg << "Sent "<< byteCount << " bytes from file '" << file_name<< "'. " << endl;
-    BESDEBUG(MODULE,msg.str());
-    INFO_LOG(msg.str());
-
-    i_stream.close();
-
-    return byteCount;
-}
-
-
-// I added this because maybe using the low-level file calls was important. I'm not
-// sure and the iostreams in C++ are safer. jhrg 6/4/21
-#define FILE_CALLS 0
-
-/**
- * *brief child thread/task to stream a netCDF file as it is built
- * @param file_name
- * @param o_strm
- */
-uint64_t BESUtil::file_to_stream_task(const std::string &file_name, std::atomic<bool> &file_write_done, std::ostream &o_strm) {
-    stringstream msg;
-    msg << prolog << "Using ostream: " << (void *) &o_strm << " cout: " << (void *) &cout << endl;
-    BESDEBUG(MODULE, msg.str());
-#ifndef NDEBUG
-    INFO_LOG(msg.str());
-#endif
-
-    vector<char> rbuffer(OUTPUT_FILE_BLOCK_SIZE);
-
-    std::ifstream i_stream(file_name, std::ios_base::in | std::ios_base::binary);
-#if FILE_CALLS
-    int fd = open(file_name.c_str(), O_RDONLY | O_NONBLOCK);
-    int eof = false;
-#endif
-
-    //vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-    // This is where the file is copied.
-    BESDEBUG(MODULE, "Starting transfer" << endl);
-    uint64_t tcount = 0;
-    while (!i_stream.bad() && !i_stream.fail() && o_strm.good()) {
-        if (file_write_done && i_stream.eof()) {
-            BESDEBUG(MODULE, "breaking out of loop" << endl);
-            break;
-        }
-        else {
-            i_stream.read(rbuffer.data(), OUTPUT_FILE_BLOCK_SIZE);      // Read at most n bytes into
-
-#if FILE_CALLS
-            int status = read(fd, rbuffer.data(), OUTPUT_FILE_BLOCK_SIZE);
-            if (status == 0) {
-                eof = true;
-            }
-            else if (status == -1) {
-                BESDEBUG(MODULE, "read() call error: " << errno << endl);
-            }
-
-            o_strm.write(rbuffer.data(), status); // buf, then write the buf to
-            tcount += status;
-#endif
-
-            o_strm.write(rbuffer.data(), i_stream.gcount()); // buf, then write the buf to
-            tcount += i_stream.gcount();
-            BESDEBUG(MODULE, "transfer bytes " << tcount << endl);
-        }
-    }
-
-#if FILE_CALLS
-    close(fd);
-#endif
-    o_strm.flush();
-
-    // And if something went wrong on the output stream we have failed.
-    if(!o_strm.good()){
-        stringstream msg;
-        msg << prolog << "There was an ostream error during transmit. Transmitted " << tcount  << " bytes.";
-        ios_state_msg(o_strm, msg);
-        auto crntpos = o_strm.tellp();
-        msg << " current_position: " << crntpos << endl;
-        BESDEBUG(MODULE, msg.str());
-#ifndef NDEBUG
-        INFO_LOG(msg.str());
-#endif
-    }
-
-    msg.str(prolog);
-    msg << "Sent "<< tcount << " bytes from file '" << file_name<< "'. " << endl;
-    BESDEBUG(MODULE,msg.str());
-#ifndef NDEBUG
-    INFO_LOG(msg.str());
-#endif
-
     return tcount;
 }
-
-#if 0
-/// Stolen from our friends at Stack Overflow and modified for our use.
-/// This is far faster than the istringstream code it replaces (for one
-/// test, run time for parse_chunk_position_in_array_string() dropped from
-/// 20ms to ~3ms). It also fixes a test we could never get to pass.
-/// jhrg 11/5/21
-
-/**
- * @brief Split a string using delimiter. Store values as unsigned long longs
- * @param s The string to split
- * @param delimiter The delimiter
- * @param res Return the result in this vector
- */
-void BESUtil::split(const string &s, const string &delimiter, vector<uint64_t> &res)
-{
-    const size_t delim_len = delimiter.size();
-
-    size_t pos_start = 0, pos_end;
-
-    while ((pos_end = s.find (delimiter, pos_start)) != string::npos) {
-        res.push_back (stoull(s.substr(pos_start, pos_end - pos_start)));
-        pos_start = pos_end + delim_len;
-    }
-
-    res.push_back (stoull(s.substr (pos_start)));
-}
-
-/**
- * @brief Split a string using delimiter. Store values as strings
- * @param s The string to split
- * @param delimiter The delimiter
- * @param res Return the result in this vector
- *
- * @note Maybe we could combine this and the previous function using a lambda
- * to wrap stoull()? jhrg 11/9/21
- */
-void BESUtil::split(const string &s, const string &delimiter, vector<string> &res)
-{
-    const size_t delim_len = delimiter.size();
-
-    size_t pos_start = 0, pos_end;
-
-    while ((pos_end = s.find (delimiter, pos_start)) != string::npos) {
-        res.push_back(s.substr(pos_start, pos_end - pos_start));
-        pos_start = pos_end + delim_len;
-    }
-
-    res.push_back(s.substr (pos_start));
-}
-#endif
 
 /// Is the given path a directory?
 bool BESUtil::is_directory(const string &p) {

--- a/dispatch/BESUtil.h
+++ b/dispatch/BESUtil.h
@@ -126,10 +126,7 @@ public:
 
     static BESCatalog *separateCatalogFromPath(std::string &path);
 
-    static void file_to_stream(const std::string &file_name, std::ostream &o_strm);
-    static uint64_t file_to_stream_helper(const std::string &file_name, std::ostream &o_strm, uint64_t byteCount);
-    static uint64_t file_to_stream_task(const std::string &file_name, std::atomic<bool> &file_write_done,
-                                        std::ostream &o_strm);
+    static uint64_t file_to_stream(const std::string &file_name, std::ostream &o_strm, uint64_t read_start_position=0);
 
     static std::string get_dir_name(const std::string &p);
     static bool is_directory(const std::string &p);

--- a/modules/builddmrpp_module/NgapBuildDmrppContainer.cc
+++ b/modules/builddmrpp_module/NgapBuildDmrppContainer.cc
@@ -121,7 +121,7 @@ void NgapBuildDmrppContainer::_duplicate(NgapBuildDmrppContainer &copy_to) {
     BESContainer::_duplicate(copy_to);
 
     copy_to.d_real_name = d_real_name;
-    copy_to.d_data_rresource = std::move(d_data_rresource); //  = d_data_rresource;
+    copy_to.d_data_rresource = std::move(d_data_rresource);
 }
 
 BESContainer *

--- a/modules/builddmrpp_module/NgapBuildDmrppContainer.h
+++ b/modules/builddmrpp_module/NgapBuildDmrppContainer.h
@@ -52,7 +52,7 @@ namespace builddmrpp {
 class NgapBuildDmrppContainer : public BESContainer {
 
 private:
-    std::shared_ptr<http::RemoteResource> d_data_rresource = nullptr;
+    std::unique_ptr<http::RemoteResource> d_data_rresource = nullptr;
     std::string d_real_name;         ///< The full name of the thing (filename, database table name, ...)
 
     void initialize();

--- a/modules/builddmrpp_module/NgapBuildDmrppContainerStorage.cc
+++ b/modules/builddmrpp_module/NgapBuildDmrppContainerStorage.cc
@@ -29,6 +29,7 @@
 
 #include <string>
 
+#include "RemoteResource.h"
 #include "NgapBuildDmrppContainerStorage.h"
 #include "NgapBuildDmrppContainer.h"
 

--- a/modules/dmrpp_module/writer/FODmrppTransmitter.cc
+++ b/modules/dmrpp_module/writer/FODmrppTransmitter.cc
@@ -62,6 +62,8 @@
 #include "build_dmrpp_util.h"
 #include "FODmrppTransmitter.h"
 
+#include "DapUtils.h"
+
 using namespace libdap;
 using namespace std;
 
@@ -141,6 +143,8 @@ void FODmrppTransmitter::send_dmrpp(BESResponseObject *obj, BESDataHandlerInterf
 
         XMLWriter dmrpp_writer;
         dmrpp.print_dmrpp(dmrpp_writer, href_url);
+
+        dap_utils::log_response_and_memory_size(prolog, dmrpp_writer);
 
         auto &strm = dhi.get_output_stream();
         strm << dmrpp_writer.get_doc() << flush;

--- a/modules/fileout_netcdf/FONcTransform.cc
+++ b/modules/fileout_netcdf/FONcTransform.cc
@@ -507,7 +507,7 @@ void FONcTransform::transform_dap2(ostream &strm) {
     }
 
     if (stax != NC_NOERR) {
-        FONcUtils::handle_error(stax, "File out netcdf, unable to open: " + _localfile, __FILE__, __LINE__);
+        FONcUtils::handle_error(stax, prolog + "Call to nc_create() failed for file: " + _localfile, __FILE__, __LINE__);
     }
 
     int current_fill_prop_vaule;
@@ -556,7 +556,7 @@ void FONcTransform::transform_dap2(ostream &strm) {
                                     __LINE__);
         }
         // write file data
-        uint64_t byteCount = 0;
+        uint64_t bytes_written = 0;
 
         if (is_streamable()) {
             // Verify the request hasn't exceeded bes_timeout.
@@ -566,8 +566,8 @@ void FONcTransform::transform_dap2(ostream &strm) {
             // cancel any pending timeout alarm according to the configuration.
             BESUtil::conditional_timeout_cancel();
 
-            byteCount = BESUtil::file_to_stream_helper(_localfile, strm, byteCount);
-            BESDEBUG(MODULE,  prolog << "First write data to stream, count:  " << byteCount << endl);
+            bytes_written += BESUtil::file_to_stream(_localfile, strm, bytes_written);
+            BESDEBUG(MODULE,  prolog << "First write data to stream, bytes_written:  " << bytes_written << endl);
         }
 
         for (FONcBaseType *fbt: _fonc_vars) {
@@ -583,8 +583,8 @@ void FONcTransform::transform_dap2(ostream &strm) {
 
             if (is_streamable()) {
                 // write the what's been written
-                byteCount = BESUtil::file_to_stream_helper(_localfile, strm, byteCount);
-                BESDEBUG(MODULE,  prolog << "Writing data to stream, count:  " << byteCount << endl);
+                bytes_written += BESUtil::file_to_stream(_localfile, strm, bytes_written);
+                BESDEBUG(MODULE,  prolog << "Writing data to stream, bytes_written:  " << bytes_written << endl);
             }
         }
 
@@ -594,8 +594,8 @@ void FONcTransform::transform_dap2(ostream &strm) {
 
         RequestServiceTimer::TheTimer()->throw_if_timeout_expired(prolog + "ERROR: bes-timeout expired before transmitting data." , __FILE__, __LINE__);
 
-        byteCount = BESUtil::file_to_stream_helper(_localfile, strm, byteCount);
-        BESDEBUG(MODULE,  prolog << "After nc_close() count:  " << byteCount << endl);
+        bytes_written += BESUtil::file_to_stream(_localfile, strm, bytes_written);
+        BESDEBUG(MODULE,  prolog << "After nc_close() bytes_written:  " << bytes_written << endl);
     }
     catch (BESError &e) {
         (void) nc_close(_ncid); // ignore the error at this point
@@ -776,7 +776,7 @@ void FONcTransform::transform_dap4() {
         BESDEBUG(MODULE, prolog << "Opening NetCDF-4 cache file. fileName:  " << _localfile << endl);
         stax = nc_create(_localfile.c_str(), NC_CLOBBER | NC_NETCDF4, &_ncid);
         if (stax != NC_NOERR)
-            FONcUtils::handle_error(stax, "File out netcdf, unable to open: " + _localfile, __FILE__, __LINE__);
+            FONcUtils::handle_error(stax, prolog + "Call to nc_create() failed for file: " + _localfile, __FILE__, __LINE__);
 
         D4Group *root_grp = _dmr->root();
 
@@ -1002,7 +1002,7 @@ void FONcTransform::transform_dap4_no_group() {
     }
 
     if (stax != NC_NOERR) {
-        FONcUtils::handle_error(stax, "File out netcdf, unable to open: " + _localfile, __FILE__, __LINE__);
+        FONcUtils::handle_error(stax, prolog + "Call to nc_create() failed for file: " + _localfile, __FILE__, __LINE__);
     }
 
     try {


### PR DESCRIPTION
This PR contains:

1. A new function `log_response_and_memory_size()` used by the **build_dmrpp** service.
2. A consolidation of the `BESUtil::file_to_stream()` methods. There were three and now there is one.
3. Repairs to the lifecycle of `NgapBuildDmrppContainer`, including using a unique_ptr for its `RemoteResource`.
4. New, more detailed error messages in `FONcTransform` and in `FONcUtils::handle_error()`