### PR TITLE
Fonc asan patch

### DIFF
--- a/modules/fileout_netcdf/FONcArray.cc
+++ b/modules/fileout_netcdf/FONcArray.cc
@@ -379,7 +379,8 @@ void FONcArray::convert(vector<string> embed, bool _dap4, bool is_dap4_group) {
 
         // For NC_CHAR, the module needs to call the intern_data().  
         // This routine is called in the convert(). So it should not called in define().
-        if (d_is_dap4)
+        // FIXME Patch for HYRAX-1334 jhrg 2/14/24
+        if (d_is_dap4 || get_eval() == nullptr || get_dds() == nullptr)
             d_a->intern_data();
         else
             d_a->intern_data(*get_eval(), *get_dds());
@@ -750,8 +751,9 @@ void FONcArray::define(int ncid) {
  */
 void FONcArray::write_nc_variable(int ncid, nc_type var_type) {
 
-  // Note: when fdio_flag is not true, the intern_data needs to be called here. 
-    if (d_is_dap4)
+    // Note: when fdio_flag is not true, the intern_data needs to be called here.
+    // FIXME Patch for HYRAX-1334 jhrg 2/14/24
+    if (d_is_dap4 || get_eval() == nullptr || get_dds() == nullptr)
         d_a->intern_data();
     else
         d_a->intern_data(*get_eval(), *get_dds());

--- a/modules/fileout_netcdf/FONcBaseType.h
+++ b/modules/fileout_netcdf/FONcBaseType.h
@@ -66,12 +66,10 @@ protected:
     bool d_defined = false;
     std::string d_ncVersion;
     std::string d_nc4_datamodel;
-    // FIXME Tried setting this true by default; that should have changed some test behavior (FONcStr.cc test 4 and 5, e.g.)
+    // FIXME Tried setting this true by default; that should have changed some test behavior
     //  but it didn't. jhrg 2/13/24. Does this mean the value is set somewhere else?
-#if 0
+    //  See HYRAX-1334.
     bool d_is_dap4 = false;
-#endif
-    bool d_is_dap4 = true;
 
     //This is to handle the name clashing of dimension names of string type
     bool d_is_dap4_group = false;

--- a/modules/fileout_netcdf/FONcBaseType.h
+++ b/modules/fileout_netcdf/FONcBaseType.h
@@ -66,7 +66,12 @@ protected:
     bool d_defined = false;
     std::string d_ncVersion;
     std::string d_nc4_datamodel;
+    // FIXME Tried setting this true by default; that should have changed some test behavior (FONcStr.cc test 4 and 5, e.g.)
+    //  but it didn't. jhrg 2/13/24. Does this mean the value is set somewhere else?
+#if 0
     bool d_is_dap4 = false;
+#endif
+    bool d_is_dap4 = true;
 
     //This is to handle the name clashing of dimension names of string type
     bool d_is_dap4_group = false;

--- a/modules/fileout_netcdf/FONcGrid.cc
+++ b/modules/fileout_netcdf/FONcGrid.cc
@@ -161,7 +161,14 @@ void FONcGrid::convert(vector<string> embed, bool _dap4, bool is_dap4_group)
 
             vector<string> map_embed;
 
+#if 0
+            // Patch for HYRAX-1334 jhrg 2/14/24
             map->intern_data(*get_eval(), *get_dds());
+#endif
+            if (d_is_dap4 || get_eval() == nullptr || get_dds() == nullptr)
+                map->intern_data();
+            else
+                map->intern_data(*get_eval(), *get_dds());
 
             FONcMap *map_found = FONcGrid::InMaps(map);
 

--- a/modules/fileout_netcdf/FONcStr.cc
+++ b/modules/fileout_netcdf/FONcStr.cc
@@ -86,13 +86,15 @@ void FONcStr::define(int ncid)
         d_varname = FONcUtils::gen_name(d_embed, d_varname, d_orig_varname);
         _data = new string;
 
-        if (d_is_dap4)
+        // FIXME This is a hack to get around the fact that the code moved away from setting the DDS and
+        //  the ConstraintEvaluator in the constructor. This is a temporary fix. jhrg 2/14/24
+        if (d_is_dap4|| get_eval() == nullptr || get_dds() == nullptr)
             _str->intern_data();
         else
             _str->intern_data(*get_eval(), *get_dds());
 
         _str->buf2val((void**) &_data);
-        int size = _data->size() + 1;
+        auto size = _data->size() + 1;
 
         string dimname;
 

--- a/modules/fileout_netcdf/FONcStr.cc
+++ b/modules/fileout_netcdf/FONcStr.cc
@@ -88,7 +88,7 @@ void FONcStr::define(int ncid)
 
         // FIXME This is a hack to get around the fact that the code moved away from setting the DDS and
         //  the ConstraintEvaluator in the constructor. This is a temporary fix. jhrg 2/14/24
-        if (d_is_dap4|| get_eval() == nullptr || get_dds() == nullptr)
+        if (d_is_dap4 || get_eval() == nullptr || get_dds() == nullptr)
             _str->intern_data();
         else
             _str->intern_data(*get_eval(), *get_dds());

--- a/modules/fileout_netcdf/FONcTransform.cc
+++ b/modules/fileout_netcdf/FONcTransform.cc
@@ -98,6 +98,8 @@ using namespace std;
  * @throws BESInternalError if dds provided is empty or not read, if the
  * file is not specified or failed to create the netcdf file
  */
+#if 0
+
 FONcTransform::FONcTransform(DDS *dds, BESDataHandlerInterface &dhi, const string &localfile, const string &ncVersion) :
                              _dds(dds), _localfile(localfile), _returnAs(ncVersion)  {
     if (!_dds) {
@@ -127,6 +129,8 @@ FONcTransform::FONcTransform(DDS *dds, BESDataHandlerInterface &dhi, const strin
     }
 }
 
+#endif
+
 /** @brief Constructor that creates transformation object from the specified
  * DataDDS object to the specified file
  *
@@ -138,6 +142,8 @@ FONcTransform::FONcTransform(DDS *dds, BESDataHandlerInterface &dhi, const strin
  * @throws BESInternalError if dds provided is empty or not read, if the
  * file is not specified or failed to create the netcdf file
  */
+#if 0
+
 FONcTransform::FONcTransform(DMR *dmr, BESDataHandlerInterface &dhi, const string &localfile, const string &ncVersion) :
                              _dmr(dmr), _localfile(localfile), _returnAs(ncVersion) {
     if (!_dmr) {
@@ -166,6 +172,8 @@ FONcTransform::FONcTransform(DMR *dmr, BESDataHandlerInterface &dhi, const strin
         FONcUtils::name_prefix = "nc_";
     }
 }
+
+#endif
 
 /** @brief Constructor that creates transformation object from the specified
  * DataDDS object to the specified file
@@ -683,10 +691,6 @@ void FONcTransform::throw_if_dap4_response_too_big(DMR *dmr, const string &dap4_
         string err_msg = too_big_error_msg(4,return_encoding,req_size_kb, max_response_size_kb, dap4_ce);
         throw BESSyntaxUserError(err_msg,__FILE__,__LINE__);
     }
-
-
-
-
 }
 
 /** @brief Transforms each of the variables of the DMR to the NetCDF

--- a/modules/fileout_netcdf/FONcTransform.cc
+++ b/modules/fileout_netcdf/FONcTransform.cc
@@ -87,96 +87,7 @@ using namespace std;
 #define MSG_LABEL_CLASSIC_MODEL " (classic model)"
 #define MSG_LABEL_SIXTYFOUR_BIT_MODEL " (64-bit offset model)"
 
-/** @brief Constructor that creates transformation object from the specified
- * DataDDS object to the specified file
- *
- * @param dds DataDDS object that contains the data structure, attributes
- * and data
- * @param dhi The data interface containing information about the current
- * request
- * @param localfile netcdf to create and write the information to
- * @throws BESInternalError if dds provided is empty or not read, if the
- * file is not specified or failed to create the netcdf file
- */
-#if 0
-
-FONcTransform::FONcTransform(DDS *dds, BESDataHandlerInterface &dhi, const string &localfile, const string &ncVersion) :
-                             _dds(dds), _localfile(localfile), _returnAs(ncVersion)  {
-    if (!_dds) {
-        throw BESInternalError("File out netcdf, null DDS passed to constructor", __FILE__, __LINE__);
-    }
-    if (_localfile.empty()) {
-        throw BESInternalError("File out netcdf, empty local file name passed to constructor", __FILE__, __LINE__);
-    }
-#if 0
-    _localfile = localfile;
-    _dds = dds;
-    _returnAs = ncVersion;
-#endif
-
-    // if there is a variable, attribute, dimension name that is not
-    // compliant with netcdf naming conventions then we will create
-    // a new name. If the new name does not begin with an alpha
-    // character then we will prefix it with name_prefix. We will
-    // get this prefix from the type of data that we are reading in,
-    // such as nc, h4, h5, ff, jg, etc...
-    dhi.first_container();
-    if (dhi.container) {
-        FONcUtils::name_prefix = dhi.container->get_container_type() + "_";
-    }
-    else {
-        FONcUtils::name_prefix = "nc_";
-    }
-}
-
-#endif
-
-/** @brief Constructor that creates transformation object from the specified
- * DataDDS object to the specified file
- *
- * @param dmr DMR object that contains the data structure, attributes
- * and data
- * @param dhi The data interface containing information about the current
- * request
- * @param localfile netcdf to create and write the information to
- * @throws BESInternalError if dds provided is empty or not read, if the
- * file is not specified or failed to create the netcdf file
- */
-#if 0
-
-FONcTransform::FONcTransform(DMR *dmr, BESDataHandlerInterface &dhi, const string &localfile, const string &ncVersion) :
-                             _dmr(dmr), _localfile(localfile), _returnAs(ncVersion) {
-    if (!_dmr) {
-        throw BESInternalError("File out netcdf, null DMR passed to constructor", __FILE__, __LINE__);
-    }
-    if (_localfile.empty()) {
-        throw BESInternalError("File out netcdf, empty local file name passed to constructor", __FILE__, __LINE__);
-    }
-#if 0
-    _localfile = localfile;
-    _dmr = dmr;
-    _returnAs = ncVersion;
-#endif
-
-    // if there is a variable, attribute, dimension name that is not
-    // compliant with netcdf naming conventions then we will create
-    // a new name. If the new name does not begin with an alpha
-    // character then we will prefix it with name_prefix. We will
-    // get this prefix from the type of data that we are reading in,
-    // such as nc, h4, h5, ff, jg, etc...
-    dhi.first_container();
-    if (dhi.container) {
-        FONcUtils::name_prefix = dhi.container->get_container_type() + "_";
-    }
-    else {
-        FONcUtils::name_prefix = "nc_";
-    }
-}
-
-#endif
-
-/** @brief Constructor that creates transformation object from the specified
- * DataDDS object to the specified file
+/** @brief Constructor that creates transformation object from the specified BESResponseObject object to the specified file
  *
  * @param dds DataDDS object that contains the data structure, attributes
  * and data
@@ -226,8 +137,6 @@ FONcTransform::~FONcTransform() {
     // _dds still is. jhrg 8/13/21
     delete _dmr;
 }
-
-
 
 /**
  *

--- a/modules/fileout_netcdf/FONcTransform.h
+++ b/modules/fileout_netcdf/FONcTransform.h
@@ -86,8 +86,13 @@ public:
 	 * @param localfile
 	 * @param netcdfVersion
 	 */
-	FONcTransform(libdap::DDS *dds, BESDataHandlerInterface &dhi, const std::string &localfile, const std::string &netcdfVersion = "netcdf");
+#if 0
+    // FIXME These are never used - that's OK, but the one remaining constructor does not set _dds or _dmr which is
+    //  the root cause of the bug in https://bugs.earthdata.nasa.gov/browse/HYRAX-1334. At leaset the part where
+    //  _dds is not set. I'm not sure where the CE Evaluator should be set. jhrg 2/13/24
+    FONcTransform(libdap::DDS *dds, BESDataHandlerInterface &dhi, const std::string &localfile, const std::string &netcdfVersion = "netcdf");
 	FONcTransform(libdap::DMR *dmr, BESDataHandlerInterface &dhi, const std::string &localfile, const std::string &netcdfVersion = "netcdf");
+#endif
     FONcTransform(BESResponseObject *obj, BESDataHandlerInterface *dhi, const std::string &localfile, const std::string &ncVersion = "netcdf");
     virtual ~FONcTransform();
 	virtual void transform_dap2(ostream &strm);
@@ -95,10 +100,10 @@ public:
 
 	virtual void dump(ostream &strm) const;
 
-        // TODO: This is for the temporary memory usage optimization. Once we can support the define() with or without dio for individual array.
-        //       This flag is not necessary and should be removed. KY 11/29/23
-        bool get_gdio_flag() const {return global_dio_flag; }
-        void set_gdio_flag(bool dio_flag_value = true) { global_dio_flag = dio_flag_value; }
+    // TODO: This is for the temporary memory usage optimization. Once we can support the define() with or without dio for individual array.
+    //       This flag is not necessary and should be removed. KY 11/29/23
+    bool get_gdio_flag() const {return global_dio_flag; }
+    void set_gdio_flag(bool dio_flag_value = true) { global_dio_flag = dio_flag_value; }
 
 
 private:

--- a/modules/fileout_netcdf/FONcTransform.h
+++ b/modules/fileout_netcdf/FONcTransform.h
@@ -76,23 +76,6 @@ private:
     bool global_dio_flag = false; 
 
 public:
-	/**
-	 * Build a FONcTransform object. By default it builds a netcdf 3 file; pass "netcdf-4"
-	 * to get a netcdf 4 file.
-	 *
-	 * @note added default value to fourth param to preserve the older API. 5/6/13 jhrg
-	 * @param dds
-	 * @param dhi
-	 * @param localfile
-	 * @param netcdfVersion
-	 */
-#if 0
-    // FIXME These are never used - that's OK, but the one remaining constructor does not set _dds or _dmr which is
-    //  the root cause of the bug in https://bugs.earthdata.nasa.gov/browse/HYRAX-1334. At leaset the part where
-    //  _dds is not set. I'm not sure where the CE Evaluator should be set. jhrg 2/13/24
-    FONcTransform(libdap::DDS *dds, BESDataHandlerInterface &dhi, const std::string &localfile, const std::string &netcdfVersion = "netcdf");
-	FONcTransform(libdap::DMR *dmr, BESDataHandlerInterface &dhi, const std::string &localfile, const std::string &netcdfVersion = "netcdf");
-#endif
     FONcTransform(BESResponseObject *obj, BESDataHandlerInterface *dhi, const std::string &localfile, const std::string &ncVersion = "netcdf");
     virtual ~FONcTransform();
 	virtual void transform_dap2(ostream &strm);


### PR DESCRIPTION
This is a patch for the issue described in HYRAX-1334 where the intern_data(...)
method is used with a DDS and CE Evaluator returned by get_dds() and get_ce_eval()
but those are actually null pointers. The call passes those nullptr values into 
formal parameters that are _references_ to the DDS and CE_Eval objects. That's 
not good. This fix just calls the no-arg version of intern_data() instead and all the
tests pass.