### PR TITLE
Fixed overflow error 

### DIFF
--- a/modules/debug_functions/DebugFunctions.cc
+++ b/modules/debug_functions/DebugFunctions.cc
@@ -290,10 +290,10 @@ void sum_until_ssf(int argc, libdap::BaseType * argv[], libdap::DDS &, libdap::B
     double start_time = (tv.tv_sec) * 1000 + (tv.tv_usec) / 1000; // convert tv_sec & tv_usec to millisecond
     double end_time = start_time;
 
-    long fib;
-    long one_past = 1;
-    long two_past = 0;
-    long n = 1;
+    uint64_t fib;
+    uint64_t one_past = 1;
+    uint64_t two_past = 0;
+    uint64_t n = 1;
 
     bool done = false;
     while (!done) {

--- a/modules/functions/tests/bescmd/make_array_7.dods.bescmd
+++ b/modules/functions/tests/bescmd/make_array_7.dods.bescmd
@@ -10,7 +10,8 @@
   <bes:define name="d1" space="default">
     <bes:container name="catalogContainer">
       <!-- y = mx + b -->
-        <bes:constraint>make_array(String,"[1]","1.0"),make_array(String,"[2][3]","1.0",test,"test and set","2.0",TEST,"TEST and SET"),make_array(Url,"[2]","http://opendap.org","http::/google.com")</bes:constraint>
+      <!--bes:constraint>make_array(String,"[1]","1.0"),make_array(String,"[2][3]","1.0",test,"test and set","2.0",TEST,"TEST and SET"),make_array(Url,"[2]","http://opendap.org","http::/google.com")</bes:constraint -->
+      <bes:constraint>make_array(Url,"[2]","http://opendap.org","http::/google.com")</bes:constraint>
     </bes:container>
   </bes:define>
   

--- a/modules/functions/tests/bescmd/make_array_7.dods.bescmd
+++ b/modules/functions/tests/bescmd/make_array_7.dods.bescmd
@@ -10,8 +10,7 @@
   <bes:define name="d1" space="default">
     <bes:container name="catalogContainer">
       <!-- y = mx + b -->
-      <!--bes:constraint>make_array(String,"[1]","1.0"),make_array(String,"[2][3]","1.0",test,"test and set","2.0",TEST,"TEST and SET"),make_array(Url,"[2]","http://opendap.org","http::/google.com")</bes:constraint -->
-      <bes:constraint>make_array(Url,"[2]","http://opendap.org","http::/google.com")</bes:constraint>
+        <bes:constraint>make_array(String,"[1]","1.0"),make_array(String,"[2][3]","1.0",test,"test and set","2.0",TEST,"TEST and SET"),make_array(Url,"[2]","http://opendap.org","http::/google.com")</bes:constraint>
     </bes:container>
   </bes:define>
   


### PR DESCRIPTION
The `sum_until()` ssf was rolling internal counter. Fixed (for now) by making them `uint64_t` 