### PR TITLE
Changed redirect acquisition attempt counting to start with 1 instead of 0

### DIFF
--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -1819,8 +1819,8 @@ std::shared_ptr<http::EffectiveUrl> get_redirect_url( const std::shared_ptr<http
     bool success = false;
 
     while ( !success && ( attempt < retry_limit ) ) {
-        success = gru_mk_attempt(origin_url,attempt, retry_limit, redirect_url);
         attempt++;
+        success = gru_mk_attempt(origin_url,attempt, retry_limit, redirect_url);
     }
     // This is a failsafe test - the gru_mk_attempt)_ should detect the errors and throw an exception
     // if the attempt count exceeds the retry_limit, but if for some reason there's flaw in that


### PR DESCRIPTION
This is pretty much a one liner. The intent in changing this is to produce better error messages for get_redirect_url as counting from 0 to n-1 does not 