### PR TITLE
Refactor to remove use of unique_ptr as singleton.

### DIFF
--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -27,13 +27,12 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <csignal>
-#include <sys/wait.h> // for wait
-#include <sstream>      // std::stringstream
+#include <sys/wait.h>
+#include <sstream>
 
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
-// #include <vector>
 #include <string>
 #include <memory>
 
@@ -90,7 +89,7 @@ void TempFile::sigpipe_handler(int sig) {
         }
     }
     catch (const std::exception &e) {
-        cerr << "std::exception: " << e.what() << " (location: " << __FILE__ << " at line: " << __LINE__ << ")\n";
+        ERROR_LOG(build_error_msg("std::exception: " + string(e.what()), __FILE__, __LINE__));
     }
 }
 

--- a/dap/TempFile.cc
+++ b/dap/TempFile.cc
@@ -26,14 +26,14 @@
 
 #include <sys/stat.h>
 #include <unistd.h>
-#include <signal.h>
+#include <csignal>
 #include <sys/wait.h> // for wait
 #include <sstream>      // std::stringstream
 
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
-#include <vector>
+// #include <vector>
 #include <string>
 #include <memory>
 
@@ -54,65 +54,73 @@ using namespace std;
 
 namespace bes {
 
-std::once_flag TempFile::d_init_once;
-std::unique_ptr< std::map<std::string, int> > TempFile::open_files;
+std::map<std::string, int, std::less<>> TempFile::open_files;
 struct sigaction TempFile::cached_sigpipe_handler;
 
+static string build_error_msg(const string &msg, const string &file = "", int line = -1) {
+    if (file.empty())
+        return {msg + ": " + strerror(errno) + " (errno: " + to_string(errno) + ")"};
+    else
+        return {msg + ": " + strerror(errno) + " (errno: " + to_string(errno) + "at" + file + ":"
+                + to_string(line) + ")\n"};
+}
 
 /**
  * We need to make sure that all of the open temporary files get cleaned up if
  * bad things happen. So far, SIGPIPE is the only bad thing we know about
  * at least with respect to the TempFile class.
  */
-void TempFile::sigpipe_handler(int sig)
-{
+void TempFile::sigpipe_handler(int sig) {
     try {
+        int saved_errno = errno;
         if (sig == SIGPIPE) {
-            for (const auto &mpair: *open_files) {
+            for (const auto &mpair: open_files) {
                 if (unlink((mpair.first).c_str()) == -1) {
-                    stringstream msg;
-                    msg << "Error unlinking temporary file: '" << mpair.first << "'";
-                    msg << " errno: " << errno << " message: " << strerror(errno) << endl;
-                    ERROR_LOG(msg.str());
+                    ERROR_LOG(build_error_msg("Error unlinking temporary file: " + mpair.first, __FILE__, __LINE__));
                 }
             }
+
             // Files cleaned up? Sweet! Time to bail...
-            // Remove this SIGPIPE handler
+            // replace this SIGPIPE handler with the cached one.
             sigaction(SIGPIPE, &cached_sigpipe_handler, nullptr);
+
             // Re-raise SIGPIPE
+            errno = saved_errno;
             raise(SIGPIPE);
         }
     }
-    catch (BESError &e) {
-        cerr << "Encountered BESError. Message: " << e.get_verbose_message();
-        cerr << " (location: " << __FILE__ << " at line: " << __LINE__ << ")" <<  endl;
-    }
-    catch (...) {
-        cerr << "Encountered unknown error in " << __FILE__ << " at line: " << __LINE__ << endl;
+    catch (const std::exception &e) {
+        cerr << "std::exception: " << e.what() << " (location: " << __FILE__ << " at line: " << __LINE__ << ")\n";
     }
 }
 
-
 /**
- * @brief Attempts to create the directory identified by dir_name, throws an exception if it fails.
- * @param dir_name
+ * @brief Attempts to create the directory identified by dir_name
+ *
+ * Tries to make a directory for temporary files. If the directory already
+ * exists, returns false. If the directory is created, returns true. If the
+ * directory is made, then the access mode is 770.
+ *
+ * @note Does not test that a directory that exists is has the access mode of
+ * at least 770.
+ *
+ * @param dir_name Full path of the directory to be created
+ * @return true if the directory was created, false if it already exists
+ * @exception BESInternalFatalError if the directory could not be created and does not already exist
  */
-void TempFile::mk_temp_dir(const std::string &dir_name) {
+bool TempFile::mk_temp_dir(const std::string &dir_name) {
 
     mode_t mode = S_IRWXU | S_IRWXG;
-    stringstream ss;
-    ss << prolog << "mode: " <<  std::oct << mode << endl;
-    BESDEBUG(MODULE, ss.str());
+    BESDEBUG(MODULE, prolog << "mode: " << std::oct << mode << endl);
 
-    if(mkdir(dir_name.c_str(), mode)){
-        if(errno != EEXIST){
-            stringstream msg;
-            msg << prolog  << "ERROR - Failed to create temp directory: " << dir_name;
-            msg << " errno: " << errno << " reason: " << strerror(errno);
-            throw BESInternalFatalError(msg.str(),__FILE__,__LINE__);
+    if (mkdir(dir_name.c_str(), mode)) {
+        if (errno != EEXIST) {
+            throw BESInternalFatalError(build_error_msg("Failed to create temp directory: " + dir_name), __FILE__,
+                                        __LINE__);
         }
         else {
-            BESDEBUG(MODULE,prolog << "The temp directory: " << dir_name << " exists." << endl);
+            BESDEBUG(MODULE, prolog << "The temp directory: " << dir_name << " exists." << endl);
+            return false;
 #if STRICT
             uid_t uid = getuid();
             gid_t gid = getgid();
@@ -136,25 +144,10 @@ void TempFile::mk_temp_dir(const std::string &dir_name) {
         }
     }
     else {
-        BESDEBUG(MODULE,prolog << "The temp directory: " << dir_name << " was created." << endl);
+        BESDEBUG(MODULE, prolog << "The temp directory: " << dir_name << " was created." << endl);
+        return true;
     }
 }
-
-/**
- * @brief Initialize static class members, should only be called once using std::call_once()
- */
-void TempFile::init() {
-    open_files.reset(new std::map<string, int>());
-}
-
-/**
- *
- * @param keep_temps Keep the temporary files.
- */
-TempFile::TempFile(bool keep_temps): d_keep_temps(keep_temps) {
-    std::call_once(d_init_once,TempFile::init);
-}
-
 
 /**
  * @brief Create a new temporary file
@@ -167,48 +160,45 @@ TempFile::TempFile(bool keep_temps): d_keep_temps(keep_temps) {
  * @param temp_file_prefix A prefix to be used for the temporary file.
  * @return The name of the temporary file.
  */
-string TempFile::create(const std::string &dir_name, const std::string &temp_file_prefix)
-{
+string TempFile::create(const std::string &dir_name, const std::string &temp_file_prefix) {
     std::lock_guard<std::recursive_mutex> lock_me(d_tf_lock_mutex);
 
     BESDEBUG(MODULE, prolog << "dir_name: " << dir_name << endl);
-    mk_temp_dir(dir_name);
 
-    BESDEBUG(MODULE, prolog << "temp_file_prefix: " << temp_file_prefix << endl);
-    string tmplt("XXXXXX");
-    if(!BESUtil::endsWith(temp_file_prefix,"_")){
-        tmplt = "_" + tmplt;
+    if (access(dir_name.c_str(), F_OK) == -1) {
+        if (errno == ENOENT) {
+            mk_temp_dir(dir_name);
+        }
+        else {
+            throw BESInternalFatalError(build_error_msg("Failed to access temp directory: " + dir_name), __FILE__,
+                                        __LINE__);
+        }
     }
-    string file_template = temp_file_prefix + tmplt;
-    BESDEBUG(MODULE, prolog << "file_template: " << file_template << endl);
 
-    string target_file = BESUtil::pathConcat(dir_name,file_template);
+    string target_file = BESUtil::pathConcat(dir_name, temp_file_prefix + "_XXXXXX");
+
     BESDEBUG(MODULE, prolog << "target_file: " << target_file << endl);
-
-    char tmp_name[target_file.size() + 1];
-    std::string::size_type len = target_file.copy(tmp_name, target_file.size());
-    tmp_name[len] = '\0';
 
     // cover the case where older versions of mkstemp() create the file using
     // a mode of 666.
     mode_t original_mode = umask(077);
-    d_fd = mkstemp(tmp_name);
+    // The 'hack' &temp_file_name[0] is explicitly supported by the C++ 11 standard.
+    d_fd = mkstemp(&target_file[0]);
     umask(original_mode);
 
     if (d_fd == -1) {
-        stringstream msg;
-        msg << "Failed to open the temporary file using mkstemp()";
-        msg << " errno: " << errno << " message: " << strerror(errno);
-        msg << " FileTemplate: " + target_file;
-        throw BESInternalError(msg.str(), __FILE__, __LINE__);
+        throw BESInternalError(
+                build_error_msg("Failed to open the temporary file using mkstemp(), FileTemplate: " + target_file),
+                __FILE__, __LINE__);
     }
-    d_fname.assign(tmp_name);
+
+    d_fname.assign(target_file);
 
     // Check to see if there are already active TempFile things,
     // we can tell because if open_files->size() is zero then this
     // is the first, and we need to register SIGPIPE handler.
-    if (open_files->empty()) {
-        struct sigaction act;
+    if (open_files.empty()) {
+        struct sigaction act{};
         sigemptyset(&act.sa_mask);
         sigaddset(&act.sa_mask, SIGPIPE);
         act.sa_flags = 0;
@@ -216,13 +206,12 @@ string TempFile::create(const std::string &dir_name, const std::string &temp_fil
         act.sa_handler = bes::TempFile::sigpipe_handler;
 
         if (sigaction(SIGPIPE, &act, &cached_sigpipe_handler)) {
-            stringstream msg;
-            msg << "Could not register a handler to catch SIGPIPE.";
-            msg << " errno: " << errno << " message: " << strerror(errno);
-            throw BESInternalFatalError(msg.str(), __FILE__, __LINE__);
+            throw BESInternalFatalError(build_error_msg("Could not register a handler to catch SIGPIPE"), __FILE__,
+                                        __LINE__);
         }
     }
-    open_files->insert(std::pair<string, int>(d_fname, d_fd));
+
+    open_files.insert(std::pair<string, int>(d_fname, d_fd));
 
     return d_fname;
 }
@@ -232,45 +221,36 @@ string TempFile::create(const std::string &dir_name, const std::string &temp_fil
  *
  * Close the open descriptor and delete (unlink) the file name.
  */
-TempFile::~TempFile()
-{
+TempFile::~TempFile() {
     try {
-        if(d_fd != -1 && close(d_fd) == -1) {
-            stringstream msg;
-            msg << "Error closing temporary file: '" << d_fname ;
-            msg << " errno: " << errno << " message: " << strerror(errno) << endl;
-            ERROR_LOG(msg.str());
+        if (d_fd != -1 && close(d_fd) == -1) {
+            ERROR_LOG(build_error_msg("Error closing temporary file: " + d_fname, __FILE__, __LINE__));
         }
-        if(!d_fname.empty()) {
+        if (!d_fname.empty()) {
             std::lock_guard<std::recursive_mutex> lock_me(d_tf_lock_mutex);
             if (!d_keep_temps) {
                 if (unlink(d_fname.c_str()) == -1) {
-                    stringstream msg;
-                    msg << "Error unlinking temporary file: '" << d_fname ;
-                    msg << " errno: " << errno << " message: " << strerror(errno) << endl;
-                    ERROR_LOG(msg.str());
+                    ERROR_LOG(build_error_msg("Error unlinking temporary file: " + d_fname, __FILE__, __LINE__));
                 }
             }
-            open_files->erase(d_fname);
-            if (open_files->empty()) {
+
+            open_files.erase(d_fname);
+
+            if (open_files.empty()) {
                 // No more files means we can unload the SIGPIPE handler
                 // If more files are created at a later time then it will get reloaded.
                 if (sigaction(SIGPIPE, &cached_sigpipe_handler, nullptr)) {
-                    stringstream msg;
-                    msg << "Could not de-register the SIGPIPE handler function cached_sigpipe_handler(). ";
-                    msg << " errno: " << errno << " message: " << strerror(errno);
-                    ERROR_LOG(msg.str());
+                    ERROR_LOG(build_error_msg("Could not remove SIGPIPE handler" , __FILE__, __LINE__));
                 }
             }
         }
     }
     catch (BESError const &e) {
-        cerr << "Encountered BESError will closing " << d_fname << " Message: " << e.get_verbose_message();
-        cerr << " (location: " << __FILE__ << " at line: " << __LINE__ << ")" <<  endl;
+        ERROR_LOG(build_error_msg("BESError while closing " + d_fname + ": " + e.get_verbose_message(),
+                                  __FILE__, __LINE__));
     }
-    catch (...) {
-        cerr << "Encountered unknown error while closing " << d_fname;
-        cerr << "  " << __FILE__ << " at line: " << __LINE__ << endl;
+    catch (std::exception const &e) {
+        ERROR_LOG(build_error_msg("C++ exception while closing " + d_fname + ": " + e.what(),  __FILE__, __LINE__));
     }
 }
 

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -56,6 +56,8 @@ class TempFile {
     std::string d_fname;
     bool d_keep_temps = false;
 
+    static bool mk_temp_dir(const std::string &dir_name = "/tmp/hyrax_tmp");
+
 public:
     // Odd, but even with TemporaryFileTest declared as a friend, the tests won't
     // compile unless this is declared public.
@@ -71,7 +73,7 @@ public:
 
     ~TempFile();
 
-    bool mk_temp_dir(const std::string &dir_name = "/tmp/hyrax_tmp");
+
 
     std::string create(const std::string &dir_name = "/tmp/hyrax_tmp", const std::string &path_template = "opendap");
 

--- a/dap/TempFile.h
+++ b/dap/TempFile.h
@@ -25,13 +25,10 @@
 #ifndef DAP_TEMPFILE_H_
 #define DAP_TEMPFILE_H_
 
-#include <unistd.h>
-
-#include <vector>
+#include <csignal>
 #include <string>
 #include <map>
 #include <mutex>
-#include <memory>
 
 namespace bes {
 
@@ -44,32 +41,37 @@ namespace bes {
  * of how the caller exits - regularly or via an exception.
  */
 class TempFile {
-private:
+
+    friend class TemporaryFileTest;
+
     // Lifecycle controls
     static struct sigaction cached_sigpipe_handler;
     mutable std::recursive_mutex d_tf_lock_mutex;
-    static void init();
-    static std::once_flag d_init_once;
 
     // Holds the static list of all open files
-    static std::unique_ptr< std::map<std::string, int> > open_files;
+    static std::map<std::string, int, std::less<>> open_files;
 
     // Instance variables
     int d_fd = -1;
     std::string d_fname;
-    bool d_keep_temps;
-
-    static void mk_temp_dir(const std::string &dir_name = "/tmp/hyrax_tmp") ;
-
-    friend class TemporaryFileTest;
+    bool d_keep_temps = false;
 
 public:
     // Odd, but even with TemporaryFileTest declared as a friend, the tests won't
     // compile unless this is declared public.
     static void sigpipe_handler(int signal);
 
-    explicit TempFile(bool keep_temps = false);
+    TempFile() = default;
+    explicit TempFile(bool keep_temps) : d_keep_temps(keep_temps) {}
+
+    TempFile(const TempFile&) = delete;
+    TempFile& operator=(const TempFile&) = delete;
+    TempFile(TempFile&&) = delete;
+    TempFile& operator=(TempFile&&) = delete;
+
     ~TempFile();
+
+    bool mk_temp_dir(const std::string &dir_name = "/tmp/hyrax_tmp");
 
     std::string create(const std::string &dir_name = "/tmp/hyrax_tmp", const std::string &path_template = "opendap");
 

--- a/dap/unit-tests/TemporaryFileTest.cc
+++ b/dap/unit-tests/TemporaryFileTest.cc
@@ -75,6 +75,15 @@ public:
         TheBESKeys::ConfigFile = BES_CONF_FILE;
         DBG(cerr << __func__ << "() - Temp file template is: '" << TEMP_FILE_PREFIX << "'" << endl);
         DBG2(cerr << __func__ << "() - END" << endl);
+
+        if (access(TEMP_DIR.c_str(), F_OK) == -1) {
+            if (errno != ENOENT) {
+                CPPUNIT_FAIL("Failed to make temporary directory for tests: " + TEMP_DIR);
+            }
+            else if (mkdir(TEMP_DIR.c_str(), S_IRWXU | S_IRWXG) != 0) {
+                CPPUNIT_FAIL("Failed to make temporary directory for tests: " + TEMP_DIR);
+            }
+        }
     }
 
     void mk_temp_dir_normal() {
@@ -89,7 +98,7 @@ public:
 
     void mk_temp_dir_exists() {
         TempFile tf;
-        auto tmp_dir = string(TEST_BUILD_DIR) + "/mk_temp_dir_normal";
+
         CPPUNIT_ASSERT_MESSAGE("The directory should exist", access(TEMP_DIR.c_str(), F_OK) == 0);
         CPPUNIT_ASSERT_MESSAGE("The directory should exist and should not be created", !tf.mk_temp_dir(TEMP_DIR));
         CPPUNIT_ASSERT_MESSAGE("The directory should still exist", access(TEMP_DIR.c_str(), F_OK) == 0);

--- a/dap/unit-tests/TemporaryFileTest.cc
+++ b/dap/unit-tests/TemporaryFileTest.cc
@@ -24,19 +24,12 @@
 
 #include "config.h"
 
-#include <signal.h>
-#include <sys/stat.h>
-
-#include <stdio.h>
-#include <stdlib.h>
+#include <csignal>
+#include <cstdlib>
 #include <sys/mman.h>
-#include <sys/types.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
-#include <unistd.h>
 
-#include <cppunit/TextTestRunner.h>
-#include <cppunit/extensions/TestFactoryRegistry.h>
-#include <cppunit/extensions/HelperMacros.h>
 #include <unistd.h>
 
 #include <libdap/debug.h>
@@ -47,45 +40,34 @@
 #include "BESUtil.h"
 #include "BESDebug.h"
 #include "TempFile.h"
+#include "modules/common/run_tests_cppunit.h"
 
 #include "test_config.h"
 
-// static bool debug = false;
-// This tests fails in CI sometimes for no known reason. Run with debugging
-// by default. jhrg 4/17/19
-static bool debug = true;
-static bool debug_2 = false;
-
-#undef DBG
-#define DBG(x) do { if (debug) (x); } while(false);
-#undef DBG2
-#define DBG2(x) do { if (debug_2) (x); } while(false);
-
 using namespace CppUnit;
-using namespace bes;
 using namespace std;
 
+namespace bes {
 
-class TemporaryFileTest: public CppUnit::TestFixture {
-    const string TEMP_DIR=string(TEST_BUILD_DIR).append("/temp_file_test");
-    const string TEMP_FILE_PREFIX = "tmpf_test_";
+class TemporaryFileTest : public CppUnit::TestFixture {
+    const string TEMP_DIR = string(TEST_BUILD_DIR).append("/temp_file_test");
+    const string TEMP_FILE_PREFIX = "tmpf_test";
     const string BES_CONF_FILE = BESUtil::assemblePath(TEST_BUILD_DIR, "bes.conf");
-private:
+
+    static bool file_present(const string &file_name) {
+        struct stat buf{};
+        return (stat(file_name.c_str(), &buf) == 0);
+    }
 
 public:
-    TemporaryFileTest()
-    {
-    }
+    TemporaryFileTest() = default;
 
-    ~TemporaryFileTest()
-    {
-    }
+    ~TemporaryFileTest() = default;
 
-    void setUp()
-    {
+    void setUp() override {
         DBG2(cerr << __func__ << "() - BEGIN" << endl);
 
-        if (debug_2) BESDebug::SetUp("cerr,dap");
+        if (debug2) BESDebug::SetUp("cerr,dap");
 
         // Because TemporaryFile uses the BESLog macro ERROR we have
         // to configure the BESKeys with the BES config file name so
@@ -95,135 +77,169 @@ public:
         DBG2(cerr << __func__ << "() - END" << endl);
     }
 
-    void tearDown()
-    {
+    void mk_temp_dir_normal() {
+        TempFile tf;
+        auto tmp_dir = string(TEST_BUILD_DIR) + "/mk_temp_dir_normal";
+        CPPUNIT_ASSERT_MESSAGE("The directory should not exist", access(tmp_dir.c_str(), F_OK) == -1);
+        CPPUNIT_ASSERT_MESSAGE("The directory should not exist and should be created", tf.mk_temp_dir(tmp_dir));
+        CPPUNIT_ASSERT_MESSAGE("The directory should exist", access(tmp_dir.c_str(), F_OK) == 0);
+        rmdir(tmp_dir.c_str());
+        CPPUNIT_ASSERT_MESSAGE("The directory should not exist", access(tmp_dir.c_str(), F_OK) == -1);
     }
 
-    void normal_test()
-    {
+    void mk_temp_dir_exists() {
+        TempFile tf;
+        auto tmp_dir = string(TEST_BUILD_DIR) + "/mk_temp_dir_normal";
+        CPPUNIT_ASSERT_MESSAGE("The directory should exist", access(TEMP_DIR.c_str(), F_OK) == 0);
+        CPPUNIT_ASSERT_MESSAGE("The directory should exist and should not be created", !tf.mk_temp_dir(TEMP_DIR));
+        CPPUNIT_ASSERT_MESSAGE("The directory should still exist", access(TEMP_DIR.c_str(), F_OK) == 0);
+    }
+
+    // Grasping at straws here; the code should not be able to make a temporary directory in root (/)
+    void mk_temp_dir_not_allowed() {
+        TempFile tf;
+        string tmp_dir = "/temporary_directory";
+        CPPUNIT_ASSERT_MESSAGE("The directory should not exist", access(tmp_dir.c_str(), F_OK) == -1);
+        CPPUNIT_ASSERT_THROW_MESSAGE("The directory should not exist and should not be created",
+                                        tf.mk_temp_dir(tmp_dir), BESInternalFatalError);
+        CPPUNIT_ASSERT_MESSAGE("The directory should not exist", access(tmp_dir.c_str(), F_OK) == -1);
+    }
+
+    void create_normal_test() {
         std::string tmp_file_name;
 
         try {
-            bes::TempFile tf;
+            TempFile tf;
             tmp_file_name = tf.create(TEMP_DIR, TEMP_FILE_PREFIX);
             DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
-                << tf.get_fd() << endl);
+                     << tf.get_fd() << endl);
 
             // Is it really there? Just sayin'...
-            struct stat buf;
-            int statret = stat(tmp_file_name.c_str(), &buf);
-            CPPUNIT_ASSERT(statret == 0);
+            CPPUNIT_ASSERT_MESSAGE("The temporary file should exist", file_present(tmp_file_name));
+
+            CPPUNIT_ASSERT_MESSAGE("TempFile.open_files should have one entry", tf.open_files.size() == 1);
         }
         catch (BESInternalError &bie) {
             DBG(cerr << __func__ << "() - Caught BESInternalError! Message: " << bie.get_message() << endl);
             CPPUNIT_ASSERT(false);
         }
-        // The name should be set to something.
-        CPPUNIT_ASSERT(!tmp_file_name.empty());
 
-        struct stat buf;
-        int statret = stat(tmp_file_name.c_str(), &buf);
         // And the file should be gone because the class TemporaryFile went out of scope.
-        CPPUNIT_ASSERT(statret != 0);
-        DBG(cerr << __func__ << "() - Temp file '" << tmp_file_name
-            << "' has been removed. (Temporary file out of scope)" << endl);
+        CPPUNIT_ASSERT_MESSAGE("The file should not exist since the temporary file scope was exited.", !file_present(tmp_file_name));
 
+        // The name should be set to something.
+        CPPUNIT_ASSERT_MESSAGE("Even after deletion, this name should not be empty", !tmp_file_name.empty());
     }
 
-    void multi_file_normal_test()
-    {
+    void create_multi_file_normal_test() {
         int count = 3;
-        bes::TempFile *tfiles[count];
-        string tmp_file_names[count];
+        vector<unique_ptr<TempFile>> tfiles(count);
+        vector<string> tmp_file_names(count);
 
         try {
             for (int i = 0; i < count; i++) {
-                tfiles[i] = new bes::TempFile();
+
+                tfiles[i] = make_unique<TempFile>();
                 tmp_file_names[i] = tfiles[i]->create(TEMP_DIR, TEMP_FILE_PREFIX);
+
                 DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_names[i] << "' has been created. fd: "
-                    << tfiles[i]->get_fd() << endl);
+                         << tfiles[i]->get_fd() << endl);
 
-                // Is it really there? Just sayin'...
-                struct stat buf;
-                int statret = stat(tmp_file_names[i].c_str(), &buf);
-                CPPUNIT_ASSERT(statret == 0);
+                CPPUNIT_ASSERT_MESSAGE("Temporary file should exist.", file_present(tfiles[i]->get_name()));
             }
 
-            for (int i = 0; i < count; i++) {
-                delete tfiles[i];
-            }
+            CPPUNIT_ASSERT_MESSAGE("TempFile.open_files should have three entries", tfiles[0]->open_files.size() == 3);
+            CPPUNIT_ASSERT_MESSAGE("TempFile.open_files should have three entries", tfiles[1]->open_files.size() == 3);
+            CPPUNIT_ASSERT_MESSAGE("TempFile.open_files should have three entries", tfiles[2]->open_files.size() == 3);
+            tfiles.clear();
         }
-        catch (BESInternalError &bie) {
+        catch (const BESInternalError &bie) {
             DBG(cerr << __func__ << "() - Caught BESInternalError! Message: " << bie.get_message() << endl);
-            CPPUNIT_ASSERT(false);
+            CPPUNIT_FAIL("Caught BESInternalError! Message: " + bie.get_message());
         }
 
         for (int i = 0; i < count; i++) {
             // The name should be set to something.
             CPPUNIT_ASSERT(!tmp_file_names[i].empty());
 
-            struct stat buf;
-            int statret = stat(tmp_file_names[i].c_str(), &buf);
             // And the file should be gone because the class TemporaryFile went out of scope.
-            CPPUNIT_ASSERT(statret != 0);
             DBG(cerr << __func__ << "() - Temp file '" << tmp_file_names[i]
-                << "' has been removed. (Temporary file out of scope)" << endl);
-        }
+                     << "' has been removed. (Temporary file out of scope)" << endl);
 
+            CPPUNIT_ASSERT_MESSAGE("The temporary files should be deleted", !file_present(tmp_file_names[i]));
+        }
     }
 
-    void exception_test()
-    {
-        std::string tmp_file_name;
+    // Test that some of the TempFile objects can be removed/deleted and the 'open_files'
+    // map is still around.
+    void create_multi_file_normal_test_2() {
+        int count = 3;
+        vector<unique_ptr<TempFile>> tfiles(count);
+        vector<string> tmp_file_names(count);
+
+        try {
+            for (int i = 0; i < count; i++) {
+
+                tfiles[i] = make_unique<TempFile>();
+                tmp_file_names[i] = tfiles[i]->create(TEMP_DIR, TEMP_FILE_PREFIX);
+
+                DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_names[i] << "' has been created. fd: "
+                         << tfiles[i]->get_fd() << endl);
+
+                CPPUNIT_ASSERT_MESSAGE("Temporary file should exist.", file_present(tfiles[i]->get_name()));
+            }
+
+            CPPUNIT_ASSERT_MESSAGE("tfiles should have three elements.", tfiles.size() == 3);
+            CPPUNIT_ASSERT_MESSAGE("TempFile.open_files should have three entries", tfiles[0]->open_files.size() == 3);
+            CPPUNIT_ASSERT_MESSAGE("TempFile.open_files should have three entries", tfiles[1]->open_files.size() == 3);
+            CPPUNIT_ASSERT_MESSAGE("TempFile.open_files should have three entries", tfiles[2]->open_files.size() == 3);
+            tfiles.erase(tfiles.begin(), tfiles.begin() + 2);
+            CPPUNIT_ASSERT_MESSAGE("tfiles should have one element, not " + to_string(tfiles.size()), tfiles.size() == 1);
+            CPPUNIT_ASSERT_MESSAGE("The first temporary file should be gone", !file_present(tmp_file_names[0]));
+            CPPUNIT_ASSERT_MESSAGE("The second temporary file should be gone", !file_present(tmp_file_names[1]));
+        }
+        catch (const BESInternalError &bie) {
+            DBG(cerr << __func__ << "() - Caught BESInternalError! Message: " << bie.get_message() << endl);
+            CPPUNIT_FAIL("Caught BESInternalError! Message: " + bie.get_message());
+        }
+
+        tfiles.clear();
+
+        CPPUNIT_ASSERT_MESSAGE("The third temporary file should be gone now", !file_present(tmp_file_names[2]));
+    }
+
+    void create_exception_test() {
+        string tmp_file_name;
 
         try {
             bes::TempFile tf;
             tmp_file_name = tf.create(TEMP_DIR, TEMP_FILE_PREFIX);
-            DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_name << "' has been created. fd: " << tf.get_fd() << endl);
+            DBG(cerr << __func__ << "() - Temp file is: '" << tmp_file_name << "' has been created. fd: " << tf.get_fd()
+                     << endl);
 
             // Is it really there? Just sayin'...
-            struct stat buf;
-            int statret = stat(tmp_file_name.c_str(), &buf);
-            CPPUNIT_ASSERT(statret == 0);
+            CPPUNIT_ASSERT(file_present(tmp_file_name));
 
             throw BESInternalError("Throwing an exception to challenge the lifecycle...", __FILE__, __LINE__);
-
         }
         catch (BESInternalError &bie) {
             DBG(cerr << __func__ << "() - Caught BESInternalError (Expected)  Message: " << bie.get_message() << endl);
         }
+
         // The name should be set to something.
         CPPUNIT_ASSERT(!tmp_file_name.empty());
 
-        struct stat buf;
-        int statret = stat(tmp_file_name.c_str(), &buf);
         // And the file should be gone because the class TemporaryFile went out of scope.
-        CPPUNIT_ASSERT(statret != 0);
         DBG(cerr << __func__ << "() - Temp file '" << tmp_file_name
-            << "' has been removed. (Temporary file out of scope)" << endl);
-
+                 << "' has been removed. (Temporary file out of scope)" << endl);
+        CPPUNIT_ASSERT(!file_present(tmp_file_name));
     }
 
-    static void register_sigpipe_handler()
-    {
-        struct sigaction act;
-        sigemptyset(&act.sa_mask);
-        sigaddset(&act.sa_mask, SIGPIPE);
-        act.sa_flags = 0;
-
-        act.sa_handler = bes::TempFile::sigpipe_handler;
-        if (sigaction(SIGPIPE, &act, 0)) {
-            cerr << "Could not register a handler to catch SIGPIPE." << endl;
-            exit(1);
-        }
-    }
-
-    void sigpipe_test()
-    {
+    void sigpipe_test() {
         // Because we are going to fork and the child will be making a temp file, we use shared memory to
         // allow the parent to know the resulting file name.
         char *glob_name;
-        int name_size = TEMP_FILE_PREFIX.size() + 1;
+        auto name_size = TEMP_FILE_PREFIX.size() + 1;
         glob_name = (char *) mmap(nullptr, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 
         pid_t pid = fork();
@@ -232,62 +248,64 @@ public:
         if (pid) {
             // parent - wait for the client to get sorted
             sleep(1);
-            // Send child a the signal
-            DBG(cerr << __func__ << "-PARENT() - Sending SIGPIPE to client." << endl);
+
+            CPPUNIT_ASSERT_MESSAGE("The file " + string(glob_name) + " should be present.", file_present(glob_name));
+
+            // Send child the signal
+            DBG(cerr << __func__ << "-PARENT() - Sending SIGPIPE to child process." << endl);
             kill(pid, SIGPIPE);
-            // wait for the child to die.
-            sleep(1);
-            DBG(cerr << __func__ << "-PARENT() - Client should be dead. Temporary File Name: '"
-                << glob_name << "'" << endl);
+
+            // wait for the child process to catch the signal, remove the temp file and exit.
+            int status;
+            auto child_pid = waitpid(pid, &status, 0);
+            DBG(cerr << __func__ << "-PARENT() - Child exited at this point,  status: " << status << endl);
+            CPPUNIT_ASSERT_MESSAGE("The child process should have exited.", child_pid == pid);
+            CPPUNIT_ASSERT_MESSAGE("The child process should exit with a status of SIGPIPE, was: " + to_string(status), status == SIGPIPE);
 
             // Is it STILL there? Better not be...
-            struct stat buf;
-            int statret = stat(glob_name, &buf);
-            CPPUNIT_ASSERT(statret != 0);
-            DBG(cerr << __func__ << "-PARENT() - Temporary File: '" << glob_name << "' was successfully removed. woot." << endl);
+            CPPUNIT_ASSERT_MESSAGE("The file " + string(glob_name) + " should be deleted.", !file_present(glob_name));
+            DBG(cerr << __func__ << "-PARENT() - Temporary File: '" << glob_name << "' was successfully removed. woot."
+                     << endl);
 
             // Tidy up the shared memory business
             munmap(glob_name, name_size);
-
         }
         else {
-            //child - register a signal handler
-            //register_sigpipe_handler();
-
+            // child
             std::string tmp_file_name;
             try {
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
                 bes::TempFile tf;
                 tmp_file_name = tf.create(TEMP_DIR, TEMP_FILE_PREFIX);
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
-                    << tf.get_fd() << endl);
+                         << tf.get_fd() << endl);
+
                 // copy the filename into shared memory.
                 tmp_file_name.copy(glob_name, tmp_file_name.size(), 0);
 
                 // Is it really there? Just sayin'...
-                struct stat buf;
-                int statret = stat(tmp_file_name.c_str(), &buf);
-                CPPUNIT_ASSERT(statret == 0);
-                // Wait for the signal
+                CPPUNIT_ASSERT(file_present(tmp_file_name));
+
+                // Wait for the signal - SIGPIPE should cause the process to exit
                 sleep(100);
-                DBG(cerr << __func__ << "-CHILD() - Client is Alive." << endl);
+                DBG(cerr << __func__ << "-CHILD() - Client process is Alive." << endl);
+                CPPUNIT_FAIL("The child process should have exited before this point.");
             }
             catch (BESInternalError &bie) {
                 DBG(cerr << __func__ << "-CHILD() - Caught BESInternalError  Message: " << bie.get_message() << endl);
-                CPPUNIT_ASSERT(false);
+                CPPUNIT_FAIL("Caught BESInternalError! Message: " + bie.get_message());
             }
+
             DBG(cerr << __func__ << "-CHILD() - Client is exiting normally." << endl);
-
+            CPPUNIT_FAIL("The child process should have exited before this point.");
         }
-
     }
 
-    void multifile_sigpipe_test()
-    {
+    void multifile_sigpipe_test() {
         // Because we are going to fork and the child will be making a temp file, we use shared memory to
         // allow the parent to know the resulting file names.
         char *glob_name[3];
-        int name_size = TEMP_FILE_PREFIX.size() + 1;
+        auto name_size = TEMP_FILE_PREFIX.size() + 1;
         glob_name[0] = (char *) mmap(nullptr, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
         glob_name[1] = (char *) mmap(nullptr, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
         glob_name[2] = (char *) mmap(nullptr, name_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
@@ -298,104 +316,111 @@ public:
         if (pid) {
             // parent - wait for the client to get sorted
             sleep(1);
-            // Send child a the signal
-            DBG(cerr << __func__ << "-PARENT() - Sending SIGPIPE to client." << endl);
-            kill(pid, SIGPIPE);
-            // wait for the child to die.
-            sleep(1);
-            DBG(cerr << __func__ << "-PARENT() - Client should be dead." << endl);
 
-            for (int i = 0; i < 3; i++) {
-                // Is it STILL there? Better not be...
-                struct stat buf;
-                int statret = stat(glob_name[i], &buf);
-                CPPUNIT_ASSERT(statret != 0);
-                DBG(cerr << __func__ << "-PARENT() - Temporary File: '" << glob_name[i]
-                    << "' was successfully removed. woot." << endl);
+            for (const char *name : glob_name) {
+                 CPPUNIT_ASSERT_MESSAGE("The file " + string(name) + " should be present.", file_present(name));
+            }
+
+            // Send the child process the signal
+            DBG(cerr << __func__ << "-PARENT() - Sending SIGPIPE to child process." << endl);
+            kill(pid, SIGPIPE);
+
+            // wait for the child process to exit.
+            int status;
+            auto child_pid = waitpid(pid, &status, 0);
+            DBG(cerr << __func__ << "-PARENT() - Child exited at this point,  status: " << status << endl);
+            CPPUNIT_ASSERT_MESSAGE("The child process should have exited.", child_pid == pid);
+            CPPUNIT_ASSERT_MESSAGE("The child process should exit with a status of SIGPIPE, was: " + to_string(status), status == SIGPIPE);
+
+
+            for (const char *name : glob_name) {
+                CPPUNIT_ASSERT_MESSAGE("The file " + string(name) + " should not be present.", !file_present(name));
+                DBG(cerr << __func__ << "-PARENT() - Temporary File: '" << name
+                         << "' was successfully removed. woot." << endl);
             }
 
             // Tidy up the shared memory business
             munmap(glob_name, name_size);
-
         }
         else {
             //child - register a signal handler
-            //register_sigpipe_handler();
-
             std::string tmp_file_name;
-            struct stat buf;
-            int statret;
             try {
-
                 // --------- File One ------------
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
                 bes::TempFile tf1;
                 tmp_file_name = tf1.create(TEMP_DIR, TEMP_FILE_PREFIX);
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
-                    << tf1.get_fd() << endl);
+                         << tf1.get_fd() << endl);
                 // copy the filename into shared memory.
                 tmp_file_name.copy(glob_name[0], tmp_file_name.size(), 0);
 
-                // Is it really there? Just sayin'...
-                statret = stat(tmp_file_name.c_str(), &buf);
-                CPPUNIT_ASSERT(statret == 0);
+                CPPUNIT_ASSERT_MESSAGE("The file " + tmp_file_name + " should be present.", file_present(tmp_file_name));
 
                 // --------- File Two ------------
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
                 bes::TempFile tf2;
                 tmp_file_name = tf2.create(TEMP_DIR, TEMP_FILE_PREFIX);
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
-                    << tf2.get_fd() << endl);
+                         << tf2.get_fd() << endl);
                 // copy the filename into shared memory.
                 tmp_file_name.copy(glob_name[1], tmp_file_name.size(), 0);
 
-                // Is it really there? Just sayin'...
-                statret = stat(tmp_file_name.c_str(), &buf);
-                CPPUNIT_ASSERT(statret == 0);
+                CPPUNIT_ASSERT_MESSAGE("The file " + tmp_file_name + " should be present.", file_present(tmp_file_name));
 
                 // --------- File Three ------------
                 DBG(cerr << __func__ << "-CHILD() - Creating temporary file." << endl);
                 bes::TempFile tf3;
                 tmp_file_name = tf3.create(TEMP_DIR, TEMP_FILE_PREFIX);
                 DBG(cerr << __func__ << "-CHILD() - Temp file is: '" << tmp_file_name << "' has been created. fd: "
-                    << tf3.get_fd() << endl);
+                         << tf3.get_fd() << endl);
                 // copy the filename into shared memory.
                 tmp_file_name.copy(glob_name[2], tmp_file_name.size(), 0);
 
-                // Is it really there? Just sayin'...
-                statret = stat(tmp_file_name.c_str(), &buf);
-                CPPUNIT_ASSERT(statret == 0);
+                CPPUNIT_ASSERT_MESSAGE("The file " + tmp_file_name + " should be present.", file_present(tmp_file_name));
 
                 // Wait for the signal
                 sleep(100);
                 DBG(cerr << __func__ << "-CHILD() - Client is Alive." << endl);
+                CPPUNIT_FAIL("The child process should have exited before this point.");
             }
             catch (BESInternalError &bie) {
                 DBG(cerr << __func__ << "-CHILD() - Caught BESInternalError  Message: " << bie.get_message() << endl);
                 CPPUNIT_ASSERT(false);
             }
+
             DBG(cerr << __func__ << "-CHILD() - Client is exiting normally." << endl);
-
+            CPPUNIT_FAIL("The child process should have exited before this point.");
         }
-
     }
 
-CPPUNIT_TEST_SUITE( TemporaryFileTest );
+CPPUNIT_TEST_SUITE(TemporaryFileTest);
 
-    CPPUNIT_TEST(normal_test);
-    CPPUNIT_TEST(multi_file_normal_test);
-    CPPUNIT_TEST(exception_test);
-    CPPUNIT_TEST(sigpipe_test);
-    CPPUNIT_TEST(multifile_sigpipe_test);
+        CPPUNIT_TEST(mk_temp_dir_normal);
+        CPPUNIT_TEST(mk_temp_dir_exists);
+        CPPUNIT_TEST(mk_temp_dir_not_allowed);
+
+        CPPUNIT_TEST(create_normal_test);
+        CPPUNIT_TEST(create_multi_file_normal_test);
+        CPPUNIT_TEST(create_multi_file_normal_test_2);
+        CPPUNIT_TEST(create_exception_test);
+
+        CPPUNIT_TEST(sigpipe_test);
+        CPPUNIT_TEST(multifile_sigpipe_test);
 
     CPPUNIT_TEST_SUITE_END();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TemporaryFileTest);
 
-int main(int argc, char*argv[])
-{
-    int option_char;
+} // namespace bes
+
+int main(int argc, char*argv[]) {
+    return bes_run_tests<bes::TemporaryFileTest>(argc, argv, "dDh") ? 0 : 1;
+}
+
+#if 0
+int option_char;
     while ((option_char = getopt(argc, argv, "dDh")) != -1)
         switch (option_char) {
         case 'd':
@@ -407,7 +432,7 @@ int main(int argc, char*argv[])
         case 'h': {     // help - show test names
             cerr << "Usage: TemporaryFileTest has the following tests:" << endl;
             const std::vector<Test*> &tests = TemporaryFileTest::suite()->getTests();
-            unsigned int prefix_len = TemporaryFileTest::suite()->getName().append("::").size();
+            unsigned int prefix_len = bes::TemporaryFileTest::suite()->getName().append("::").size();
             for (std::vector<Test*>::const_iterator i = tests.begin(), e = tests.end(); i != e; ++i) {
                 cerr << (*i)->getName().replace(0, prefix_len, "") << endl;
             }
@@ -441,3 +466,4 @@ int main(int argc, char*argv[])
 
     return wasSuccessful ? 0 : 1;
 }
+#endif

--- a/http/AllowedHosts.cc
+++ b/http/AllowedHosts.cc
@@ -54,6 +54,7 @@ using namespace std;
 namespace http {
 
 AllowedHosts *AllowedHosts::d_instance = nullptr;
+
 /**
  * Run once_flag for initializing the singleton instance.
  */
@@ -108,7 +109,6 @@ void AllowedHosts::delete_instance() {
  * @return True if the URL may be dereferenced, given the BES's configuration,
  * false otherwise.
  */
-
 bool AllowedHosts::is_allowed(shared_ptr<http::url> candidate_url) {
     string error_msg;
     return is_allowed(candidate_url, error_msg);
@@ -192,9 +192,6 @@ bool AllowedHosts::is_allowed(shared_ptr<http::url> candidate_url, std::string &
 
         isAllowed = candidate_url->is_trusted() || check(candidate_url->str());
 
-        //if (candidate_url->is_trusted()) {
-        //    INFO_LOG(prolog << "Candidate URL is marked trusted, allowing. url: " << candidate_url->str() <<  endl);
-        //}
         BESDEBUG(MODULE, prolog << "HTTP Access Allowed: " << (isAllowed ? "true " : "false ") << endl);
     }
     else {
@@ -206,8 +203,6 @@ bool AllowedHosts::is_allowed(shared_ptr<http::url> candidate_url, std::string &
     BESDEBUG(MODULE, prolog << "END Access Allowed: " << (isAllowed ? "true " : "false ") << endl);
     return isAllowed;
 }
-
-
 
 bool AllowedHosts::check(const std::string &url){
     bool isAllowed=false;

--- a/modules/common/run_tests_cppunit.h
+++ b/modules/common/run_tests_cppunit.h
@@ -78,6 +78,11 @@ void show_file(const std::string &filename)
 /**
  * @brief Run the test(s)
  *
+ * @note How to use this:
+ * int main(int argc, char*argv[]) {
+ *     return bes_run_tests<bes::TemporaryFileTest>(argc, argv, "dDh") ? 0 : 1;
+ * }
+ *
  * @tparam CLASS The CppUnit test class to run/test
  * @param argc The argc value passed to main
  * @param argv The command line parameters passed to main()

--- a/modules/dmrpp_module/tests/Makefile.am
+++ b/modules/dmrpp_module/tests/Makefile.am
@@ -58,6 +58,7 @@ check-local: atconfig atlocal $(TESTSUITE) $(TESTSUITE_S3) $(TESTSUITE_DMRPP_BUI
 		true;\
 	fi
 	@echo "# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
+	$(SHELL) '$(TESTSUITE_H4_DMRPP_BUILDER)' $(TESTSUITEFLAGS)
 
 clean-local:
 	test ! -f '$(TESTSUITE)' || $(SHELL) '$(TESTSUITE)' --clean

--- a/modules/dmrpp_module/tests/Makefile.am
+++ b/modules/dmrpp_module/tests/Makefile.am
@@ -58,7 +58,6 @@ check-local: atconfig atlocal $(TESTSUITE) $(TESTSUITE_S3) $(TESTSUITE_DMRPP_BUI
 		true;\
 	fi
 	@echo "# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
-	$(SHELL) '$(TESTSUITE_H4_DMRPP_BUILDER)' $(TESTSUITEFLAGS)
 
 clean-local:
 	test ! -f '$(TESTSUITE)' || $(SHELL) '$(TESTSUITE)' --clean

--- a/server/ServerApp.cc
+++ b/server/ServerApp.cc
@@ -218,7 +218,7 @@ static void catch_sig_term(int sig)
  */
 static void register_signal_handlers()
 {
-    struct sigaction act;
+    struct sigaction act{};
     sigemptyset(&act.sa_mask);
     sigaddset(&act.sa_mask, SIGCHLD);
     sigaddset(&act.sa_mask, SIGPIPE);


### PR DESCRIPTION
Refactor to remove use of unique_ptr as singleton.

Also includes more tests, but no change to functionality. 
Question: Should we include other signals besides SIGPIPE?