### PR TITLE
Added a macro to streamline BESStopWatch use.

### DIFF
--- a/dispatch/BESStopWatch.h
+++ b/dispatch/BESStopWatch.h
@@ -59,7 +59,7 @@ if (BESISDEBUG((module)) || BESISDEBUG(TIMING_LOG_KEY) || BESLog::TheLog()->is_v
     besTimer.start((x)); \
 } while(false)
 #else
-#define BES_STOPWATCH_START(x)
+#define BES_STOPWATCH_START(module, x)
 #endif
 
 class BESStopWatch;

--- a/dispatch/BESStopWatch.h
+++ b/dispatch/BESStopWatch.h
@@ -46,6 +46,22 @@
 static const std::string TIMING_LOG_KEY = "timing";
 static const std::string MISSING_LOG_PARAM;
 
+// This macro is used to start a timer if any of the BESDebug flags it tests are set.
+// The advantage of this macro is that it drops to zero code when NDEBUG is defined.
+// Our code often uses a macro that leaves the BESStopWatch object definition in the
+// code when NDEBUG is defined. This is not a problem, but it does make the code a bit
+// slower. jhrg 5/17/24
+#ifndef NDEBUG
+#define BES_STOPWATCH_START(module, x) \
+do { \
+BESStopWatch besTimer; \
+if (BESISDEBUG((module)) || BESISDEBUG(TIMING_LOG_KEY) || BESLog::TheLog()->is_verbose()) \
+    besTimer.start((x)); \
+} while(false)
+#else
+#define BES_STOPWATCH_START(x)
+#endif
+
 class BESStopWatch;
 
 namespace bes_timing {


### PR DESCRIPTION
Added a macro to start a timer if any of a set of BESDebug flags it tests are set.
The advantage of this macro is that it drops to zero code when NDEBUG is defined.
Our code often uses a macro that leaves the BESStopWatch object definition in the 
code when NDEBUG is defined. This is not a problem, but it does make the code a bit
slower. 