### PR TITLE
This fixes HYRAX-1426: the spurious PPTConnection error messages.

### DIFF
--- a/ppt/Connection.h
+++ b/ppt/Connection.h
@@ -42,22 +42,17 @@
 
 class Connection: public BESObj {
 protected:
-	Socket *_mySock;
-	std::ostream *_out;
-	bool _brokenPipe;
+	Socket *_mySock = nullptr;
+	std::ostream *_out = nullptr;
+	bool _brokenPipe = false;
 
-	Connection() :
-			_mySock(0), _out(0), _brokenPipe(false)
-	{
-	}
+	Connection() = default;
 
 	virtual void send(const std::string &buffer) = 0;
 	virtual void sendChunk(const std::string &buffer, std::map<std::string, std::string> &extensions) = 0;
 
 public:
-	virtual ~Connection()
-	{
-	}
+	virtual ~Connection() = default;
 
 	virtual void initConnection() = 0;
 	virtual void closeConnection() = 0;

--- a/ppt/Connection.h
+++ b/ppt/Connection.h
@@ -52,7 +52,7 @@ protected:
 	virtual void sendChunk(const std::string &buffer, std::map<std::string, std::string> &extensions) = 0;
 
 public:
-	virtual ~Connection() = default;
+	~Connection() override = default;
 
 	virtual void initConnection() = 0;
 	virtual void closeConnection() = 0;
@@ -62,7 +62,7 @@ public:
 	virtual void send(const std::string &buffer, std::map<std::string, std::string> &extensions) = 0;
 	virtual void sendExtensions(std::map<std::string, std::string> &extensions) = 0;
 	virtual void sendExit() = 0;
-	virtual bool receive(std::map<std::string, std::string> &extensions, std::ostream *strm = 0) = 0;
+	virtual bool receive(std::map<std::string, std::string> &extensions, std::ostream *strm = nullptr) = 0;
 
 	virtual Socket * getSocket()
 	{
@@ -92,7 +92,7 @@ public:
 	virtual unsigned int getRecvChunkSize() = 0;
 	virtual unsigned int getSendChunkSize() = 0;
 
-	virtual void dump(std::ostream &strm) const;
+	void dump(std::ostream &strm) const override;
 };
 
 #endif // Connection_h

--- a/ppt/PPTConnection.cc
+++ b/ppt/PPTConnection.cc
@@ -191,13 +191,6 @@ void PPTConnection::send(const string &buffer)
 {
 	BESDEBUG(MODULE, prolog << "Sending " << buffer << endl);
 	_mySock->send(buffer, 0, buffer.size());
-
-#if 0
-	// was calling fsync() which is not defined for sockets. There might be some
-	// 'sync' operation needed in the future, but for now this is an empty call. removed
-	// jhrg 5/5/11
-	_mySock->sync();
-#endif
 }
 
 /** @brief read a buffer of data from the socket
@@ -273,8 +266,18 @@ bool PPTConnection::receive(map<string, string> &extensions, ostream *strm)
 	// if x then extensions follow, if d then data follows.
 	int bytesRead = readChunkHeader(_inBuff, 8);
 	BESDEBUG( MODULE, prolog << "Reading header, read " << bytesRead << " bytes" << endl );
-	if (bytesRead != 8)
-		throw BESInternalError(prolog + "Failed to read chunk header", __FILE__, __LINE__);
+    if (bytesRead == 0) {
+        INFO_LOG("PPTConnection::receive: read EOF from the OLFS, beslistener exiting.");
+        // Since this is the exit condition, set extensions["status"] so that it's value is PPT_EXIT_NOW.
+        // See BESServerHandler::execute(Connection *connection) and note that Connection::exit()
+        // returns a string value (!). It does not do what unix exit() does! This is how the server
+        // knows to exit. jhrg 5/30/24
+        extensions["status"] = PPT_EXIT_NOW;
+        return true;
+    }
+    else if (bytesRead != 8) {
+        throw BESInternalError(prolog + "Failed to read chunk header", __FILE__, __LINE__);
+    }
 
 	char lenbuffer[8];
 	lenbuffer[0] = _inBuff[0];
@@ -424,14 +427,8 @@ int PPTConnection::readBufferNonBlocking(char *inBuff, const /* unsigned*/int bu
     arr[0].fd = getSocket()->getSocketDescriptor();
     arr[0].events = POLLIN;
     arr[0].revents = 0;
-#if 0
-    struct pollfd p = {};
-    p.fd = getSocket()->getSocketDescriptor();
-    p.events = POLLIN;
-    struct pollfd arr[1];
-    arr[0] = p;
-#endif
-	// Lets loop _timeout times with a delay block on poll of 1000 milliseconds
+
+	// Let's loop _timeout times with a delay block on poll of 1000 milliseconds
 	// and see if there are any data.
 	for (int j = 0; j < _timeout; j++) {
 		if (poll(arr, 1, 1000) < 0) {

--- a/ppt/PPTConnection.cc
+++ b/ppt/PPTConnection.cc
@@ -268,7 +268,7 @@ bool PPTConnection::receive(map<string, string> &extensions, ostream *strm)
 	int bytesRead = readChunkHeader(_inBuff, 8);
 	BESDEBUG( MODULE, prolog << "Reading header, read " << bytesRead << " bytes" << endl );
     if (bytesRead == 0) {
-        INFO_LOG("PPTConnection::receive: read EOF from the OLFS, beslistener exiting.");
+        INFO_LOG("PPTConnection::receive: read EOF from the OLFS, beslistener exiting.\n");
         // Since this is the exit condition, set extensions["status"] so that it's value is PPT_EXIT_NOW.
         // See BESServerHandler::execute(Connection *connection) and note that Connection::exit()
         // returns a string value (!). It does not do what unix exit() does! This is how the server

--- a/ppt/PPTConnection.cc
+++ b/ppt/PPTConnection.cc
@@ -69,7 +69,6 @@ PPTConnection::~PPTConnection()
 {
 	if (_inBuff) {
 		delete[] _inBuff;
-		_inBuff = 0;
 	}
 }
 

--- a/ppt/PPTConnection.cc
+++ b/ppt/PPTConnection.cc
@@ -44,6 +44,7 @@
 #include "PPTConnection.h"
 #include "PPTProtocolNames.h"
 #include "Socket.h"
+#include "BESLog.h"
 #include "BESDebug.h"
 #include "BESInternalError.h"
 
@@ -272,6 +273,8 @@ bool PPTConnection::receive(map<string, string> &extensions, ostream *strm)
         // See BESServerHandler::execute(Connection *connection) and note that Connection::exit()
         // returns a string value (!). It does not do what unix exit() does! This is how the server
         // knows to exit. jhrg 5/30/24
+        // Note that when this child listener exits, it will use exit code '6' and that will be picked up
+        // by the master listener. That will show up in the bes.log. jhrg 5/30/24
         extensions["status"] = PPT_EXIT_NOW;
         return true;
     }

--- a/ppt/PPTConnection.h
+++ b/ppt/PPTConnection.h
@@ -42,24 +42,19 @@ class Socket;
 
 class PPTConnection: public Connection {
 private:
-	int _timeout;
-	char * _inBuff;
-	int _inBuff_len;
-#if 0
-	int _bytesRead;
-#endif
+	int _timeout = 0;
+	char * _inBuff = nullptr;
+	int _inBuff_len = 0;
 
-	PPTConnection() : _timeout(0), _inBuff(0), _inBuff_len(0) //, _bytesRead(0)
-	{
-	}
+	PPTConnection() = default;
 
 	virtual int readChunkHeader(char *inBuff,
-	/*unsigned*/int buff_size);
+	int buff_size);
 	virtual void sendChunk(const std::string &buffer, std::map<std::string, std::string> &extensions);
-	virtual void receive(std::ostream &strm, const /*unsigned*/int len);
+	virtual void receive(std::ostream &strm, const int len);
 
 protected:
-	PPTConnection(int timeout) : _timeout(timeout), _inBuff(0), _inBuff_len(0) //, _bytesRead(0)
+	PPTConnection(int timeout) : _timeout(timeout)
 	{
 	}
 

--- a/ppt/PPTConnection.h
+++ b/ppt/PPTConnection.h
@@ -48,42 +48,39 @@ private:
 
 	PPTConnection() = default;
 
-	virtual int readChunkHeader(char *inBuff,
-	int buff_size);
-	virtual void sendChunk(const std::string &buffer, std::map<std::string, std::string> &extensions);
+	virtual int readChunkHeader(char *inBuff, int buff_size);
+	virtual void sendChunk(const std::string &buffer, std::map<std::string, std::string> &extensions) override;
 	virtual void receive(std::ostream &strm, const int len);
 
 protected:
-	PPTConnection(int timeout) : _timeout(timeout)
-	{
-	}
+	explicit PPTConnection(int timeout) : _timeout(timeout) { }
 
 	virtual int readBuffer(char *inBuff, const unsigned int buff_size);
-	virtual int readBufferNonBlocking(char *inBuff, const /*unsigned*/int buff_size);
+	virtual int readBufferNonBlocking(char *inBuff, const int buff_size);
 
-	virtual void send(const std::string &buffer);
+	virtual void send(const std::string &buffer) override;
 	virtual void read_extensions(std::map<std::string, std::string> &extensions, const std::string &xstr);
 
 public:
-	virtual ~PPTConnection();
+	~PPTConnection() override;
 
-	virtual void initConnection() = 0;
-	virtual void closeConnection() = 0;
+	virtual void initConnection() override = 0;
+	virtual void closeConnection() override = 0;
 
-	virtual std::string exit()
+	std::string exit() override
 	{
 		return PPT_EXIT_NOW;
 	}
 
-	virtual void send(const std::string &buffer, std::map<std::string, std::string> &extensions);
-	virtual void sendExtensions(std::map<std::string, std::string> &extensions);
-	virtual void sendExit();
-	virtual bool receive(std::map<std::string, std::string> &extensions, std::ostream *strm = 0);
+	void send(const std::string &buffer, std::map<std::string, std::string> &extensions) override;
+	void sendExtensions(std::map<std::string, std::string> &extensions) override;
+	void sendExit() override;
+	bool receive(std::map<std::string, std::string> &extensions, std::ostream *strm = nullptr) override;
 
-	virtual unsigned int getRecvChunkSize();
-	virtual unsigned int getSendChunkSize();
+	virtual unsigned int getRecvChunkSize() override;
+	virtual unsigned int getSendChunkSize() override;
 
-	virtual void dump(std::ostream &strm) const;
+	void dump(std::ostream &strm) const override;
 };
 
 #endif // PPTConnection_h

--- a/ppt/PPTConnection.h
+++ b/ppt/PPTConnection.h
@@ -49,7 +49,7 @@ private:
 	PPTConnection() = default;
 
 	virtual int readChunkHeader(char *inBuff, int buff_size);
-	virtual void sendChunk(const std::string &buffer, std::map<std::string, std::string> &extensions) override;
+	void sendChunk(const std::string &buffer, std::map<std::string, std::string> &extensions) override;
 	virtual void receive(std::ostream &strm, const int len);
 
 protected:
@@ -58,14 +58,14 @@ protected:
 	virtual int readBuffer(char *inBuff, const unsigned int buff_size);
 	virtual int readBufferNonBlocking(char *inBuff, const int buff_size);
 
-	virtual void send(const std::string &buffer) override;
+	void send(const std::string &buffer) override;
 	virtual void read_extensions(std::map<std::string, std::string> &extensions, const std::string &xstr);
 
 public:
 	~PPTConnection() override;
 
-	virtual void initConnection() override = 0;
-	virtual void closeConnection() override = 0;
+	void initConnection() override = 0;
+	void closeConnection() override = 0;
 
 	std::string exit() override
 	{
@@ -77,8 +77,8 @@ public:
 	void sendExit() override;
 	bool receive(std::map<std::string, std::string> &extensions, std::ostream *strm = nullptr) override;
 
-	virtual unsigned int getRecvChunkSize() override;
-	virtual unsigned int getSendChunkSize() override;
+	unsigned int getRecvChunkSize() override;
+	unsigned int getSendChunkSize() override;
 
 	void dump(std::ostream &strm) const override;
 };

--- a/ppt/PPTServer.cc
+++ b/ppt/PPTServer.cc
@@ -89,12 +89,6 @@ PPTServer::PPTServer(ServerHandler *handler, SocketListener *listener, bool isSe
 	}
 }
 
-#if 0
-PPTServer::~PPTServer()
-{
-}
-#endif
-
 void PPTServer::get_secure_files()
 {
 	bool found = false;
@@ -177,7 +171,7 @@ int PPTServer::welcomeClient()
 	const unsigned int ppt_buffer_size = 64;
 	char inBuff[ppt_buffer_size + 1];
 
-	// Doing a non blocking read in case the connection is being initiated
+	// Doing a non-blocking read in case the connection is being initiated
 	// by a non-bes client. Don't want this to block. pcw - 3/5/07
 	// int bytesRead = _mySock->receive( inBuff, ppt_buffer_size ) ;
 	//

--- a/ppt/Socket.h
+++ b/ppt/Socket.h
@@ -73,11 +73,7 @@ public:
 	virtual void close();
 	virtual void send(const std::string &str, int start, int end);
 	virtual int receive(char *inBuff, const int inSize);
-#if 0
-	// sync() was calling fsync() which is not defined for a socket.
-	// jhrg 5/5/11
-	virtual void sync();
-#endif
+
 	virtual int getSocketDescriptor()
 	{
 		return _socket;

--- a/ppt/UnixSocket.cc
+++ b/ppt/UnixSocket.cc
@@ -210,24 +210,10 @@ void UnixSocket::close()
 {
     Socket::close();
     if (_tempSocket != "") {
-#if 0
-	// This is flaggeed as a 'Time of check, time of use' error by
-	// coverity. I think the test to see if the file exists is not
-	// needed since the code ignores the error return by remove.
-	// jhrg 10/23/15
-        if (!access(_tempSocket.c_str(), F_OK)) {
-            (void) remove(_tempSocket.c_str());
-        }
-#endif
 	(void) remove(_tempSocket.c_str());
         _connected = false;
     }
     if (_listening && _unixSocket != "") {
-#if 0
-        if (!access(_unixSocket.c_str(), F_OK)) {
-            (void) remove(_unixSocket.c_str());
-        }
-#endif
 	(void) remove(_unixSocket.c_str());
         _listening = false;
     }

--- a/server/ServerApp.cc
+++ b/server/ServerApp.cc
@@ -524,32 +524,14 @@ int ServerApp::run()
 
             if (sighup) {
                 BESDEBUG("ppt2", "Master listener caught SIGHUP, exiting with SERVER_EXIT_RESTART" << endl);
-
                 INFO_LOG("Master listener caught SIGHUP, exiting with SERVER_EXIT_RESTART" << endl);
-
-#if 0
-                d_ppt_server->closeConnection();
-                close(BESLISTENER_PIPE_FD);
-#endif
                 return SERVER_EXIT_RESTART;
-#if 0
-                ::exit(SERVER_EXIT_RESTART);
-#endif
             }
 
             if (sigterm) {
                 BESDEBUG("ppt2", "Master listener caught SIGTERM, exiting with SERVER_NORMAL_SHUTDOWN" << endl);
-
                 INFO_LOG("Master listener caught SIGTERM, exiting with SERVER_NORMAL_SHUTDOWN" << endl);
-
-#if 0
-                d_ppt_server->closeConnection();
-                close(BESLISTENER_PIPE_FD);
-#endif
                 return SERVER_EXIT_NORMAL_SHUTDOWN;
-#if 0
-                ::exit(SERVER_EXIT_NORMAL_SHUTDOWN);
-#endif
             }
 
             sigchild = 0;   // Only reset this signal, all others cause an exit/restart
@@ -562,35 +544,17 @@ int ServerApp::run()
             // This call blocks, using select(), until a client asks for another beslistener.
             d_ppt_server->initConnection();
         }
-#if 0
-        d_ppt_server->closeConnection();
-#endif
     }
     catch (BESError &se) {
         BESDEBUG("beslistener", "beslistener: caught BESError (" << se.get_message() << ")" << endl);
 
         ERROR_LOG(se.get_message() << endl);
-#if 0
-        int status = SERVER_EXIT_FATAL_CANNOT_START;
-        write(MASTER_TO_DAEMON_PIPE_FD, &status, sizeof(status));
-        close(MASTER_TO_DAEMON_PIPE_FD);
-#endif
         return SERVER_EXIT_FATAL_CANNOT_START;
     }
     catch (...) {
         ERROR_LOG("caught unknown exception initializing sockets" << endl);
-#if 0
-        int status = SERVER_EXIT_FATAL_CANNOT_START;
-        write(MASTER_TO_DAEMON_PIPE_FD, &status, sizeof(status));
-        close(MASTER_TO_DAEMON_PIPE_FD);
-#endif
         return SERVER_EXIT_FATAL_CANNOT_START;
     }
-
-#if 0
-    close(BESLISTENER_PIPE_FD);
-    return 0;
-#endif
 }
 
 // The BESApp::main() method will call terminate() with the return value of


### PR DESCRIPTION
These messages happen because the olfs no longer sends an 'exit' message to the BES. Instead the OLFS just closes the socket. The PPTConnection code detects this as a read of zero bytes.