### PR TITLE
fixes for 883 - missing include <cstring> needed by GCC 14

### DIFF
--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <ctime>
+#include <cstring>
 
 #include <curl/curl.h>
 

--- a/http/RemoteResource.cc
+++ b/http/RemoteResource.cc
@@ -28,6 +28,7 @@
 
 #include <cstdio>
 #include <unistd.h>
+#include <cstring>
 
 #include <sstream>
 #include <string>

--- a/http/tests/remote_resource_tester.cc
+++ b/http/tests/remote_resource_tester.cc
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <string>
+#include <cstring>
 
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
fixes for 883 - missing include <cstring> needed by GCC 14