### PR TITLE
Improved print_compact_element and print_missing_data_element

### DIFF
--- a/modules/dmrpp_module/DmrppCommon.cc
+++ b/modules/dmrpp_module/DmrppCommon.cc
@@ -564,34 +564,50 @@ DmrppCommon::print_chunks_element(XMLWriter &xml, const string &name_space)
 
 /**
  * @brief Print the Compact base64-encoded information.
+ * @see https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-xmlwriter.html#xmlTextWriterWriteElementNS
  */
 void
-DmrppCommon::print_compact_element(XMLWriter &xml, const string &name_space, const std::string &encoded)
+DmrppCommon::print_compact_element(XMLWriter &xml, const string &name_space, const std::string &encoded) const
 {
-    // Write element "compact" with dmrpp namespace:
-    ostringstream oss;
-    copy(encoded.begin(), encoded.end(), ostream_iterator<char>(oss, ""));
-    string sizes = oss.str();
-
     if (xmlTextWriterWriteElementNS(xml.get_writer(), (const xmlChar *) name_space.c_str(),
                                     (const xmlChar *) "compact", NULL,
-                                    (const xmlChar *) sizes.c_str()) < 0)
+                                    (const xmlChar *) encoded.c_str()) < 0)
         throw BESInternalError("Could not write compact element.", __FILE__, __LINE__);
 }
 
 void
 DmrppCommon::print_missing_data_element(const XMLWriter &xml, const string &name_space, const std::string &encoded) const
 {
-    // Write element "missing_data" with dmrpp namespace:
-    ostringstream oss;
-    copy(encoded.begin(), encoded.end(), ostream_iterator<char>(oss, ""));
-    string sizes = oss.str();
 
     if (xmlTextWriterWriteElementNS(xml.get_writer(), (const xmlChar *) name_space.c_str(),
                                     (const xmlChar *) "missingdata", nullptr,
-                                    (const xmlChar *) sizes.c_str()) < 0)
+                                    (const xmlChar *) encoded.c_str()) < 0)
         throw BESInternalError("Could not write missingdata element.", __FILE__, __LINE__);
 }
+
+/**
+ * @brief Print the DMR++ missing data XML element
+ * @param xml
+ * @param name_space
+ * @param data
+ * @param length
+ */
+void
+DmrppCommon::print_missing_data_element(const XMLWriter &xml, const string &name_space, const char *data, int length) const
+{
+
+    if (xmlTextWriterStartElementNS(xml.get_writer(), (const xmlChar *) name_space.c_str(),
+                                    (const xmlChar *) "missingdata", nullptr) < 0)
+        throw BESInternalError("Could not start missingdata element.", __FILE__, __LINE__);
+
+    if (xmlTextWriterWriteBase64(xml.get_writer(), data, 0, length) < 0)
+        throw BESInternalError("Could not write the base 64 data for the  missingdata element.", __FILE__, __LINE__);
+
+    if (xmlTextWriterEndElement(xml.get_writer()) < 0)
+        throw BESInternalError("Could not end missingdata element.", __FILE__, __LINE__);
+}
+
+
 /**
  * @brief Print the DMR++ response for the Scalar types
  *

--- a/modules/dmrpp_module/DmrppCommon.h
+++ b/modules/dmrpp_module/DmrppCommon.h
@@ -280,8 +280,9 @@ public:
 
     void print_chunks_element(libdap::XMLWriter &xml, const std::string &name_space = "");
 
-    void print_compact_element(libdap::XMLWriter &xml, const std::string &name_space = "", const std::string &encoded = "");
+    void print_compact_element(libdap::XMLWriter &xml, const std::string &name_space = "", const std::string &encoded = "") const;
     void print_missing_data_element(const libdap::XMLWriter &xml, const std::string &name_space = "", const std::string &encoded = "") const;
+    void print_missing_data_element(const libdap::XMLWriter &xml, const std::string &name_space, const char *data, int length) const;
 
     void print_dmrpp(libdap::XMLWriter &writer, bool constrained = false);
 


### PR DESCRIPTION
Improved print_compact_element and print_missing_data_element

Also added new print_missing_data_element() that takes raw data and performs the base64 encoding itself.

I added tests for all three methods.