### PR TITLE
Fixing issues identified by asan

### DIFF
--- a/modules/dmrpp_module/Chunk.cc
+++ b/modules/dmrpp_module/Chunk.cc
@@ -803,14 +803,12 @@ void Chunk::filter_chunk(const string &filters, unsigned long long chunk_size, u
                 throw BESInternalError("fletcher32 filter: buffer size is less than the size of the checksum", __FILE__, __LINE__);
             }
 
-            auto f_chksum_ptr = get_rbuf() + get_rbuf_size() - FLETCHER32_CHECKSUM;
-
+            // Where is the checksum value?
+            auto data_ptr = get_rbuf() + get_rbuf_size() - FLETCHER32_CHECKSUM;
+            // Using a temporary variable ensures that the value is correctly positioned
+            // on a 4 byte memory alignment. Casting data_ptr to a pointer to uint_32 does not.
             uint32_t f_checksum;
-            auto ui32_ptr = &f_checksum;
-            auto c_ptr = (char *)ui32_ptr;
-            for(uint32_t i=0; i<FLETCHER32_CHECKSUM; i++){
-                c_ptr[i] = f_chksum_ptr[i];
-            }
+            memcpy(&f_checksum, data_ptr, FLETCHER32_CHECKSUM );
 
             // If the code should actually use the checksum (they can be expensive to compute), does it match
             // with once computed on the data actually read? Maybe make this a bes.conf parameter?

--- a/modules/dmrpp_module/Chunk.cc
+++ b/modules/dmrpp_module/Chunk.cc
@@ -803,7 +803,14 @@ void Chunk::filter_chunk(const string &filters, unsigned long long chunk_size, u
                 throw BESInternalError("fletcher32 filter: buffer size is less than the size of the checksum", __FILE__, __LINE__);
             }
 
-            auto f_checksum = *(uint32_t *)(get_rbuf() + get_rbuf_size() - FLETCHER32_CHECKSUM);
+            auto f_chksum_ptr = get_rbuf() + get_rbuf_size() - FLETCHER32_CHECKSUM;
+
+            uint32_t f_checksum;
+            auto ui32_ptr = &f_checksum;
+            auto c_ptr = (char *)ui32_ptr;
+            for(uint32_t i=0; i<FLETCHER32_CHECKSUM; i++){
+                c_ptr[i] = f_chksum_ptr[i];
+            }
 
             // If the code should actually use the checksum (they can be expensive to compute), does it match
             // with once computed on the data actually read? Maybe make this a bes.conf parameter?

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -2022,7 +2022,7 @@ void DmrppArray::read_contiguous_string()
     set_read_p(true);
 }
 
-string DmrppArray::ingest_fixed_length_string(char *buf, const unsigned long long fixed_str_len, string_pad_type pad_type)
+string DmrppArray::ingest_fixed_length_string(const char *buf, const unsigned long long fixed_str_len, string_pad_type pad_type)
 {
     string value;
     unsigned long long str_len = 0;

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -2022,7 +2022,7 @@ void DmrppArray::read_contiguous_string()
     set_read_p(true);
 }
 
-string DmrppArray::ingest_fixed_length_string(char *buf, unsigned long long fixed_str_len, string_pad_type pad_type)
+string DmrppArray::ingest_fixed_length_string(char *buf, const unsigned long long fixed_str_len, string_pad_type pad_type)
 {
     string value;
     unsigned long long str_len = 0;
@@ -2030,7 +2030,7 @@ string DmrppArray::ingest_fixed_length_string(char *buf, unsigned long long fixe
         case null_pad:
         case null_term:
         {
-            while(buf[str_len]!=0 && str_len < fixed_str_len){
+            while( str_len < fixed_str_len && buf[str_len]!=0 ){
                 str_len++;
             }
             BESDEBUG(MODULE, prolog << DmrppArray::pad_type_to_str(pad_type) << " scheme. str_len: " << str_len << endl);
@@ -2040,7 +2040,7 @@ string DmrppArray::ingest_fixed_length_string(char *buf, unsigned long long fixe
         case space_pad:
         {
             str_len = fixed_str_len;
-            while( (buf[str_len-1]==' ' || buf[str_len-1]==0) && str_len>0){
+            while(  str_len>0 && (buf[str_len-1]==' ' || buf[str_len-1]==0)){
                 str_len--;
             }
             BESDEBUG(MODULE, prolog << DmrppArray::pad_type_to_str(pad_type) << " scheme. str_len: " << str_len << endl);

--- a/modules/dmrpp_module/DmrppArray.h
+++ b/modules/dmrpp_module/DmrppArray.h
@@ -225,7 +225,7 @@ public:
     void get_ons_objs(vector<ons> &ons_list);
 
     static std::string pad_type_to_str(string_pad_type pad_type);
-    static string ingest_fixed_length_string(char *buf, unsigned long long fixed_str_len, string_pad_type pad_type);
+    static string ingest_fixed_length_string(const char *buf, unsigned long long fixed_str_len, string_pad_type pad_type);
 
 
     unsigned int buf2val(void **val) override;

--- a/modules/dmrpp_module/DmrppStr.cc
+++ b/modules/dmrpp_module/DmrppStr.cc
@@ -79,7 +79,7 @@ DmrppStr::read()
     unsigned long long str_len=0;
     bool done = false;
     while(!done){
-        done = (data[str_len] == 0) || (str_len >= chunk_size);
+        done = (str_len >= chunk_size) || (data[str_len] == 0);
         if(!done) str_len++;
     }
     string value(data,str_len);

--- a/modules/dmrpp_module/check_dmrpp.cc
+++ b/modules/dmrpp_module/check_dmrpp.cc
@@ -536,7 +536,7 @@ cerr<<"group name  is "<<gn <<endl;
 
     // Both the group path for this var and the group lines are sorted.
     // group path is from backward. So we match the group line backward.
-    int gl_index = gs_line_nums.size();
+    int gl_index = gs_line_nums.size() - 1; // gl_index should start with size-1 since we count backwards to zero
 
     for (const auto & gpl:grp_path_lines) {
 

--- a/modules/dmrpp_module/merge_dmrpp.cc
+++ b/modules/dmrpp_module/merge_dmrpp.cc
@@ -1315,7 +1315,7 @@ cerr<<"group name  is "<<gn <<endl;
 
     // Both the group path for this var and the group lines are sorted.
     // group path is from backward. So we match the group line backward.
-    int gl_index = gs_line_nums.size();
+    int gl_index = gs_line_nums.size() - 1; // An gl_index starts at size-1
 
     for (const auto &gpl:grp_path_lines) {
 


### PR DESCRIPTION
Problems discovered by ASAN in the dmrpp_module are remedied here. These changes alleviate several ASAN problems:

1.  Heap overflow issues in DmrppArray and DmrppStr caused by the order of evaluation in loop conditions used to read string values.
2. Variable alignment problems in the retrieval of the Chunk checksum from the data stream. In this case the casting of the computed point location:
`            auto f_checksum = *(uint32_t *)(get_rbuf() + get_rbuf_size() - FLETCHER32_CHECKSUM);`
Was attempting to assign `f_checksum` to a value that did not start on a 4 byte boundary. 
My patch uses a temporary stack variable and memcpy to get the checksum value into it. This produces the correct result and resolves the ASAN error. 
3. Heap overflow problems in `build_dmrpp_util.cc` that I fixed by normalizing the way the code declares and initializes `vector<>` objects.
4. Indexing issues caused by setting the initial value of a count-down index to the size() of a vector and not to size()-1 in `merge_dmrpp.cc` and `check_dmrpp.cc`
 