### PR TITLE
Hyrax 1454

### DIFF
--- a/modules/dmrpp_module/Chunk.cc
+++ b/modules/dmrpp_module/Chunk.cc
@@ -965,6 +965,10 @@ void Chunk::load_fill_values() {
         is_big_endian = true;
     const char *value = get_value_ptr(fv, d_fill_value_type, d_fill_value,is_big_endian);
 
+    if(d_fill_value_type == libdap::dods_str_c && d_fill_value==""){
+        d_fill_value = ' ';
+        value_size = 1;
+    }
     unsigned long long num_values = get_rbuf_size() / value_size;
 
     char *buffer = get_rbuf();

--- a/modules/dmrpp_module/Chunk.cc
+++ b/modules/dmrpp_module/Chunk.cc
@@ -965,10 +965,14 @@ void Chunk::load_fill_values() {
         is_big_endian = true;
     const char *value = get_value_ptr(fv, d_fill_value_type, d_fill_value,is_big_endian);
 
+    // If a string is empty, current build_dmrpp will assign an "" to fillvalue and causes the value size to be 0.
     if(d_fill_value_type == libdap::dods_str_c && d_fill_value==""){
         d_fill_value = ' ';
         value_size = 1;
     }
+
+    if (value_size == 0) 
+       throw BESInternalError("The size of fill value should NOT be 0.", __FILE__,__LINE__);
     unsigned long long num_values = get_rbuf_size() / value_size;
 
     char *buffer = get_rbuf();

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -1040,6 +1040,7 @@ void DmrppArray::read_contiguous()
             throw;
         }
     }
+    BESDEBUG(dmrpp_3, prolog << "Before is_filter " << endl);
 
     // Now that the_one_chunk has been read, we do what is necessary...
     if (!is_filters_empty() && !get_one_chunk_fill_value()) {
@@ -1097,6 +1098,8 @@ void DmrppArray::read_contiguous()
     }
 
     set_read_p(true);
+
+    BESDEBUG(dmrpp_3, prolog << " NOT using direct IO : end of this method." << endl);
 }
 
 void DmrppArray::read_one_chunk_dio() {


### PR DESCRIPTION
Fix the issue caused by an chunked and compressed empty string array. Test the 3 SMAP Level 4 files that encounter the issue. The fileout netCDF can successfully generate the expected netCDF-4 files.