### PR TITLE
Changed 'struct tm <var>' so the variable is always initialized

### DIFF
--- a/dap/GlobalMetadataStore.cc
+++ b/dap/GlobalMetadataStore.cc
@@ -428,7 +428,7 @@ static void dump_time(ostream &os, bool use_local_time)
     //
     // Apologies for the twisted logic - UTC is the default. Override to
     // local time using BES.LogTimeLocal=yes in bes.conf. jhrg 11/15/17
-    struct tm result;
+    struct tm result{};
     if (!use_local_time) {
         gmtime_r(&now, &result);
         status = strftime(buf, sizeof buf, "%FT%T%Z", &result);

--- a/dispatch/BESCatalogDirectory.cc
+++ b/dispatch/BESCatalogDirectory.cc
@@ -283,7 +283,7 @@ static string get_time(time_t the_time, bool use_local_time = false)
     //
     // Apologies for the twisted logic - UTC is the default. Override to
     // local time using BES.LogTimeLocal=yes in bes.conf. jhrg 11/15/17
-    struct tm result;
+    struct tm result{};
     if (!use_local_time) {
         gmtime_r(&the_time, &result);
         status = strftime(buf, sizeof buf, "%FT%T%Z", &result);

--- a/dispatch/BESCatalogUtils.cc
+++ b/dispatch/BESCatalogUtils.cc
@@ -474,7 +474,7 @@ void BESCatalogUtils::bes_add_stat_info(BESCatalogEntry *entry, struct stat &buf
     // %T = %H:%M:%S
     // %F = %Y-%m-%d
     time_t mod = buf.st_mtime;
-    struct tm stm;
+    struct tm stm{};
     gmtime_r(&mod, &stm);
     char mdate[64];
     strftime(mdate, 64, "%Y-%m-%d", &stm);

--- a/dispatch/bes/old/BESExceptionManager.cc
+++ b/dispatch/bes/old/BESExceptionManager.cc
@@ -80,7 +80,7 @@ void BESExceptionManager::add_ehm_callback(p_bes_ehm ehm)
 void log_error(BESError &e)
 {
 #if 0
-    struct tm *ptm;
+    struct tm *ptm = nullptr;
     time_t timer = time(NULL);
     ptm = gmtime(&timer);
     string now(asctime(ptm));

--- a/dispatch/old/BESStatus.cc
+++ b/dispatch/old/BESStatus.cc
@@ -40,7 +40,7 @@ int BESStatus::_counter;
 BESStatus::BESStatus() {
     if (_counter++ == 0) {
         const time_t sctime = time(NULL);
-        struct tm sttime;
+        struct tm sttime{};
         localtime_r(&sctime, &sttime);
         char zone_name[10];
         strftime(zone_name, sizeof(zone_name), "%Z", &sttime);

--- a/http/awsv4.cc
+++ b/http/awsv4.cc
@@ -188,7 +188,7 @@ std::string credential_scope(const std::time_t &request_date,
 // time_t -> 20131222T043039Z
 std::string ISO8601_date(const std::time_t &t) {
     char buf[sizeof "20111008T070709Z"];
-    struct tm tm_buf{0};
+    struct tm tm_buf{};
     std::strftime(buf, sizeof buf, "%Y%m%dT%H%M%SZ", gmtime_r(&t, &tm_buf));
     return buf;
 }
@@ -196,7 +196,7 @@ std::string ISO8601_date(const std::time_t &t) {
 // time_t -> 20131222
 std::string utc_yyyymmdd(const std::time_t &t) {
     char buf[sizeof "20111008"];
-    struct tm tm_buf{0};
+    struct tm tm_buf{};
     std::strftime(buf, sizeof buf, "%Y%m%d", gmtime_r(&t, &tm_buf));
     return buf;
 }

--- a/http/unit-tests/HttpUrlTest.cc
+++ b/http/unit-tests/HttpUrlTest.cc
@@ -97,7 +97,7 @@ public:
     string get_amz_date(const time_t &date_time){
         DBG(cerr << prolog << "BEGIN" << endl);
         // string amz_date_format("%Y%m%dT%H%M%SZ"); // 20200808T032623Z
-        struct tm dttm{0};
+        struct tm dttm{};
         gmtime_r(&date_time, &dttm);
 
         vector<char> amz_date(32, 0);

--- a/http/url_impl.cc
+++ b/http/url_impl.cc
@@ -252,7 +252,7 @@ bool url::is_expired()
             std::time_t old_now;
             time(&old_now);  /* get current time; same as: timer = time(NULL)  */
             BESDEBUG(MODULE, prolog << "old_now: " << old_now << endl);
-            struct tm ti{0};
+            struct tm ti{};
             gmtime_r(&old_now, &ti);
             ti.tm_year = stoi(year) - 1900;
             ti.tm_mon = stoi(month) - 1;

--- a/modules/fileout_covjson/FoDapCovJsonTransform.cc
+++ b/modules/fileout_covjson/FoDapCovJsonTransform.cc
@@ -3528,9 +3528,9 @@ cerr<<"time_val is "<<time_val <<endl;
 //cerr<<"t_ycf_2 is "<<t_ycf_2 <<endl;
 #endif
 
-  struct tm *t_new_ycf;
-  struct tm temp_new_ycf;
-  // The use of localtime() is to calcuate the time based on the CF time unit.
+  // jhrg 2/2/24 struct tm *t_new_ycf;
+  struct tm temp_new_ycf{};
+  // The use of localtime() is to calculate the time based on the CF time unit.
   // So the value actually represents the GMT time. 
   // Note: we didn't consider the use of local time in the CF. 
   // Our currently supported product uses GMT. Will consider the other cases later.
@@ -3538,7 +3538,7 @@ cerr<<"time_val is "<<time_val <<endl;
   //t_new_ycf = localtime(&t_ycf_2);
   //t_new_ycf = gmtime(&t_ycf_2);
 #endif
-  t_new_ycf = gmtime_r(&t_ycf_2,&temp_new_ycf);
+  auto t_new_ycf = gmtime_r(&t_ycf_2, &temp_new_ycf);
 
 #if 0
 cerr<< "t_new_ycf.tm_year is " <<t_new_ycf->tm_year <<endl;

--- a/modules/fileout_netcdf/history_utils.cc
+++ b/modules/fileout_netcdf/history_utils.cc
@@ -93,7 +93,7 @@ get_time_now() {
     time_t raw_now;
     // jhrg 2/2/24 struct tm *timeinfo;
     time(&raw_now); /* get current time; same as: timer = time(NULL)  */
-    struct tm *timeinfo = localtime(&raw_now);
+    const struct tm *timeinfo = localtime(&raw_now);
 
     char time_str[128];
     strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", timeinfo);

--- a/modules/fileout_netcdf/history_utils.cc
+++ b/modules/fileout_netcdf/history_utils.cc
@@ -91,9 +91,9 @@ namespace fonc_history_util {
 string
 get_time_now() {
     time_t raw_now;
-    struct tm *timeinfo;
+    // jhrg 2/2/24 struct tm *timeinfo;
     time(&raw_now); /* get current time; same as: timer = time(NULL)  */
-    timeinfo = localtime(&raw_now);
+    struct tm *timeinfo = localtime(&raw_now);
 
     char time_str[128];
     strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", timeinfo);

--- a/modules/freeform_handler/DODS_Date.cc
+++ b/modules/freeform_handler/DODS_Date.cc
@@ -462,7 +462,7 @@ string DODS_Date::get(date_format format) const
 
 time_t DODS_Date::unix_time() const
 {
-	struct tm tm_rec;
+	struct tm tm_rec{};
 	tm_rec.tm_mday = _day;
 	tm_rec.tm_mon = _month - 1; // zero-based
 	tm_rec.tm_year = _year - 1900; // years since 1900

--- a/modules/freeform_handler/DODS_Date_Time.cc
+++ b/modules/freeform_handler/DODS_Date_Time.cc
@@ -328,7 +328,7 @@ DODS_Date_Time::julian_day() const
 time_t 
 DODS_Date_Time::unix_time() const
 {
-    struct tm tm_rec;
+    struct tm tm_rec{};
     tm_rec.tm_mday = _date.day();
     tm_rec.tm_mon = _date.month() - 1; // zero-based 
     tm_rec.tm_year = _date.year() - 1900; // years since 1900

--- a/modules/freeform_handler/DODS_Decimal_Year.cc
+++ b/modules/freeform_handler/DODS_Decimal_Year.cc
@@ -284,7 +284,7 @@ DODS_Decimal_Year::julian_day() const
 time_t
 DODS_Decimal_Year::unix_time() const
 {
-    struct tm tm_rec;
+    struct tm tm_rec{};
     tm_rec.tm_mday = _date.day();
     tm_rec.tm_mon = _date.month() - 1; // zero-based
     tm_rec.tm_year = _date.year() - 1900; // years since 1900

--- a/modules/httpd_catalog_module/HttpdDirScraper.cc
+++ b/modules/httpd_catalog_module/HttpdDirScraper.cc
@@ -233,8 +233,6 @@ time_t HttpdDirScraper::parse_time_format_B(const vector<string> tokens) const
 {
     // void BESUtil::tokenize(const string& str, vector<string>& tokens, const string& delimiters)
     struct tm tm{};
-    // jhrg 2/2/24 zero_tm_struct(tm);
-
     if (tokens.size() > 2) {
         std::istringstream(tokens[0]) >> tm.tm_year;
         tm.tm_year -= 1900;

--- a/modules/httpd_catalog_module/HttpdDirScraper.cc
+++ b/modules/httpd_catalog_module/HttpdDirScraper.cc
@@ -192,8 +192,8 @@ string HttpdDirScraper::httpd_time_to_iso_8601(const string httpd_time) const
 time_t HttpdDirScraper::parse_time_format_A(const vector<string> tokens) const
 {
     // void BESUtil::tokenize(const string& str, vector<string>& tokens, const string& delimiters)
-    struct tm tm;
-    zero_tm_struct(tm);
+    struct tm tm{};
+    // jhrg 2/2/24 zero_tm_struct(tm);
 
     if (tokens.size() > 2) {
         std::istringstream(tokens[0]) >> tm.tm_mday;
@@ -232,8 +232,8 @@ time_t HttpdDirScraper::parse_time_format_A(const vector<string> tokens) const
 time_t HttpdDirScraper::parse_time_format_B(const vector<string> tokens) const
 {
     // void BESUtil::tokenize(const string& str, vector<string>& tokens, const string& delimiters)
-    struct tm tm;
-    zero_tm_struct(tm);
+    struct tm tm{};
+    // jhrg 2/2/24 zero_tm_struct(tm);
 
     if (tokens.size() > 2) {
         std::istringstream(tokens[0]) >> tm.tm_year;


### PR DESCRIPTION
Changed 'struct tm <var>' so the variable is always initialized.

This was causing intermittent failures because some fields of the struct held
garbage values that made bogus dates.