### PR TITLE
Add creation date to build_dmrpp metadata

### DIFF
--- a/modules/dmrpp_module/build_dmrpp_h4/build_dmrpp_util_h4.cc
+++ b/modules/dmrpp_module/build_dmrpp_h4/build_dmrpp_util_h4.cc
@@ -1436,7 +1436,10 @@ void build_dmrpp_from_dmr_file(const string &dmrpp_href_value, const string &dmr
 
 #if 0
     if (add_production_metadata) {
-        inject_version_and_configuration(argc, argv, bes_conf_file_used_to_create_dmr, &dmrpp);
+        // I updated this function call to reflect the changes I made to the build_dmrpp_utl.cc
+        // I see that it is not currently in service but it's clear that something like this
+        // will be needed to establish history/provenance of the dmr++ file. - ndp 07/26/24
+        inject_build_dmrpp_metadata(argc, argv, bes_conf_file_used_to_create_dmr, &dmrpp);
     }
 #endif
 

--- a/modules/dmrpp_module/build_dmrpp_h4/build_dmrpp_util_h4.cc
+++ b/modules/dmrpp_module/build_dmrpp_h4/build_dmrpp_util_h4.cc
@@ -1436,7 +1436,7 @@ void build_dmrpp_from_dmr_file(const string &dmrpp_href_value, const string &dmr
 
 #if 0
     if (add_production_metadata) {
-        // I updated this function call to reflect the changes I made to the build_dmrpp_utl.cc
+        // I updated this function call to reflect the changes I made to the build_dmrpp_util.cc
         // I see that it is not currently in service but it's clear that something like this
         // will be needed to establish history/provenance of the dmr++ file. - ndp 07/26/24
         inject_build_dmrpp_metadata(argc, argv, bes_conf_file_used_to_create_dmr, &dmrpp);

--- a/modules/dmrpp_module/build_dmrpp_util.cc
+++ b/modules/dmrpp_module/build_dmrpp_util.cc
@@ -1867,6 +1867,26 @@ static string recreate_cmdln_from_args(int argc, char *argv[])
     return ss.str();
 }
 
+/**
+ * @brief Returns an ISO-8601 date time string for the time at which this function is called.
+ * @return An ISO-8601 date time string
+ */
+std::string get_time_str_now(){
+    // Get current time as a time_point
+    auto now = std::chrono::system_clock::now();
+
+    // Convert to system time (time_t)
+    auto time_t_now = std::chrono::system_clock::to_time_t(now);
+
+    // Convert to tm structure (GMT time)
+    std::tm* gmt_time = std::gmtime(&time_t_now);
+
+    // Format the time using a stringstream
+    std::stringstream ss;
+    ss << std::put_time(gmt_time, "%Y-%m-%dT%H:%M:%S");
+
+    return ss.str();
+}
 
 /**
  * @brief This worker method provides a SSOT for how the version and configuration information are added to the DMR++
@@ -1882,6 +1902,10 @@ void inject_version_and_configuration_worker( DMRpp *dmrpp, const string &bes_co
 
     // Build the version attributes for the DMR++
     auto version = new D4Attribute("build_dmrpp_metadata", StringToD4AttributeType("container"));
+
+    auto creation_date = new D4Attribute("creation_date", StringToD4AttributeType("string"));
+    creation_date->add_value(get_time_str_now());
+    version->attributes()->add_attribute_nocopy(creation_date);
 
     auto build_dmrpp_version = new D4Attribute("build_dmrpp", StringToD4AttributeType("string"));
     build_dmrpp_version->add_value(CVER);

--- a/modules/dmrpp_module/build_dmrpp_util.cc
+++ b/modules/dmrpp_module/build_dmrpp_util.cc
@@ -1870,9 +1870,10 @@ static string recreate_cmdln_from_args(int argc, char *argv[])
 
 /**
  * @brief Returns an ISO-8601 date time string for the time at which this function is called.
+ * Tip-o-the-hat to Morris Day and The Time...
  * @return An ISO-8601 date time string
  */
-std::string get_time_str_now(){
+std::string what_time_is_it(){
     // Get current time as a time_point
     auto now = std::chrono::system_clock::now();
 
@@ -1905,7 +1906,7 @@ void inject_build_dmrpp_metadata_worker( DMRpp *dmrpp, const string &bes_conf_do
     auto version = new D4Attribute("build_dmrpp_metadata", StringToD4AttributeType("container"));
 
     auto creation_date = new D4Attribute("created", StringToD4AttributeType("string"));
-    creation_date->add_value(get_time_str_now());
+    creation_date->add_value(what_time_is_it());
     version->attributes()->add_attribute_nocopy(creation_date);
 
     auto build_dmrpp_version = new D4Attribute("build_dmrpp", StringToD4AttributeType("string"));

--- a/modules/dmrpp_module/build_dmrpp_util.cc
+++ b/modules/dmrpp_module/build_dmrpp_util.cc
@@ -1893,7 +1893,7 @@ std::string what_time_is_it(){
 }
 
 /**
- * @brief This worker method provides a SSOT for how the version and configuration information are added to the DMR++
+ * @brief This worker method provides a SSOT for how the build_dmrpp metadata (creation time, version, and configuration information) are added to the DMR++
  *
  * @param dmrpp The DMR++ to annotate
  * @param bes_conf_doc The BES configuration document used to produce the source DMR.

--- a/modules/dmrpp_module/build_dmrpp_util.cc
+++ b/modules/dmrpp_module/build_dmrpp_util.cc
@@ -29,7 +29,7 @@
 #include <iterator>
 #include <unordered_set>
 #include <iomanip>      // std::put_time()
-#include <time.h>      // std::gmtime_r()
+#include <ctime>      // std::gmtime_r()
 
 #include <H5Ppublic.h>
 #include <H5Dpublic.h>

--- a/modules/dmrpp_module/build_dmrpp_util.cc
+++ b/modules/dmrpp_module/build_dmrpp_util.cc
@@ -1896,14 +1896,14 @@ std::string get_time_str_now(){
  * @param invocation The invocation of the build_dmrpp program, or the request URL if the running server was used to
  * create the DMR file that is being annotated into a DMR++.
  */
-void inject_version_and_configuration_worker( DMRpp *dmrpp, const string &bes_conf_doc, const string &invocation)
+void inject_build_dmrpp_metadata_worker( DMRpp *dmrpp, const string &bes_conf_doc, const string &invocation)
 {
     dmrpp->set_version(CVER);
 
     // Build the version attributes for the DMR++
     auto version = new D4Attribute("build_dmrpp_metadata", StringToD4AttributeType("container"));
 
-    auto creation_date = new D4Attribute("creation_date", StringToD4AttributeType("string"));
+    auto creation_date = new D4Attribute("created", StringToD4AttributeType("string"));
     creation_date->add_value(get_time_str_now());
     version->attributes()->add_attribute_nocopy(creation_date);
 
@@ -1952,7 +1952,7 @@ void inject_version_and_configuration_worker( DMRpp *dmrpp, const string &bes_co
  * @param dmrpp The DMR++ instance to anontate.
  * @note The DMRpp instance will free all memory allocated by this method.
 */
- void inject_version_and_configuration(int argc, char **argv, const string &bes_conf_file_used_to_create_dmr, DMRpp *dmrpp)
+ void inject_build_dmrpp_metadata(int argc, char **argv, const string &bes_conf_file_used_to_create_dmr, DMRpp *dmrpp)
 {
     string bes_configuration;
     string invocation;
@@ -1964,7 +1964,7 @@ void inject_version_and_configuration_worker( DMRpp *dmrpp, const string &bes_co
 
     invocation = recreate_cmdln_from_args(argc, argv);
 
-    inject_version_and_configuration_worker(dmrpp, bes_configuration, invocation);
+    inject_build_dmrpp_metadata_worker(dmrpp, bes_configuration, invocation);
 
 }
 
@@ -1978,7 +1978,7 @@ void inject_version_and_configuration_worker( DMRpp *dmrpp, const string &bes_co
  * @param dmrpp The DMRpp instance to annotate.
  * @note The DMRpp instance will free all memory allocated by this method.
 */
-void inject_version_and_configuration(DMRpp *dmrpp)
+void inject_build_dmrpp_metadata(DMRpp *dmrpp)
 {
     bool found;
 
@@ -1993,7 +1993,7 @@ void inject_version_and_configuration(DMRpp *dmrpp)
     invocation = BESContextManager::TheManager()->get_context(INVOCATION_CONTEXT, found);
 
     // Do the work now...
-    inject_version_and_configuration_worker(dmrpp, bes_configuration, invocation);
+    inject_build_dmrpp_metadata_worker(dmrpp, bes_configuration, invocation);
 }
 
 
@@ -2024,7 +2024,7 @@ void build_dmrpp_from_dmr_file(const string &dmrpp_href_value, const string &dmr
     add_chunk_information(h5_file_fqn, &dmrpp);
 
     if (add_production_metadata) {
-        inject_version_and_configuration(argc, argv, bes_conf_file_used_to_create_dmr, &dmrpp);
+        inject_build_dmrpp_metadata(argc, argv, bes_conf_file_used_to_create_dmr, &dmrpp);
     }
 
     XMLWriter writer;

--- a/modules/dmrpp_module/build_dmrpp_util.cc
+++ b/modules/dmrpp_module/build_dmrpp_util.cc
@@ -1883,7 +1883,7 @@ std::string get_time_str_now(){
 
     // Format the time using a stringstream
     std::stringstream ss;
-    ss << std::put_time(gmt_time, "%Y-%m-%dT%H:%M:%S");
+    ss << std::put_time(gmt_time, "%Y-%m-%dT%H:%M:%SZ");
 
     return ss.str();
 }

--- a/modules/dmrpp_module/build_dmrpp_util.cc
+++ b/modules/dmrpp_module/build_dmrpp_util.cc
@@ -28,6 +28,7 @@
 #include <memory>
 #include <iterator>
 #include <unordered_set>
+#include <iomanip>      // std::put_time
 
 #include <H5Ppublic.h>
 #include <H5Dpublic.h>

--- a/modules/dmrpp_module/build_dmrpp_util.cc
+++ b/modules/dmrpp_module/build_dmrpp_util.cc
@@ -28,7 +28,8 @@
 #include <memory>
 #include <iterator>
 #include <unordered_set>
-#include <iomanip>      // std::put_time
+#include <iomanip>      // std::put_time()
+#include <time.h>      // std::gmtime_r()
 
 #include <H5Ppublic.h>
 #include <H5Dpublic.h>
@@ -1881,7 +1882,8 @@ std::string what_time_is_it(){
     auto time_t_now = std::chrono::system_clock::to_time_t(now);
 
     // Convert to tm structure (GMT time)
-    std::tm* gmt_time = std::gmtime(&time_t_now);
+    struct tm tbuf{};
+    const std::tm* gmt_time = gmtime_r(&time_t_now, &tbuf);
 
     // Format the time using a stringstream
     std::stringstream ss;

--- a/modules/dmrpp_module/build_dmrpp_util.h
+++ b/modules/dmrpp_module/build_dmrpp_util.h
@@ -41,9 +41,9 @@ void build_dmrpp_from_dmr_file(const string &dmrpp_href_value, const string &dmr
 void qc_input_file(const std::string &file_name);
 
 
-void inject_version_and_configuration(int argc, char **argv, const string &bes_conf_file_used_to_create_dmr, dmrpp::DMRpp *dmrpp);
+void inject_build_dmrpp_metadata(int argc, char **argv, const string &bes_conf_file_used_to_create_dmr, dmrpp::DMRpp *dmrpp);
 
-void inject_version_and_configuration(dmrpp::DMRpp *dmrpp);
+void inject_build_dmrpp_metadata(dmrpp::DMRpp *dmrpp);
 
 extern bool verbose;
 }

--- a/modules/dmrpp_module/data/dmrpp/chunked_enum.h5.dmrpp.M.baseline
+++ b/modules/dmrpp_module/data/dmrpp/chunked_enum.h5.dmrpp.M.baseline
@@ -36,6 +36,9 @@
         </dmrpp:chunks>
     </Int64>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/data/dmrpp/chunked_oneD.h5.dmrpp.M.baseline
+++ b/modules/dmrpp_module/data/dmrpp/chunked_oneD.h5.dmrpp.M.baseline
@@ -17,6 +17,9 @@
         </dmrpp:chunks>
     </Float32>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/data/dmrpp/chunked_opaque.h5.dmrpp.M.baseline
+++ b/modules/dmrpp_module/data/dmrpp/chunked_opaque.h5.dmrpp.M.baseline
@@ -12,6 +12,9 @@
         </dmrpp:chunks>
     </Int64>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/data/dmrpp/chunked_string_array.h5.dmrpp.M.baseline
+++ b/modules/dmrpp_module/data/dmrpp/chunked_string_array.h5.dmrpp.M.baseline
@@ -15,6 +15,9 @@
         <dmrpp:FixedLengthStringArray string_length="8" pad="null_pad"/>
     </String>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/data/string_arrays/t_string_chunk.h5.dmrpp.M.baseline
+++ b/modules/dmrpp_module/data/string_arrays/t_string_chunk.h5.dmrpp.M.baseline
@@ -52,6 +52,9 @@
         </dmrpp:chunks>
     </String>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/data/string_arrays/t_string_compact.h5.dmrpp.M.baseline
+++ b/modules/dmrpp_module/data/string_arrays/t_string_compact.h5.dmrpp.M.baseline
@@ -43,6 +43,9 @@
         <dmrpp:compact>UGFydGluZyBpcyBzdWNoIHN3ZWV0IHNvcnJvdy4=</dmrpp:compact>
     </String>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/data/string_arrays/t_string_cont.h5.dmrpp.M.baseline
+++ b/modules/dmrpp_module/data/string_arrays/t_string_cont.h5.dmrpp.M.baseline
@@ -47,6 +47,9 @@
         </dmrpp:chunks>
     </String>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/build_dmrpp_macros.m4
+++ b/modules/dmrpp_module/tests_build_dmrpp/build_dmrpp_macros.m4
@@ -96,6 +96,7 @@ m4_define([AT_BUILD_DMRPP_M],  [dnl
         NORMALIZE_EXEC_NAME([stdout])
         REMOVE_PATH_COMPONENTS([stdout])
         REMOVE_VERSIONS([stdout])
+        REMOVE_BUILD_DMRPP_CREATED_ATTR_VALUE([stdout])
         AT_CHECK([mv stdout $baseline.tmp])
         ],
         [
@@ -103,6 +104,7 @@ m4_define([AT_BUILD_DMRPP_M],  [dnl
         NORMALIZE_EXEC_NAME([stdout])
         REMOVE_PATH_COMPONENTS([stdout])
         REMOVE_VERSIONS([stdout])
+        REMOVE_BUILD_DMRPP_CREATED_ATTR_VALUE([stdout])
         AT_CHECK([diff -b -B $baseline stdout])
         ])
 

--- a/modules/dmrpp_module/tests_build_dmrpp/build_dmrpp_macros.m4
+++ b/modules/dmrpp_module/tests_build_dmrpp/build_dmrpp_macros.m4
@@ -309,6 +309,7 @@ AS_IF([test -n "$baselines" -a x$baselines = xyes],
     REMOVE_PATH_COMPONENTS([${output_file}])
     REMOVE_VERSIONS([${output_file}])
     REMOVE_BUILD_DMRPP_INVOCATION_ATTR([${output_file}])
+    REMOVE_BUILD_DMRPP_CREATED_ATTR_VALUE([${output_file}])
     AS_IF([test -z "$at_verbose"], [echo "# get_dmrpp_baselines: Copying result to ${baseline}.tmp"])
     AT_CHECK([mv ${output_file} ${baseline}.tmp])
 ],
@@ -319,6 +320,7 @@ AS_IF([test -n "$baselines" -a x$baselines = xyes],
     REMOVE_PATH_COMPONENTS([${output_file}])
     REMOVE_VERSIONS([${output_file}])
     REMOVE_BUILD_DMRPP_INVOCATION_ATTR([${output_file}])
+    REMOVE_BUILD_DMRPP_CREATED_ATTR_VALUE([${output_file}])
     AS_IF([test -z "$at_verbose"], [
         echo ""
         echo "# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --"
@@ -427,6 +429,7 @@ AS_IF([test -n "$baselines" -a x$baselines = xyes],
     REMOVE_PATH_COMPONENTS([${output_file}])
     REMOVE_VERSIONS([${output_file}])
     REMOVE_BUILD_DMRPP_INVOCATION_ATTR([${output_file}])
+    REMOVE_BUILD_DMRPP_CREATED_ATTR_VALUE([${output_file}])
     AS_IF([test -z "$at_verbose"], [echo "# get_dmrpp_baselines: Copying missing data dmrpp result to ${dmrpp_baseline}.tmp"])
     AT_CHECK([mv ${output_file} ${dmrpp_baseline}.tmp])
     AS_IF([test -z "$at_verbose"], [echo "# get_dmrpp_baselines: Copying missing data result to ${missing_baseline}.missing.tmp"])
@@ -440,6 +443,7 @@ AS_IF([test -n "$baselines" -a x$baselines = xyes],
     REMOVE_PATH_COMPONENTS([${output_file}])
     REMOVE_VERSIONS([${output_file}])
     REMOVE_BUILD_DMRPP_INVOCATION_ATTR([${output_file}])
+    REMOVE_BUILD_DMRPP_CREATED_ATTR_VALUE([${output_file}])
     AS_IF([test -z "$at_verbose"], [
         echo ""
         echo "# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --"
@@ -560,6 +564,7 @@ AS_IF([test -n "$baselines" -a x$baselines = xyes],
     REMOVE_PATH_COMPONENTS([${output_file}])
     REMOVE_VERSIONS([${output_file}])
     REMOVE_BUILD_DMRPP_INVOCATION_ATTR_VALUE([${output_file}])
+    REMOVE_BUILD_DMRPP_CREATED_ATTR_VALUE([${output_file}])
     AS_IF([test -z "$at_verbose"], [echo "# get_dmrpp_baselines: Copying missing data dmrpp result to ${dmrpp_baseline}.tmp"])
     AT_CHECK([mv ${output_file} ${dmrpp_baseline}.tmp])
     AS_IF([test -z "$at_verbose"], [echo "# get_dmrpp_baselines: Copying missing data result to ${missing_baseline}.missing.tmp"])
@@ -584,6 +589,7 @@ AS_IF([test -n "$baselines" -a x$baselines = xyes],
     ])
     
     REMOVE_BUILD_DMRPP_INVOCATION_ATTR_VALUE([${output_file}])
+    REMOVE_BUILD_DMRPP_CREATED_ATTR_VALUE([${output_file}])
     AS_IF([test -z "$at_verbose"], [
         echo ""
         echo "# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --"
@@ -709,6 +715,7 @@ AS_IF([test -n "$baselines" -a x$baselines = xyes],
     REMOVE_PATH_COMPONENTS([${output_file}])
     REMOVE_VERSIONS([${output_file}])
     REMOVE_BUILD_DMRPP_INVOCATION_ATTR([${output_file}])
+    REMOVE_BUILD_DMRPP_CREATED_ATTR_VALUE([${output_file}])
     AS_IF([test -z "$at_verbose"], [echo "# get_dmrpp_baselines: Copying result to ${baseline}.tmp"])
     AT_CHECK([mv ${output_file} ${baseline}.tmp])
 ],
@@ -719,6 +726,7 @@ AS_IF([test -n "$baselines" -a x$baselines = xyes],
     REMOVE_PATH_COMPONENTS([${output_file}])
     REMOVE_VERSIONS([${output_file}])
     REMOVE_BUILD_DMRPP_INVOCATION_ATTR([${output_file}])
+    REMOVE_BUILD_DMRPP_CREATED_ATTR_VALUE([${output_file}])
     AS_IF([test -z "$at_verbose"], [
         echo ""
         echo "# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --"
@@ -742,6 +750,16 @@ AT_CLEANUP
 # Usage: REMOVE_BUILD_DMRPP_INVOCATION_ATTR_VALUE(file_name)
 m4_define([REMOVE_BUILD_DMRPP_INVOCATION_ATTR_VALUE], [dnl
     sed -e 's@<Value>build_dmrpp.*<\/Value>@<Value>Removed</Value>@g'  < $1 > $1.sed
+    mv $1.sed $1
+])
+
+# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+# Remove the build_dmrpp creation time attribute value, an ISO-68601 date string
+# ndp 07/25/24
+# Usage: REMOVE_BUILD_DMRPP_CREATED_ATTR_VALUE(file_name)
+#             <Value>2024-07-25T18:22:54Z</Value>
+m4_define([REMOVE_BUILD_DMRPP_CREATED_ATTR_VALUE], [dnl
+    sed -e 's@<Value>[[0-9]]\{4\}-[[0-9]]\{2\}-[[0-9]]\{2\}T[[0-9]]\{2\}\:[[0-9]]\{2\}\:[[0-9]]\{2\}Z</Value>@<Value>removed date string</Value>@g'  < $1 > $1.sed
     mv $1.sed $1
 ])
 

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/inject_bes_conf.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/inject_bes_conf.baseline
@@ -56,6 +56,9 @@
     </Float32>
     <Attribute name="g1" type="Container"/>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/inject_href.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/inject_href.baseline
@@ -11,6 +11,9 @@
         </dmrpp:chunks>
     </Float32>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/inventory_test.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/inventory_test.baseline
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="grid_1_2d.h5" dmrpp:href="OPeNDAP_DMRpp_DATA_ACCESS_URL" removed dmrpp:version>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/missing_data_url_dmrpp.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/missing_data_url_dmrpp.baseline
@@ -69,6 +69,9 @@
         </Attribute>
     </Attribute>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/missing_dmrpp.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/missing_dmrpp.baseline
@@ -69,6 +69,9 @@
         </Attribute>
     </Attribute>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/missing_group_dmrpp.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/missing_group_dmrpp.baseline
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="grid_2_2d_size.h5" dmrpp:href="OPeNDAP_DMRpp_DATA_ACCESS_URL" removed dmrpp:version>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/missing_group_dmrpp_comp.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/missing_group_dmrpp_comp.baseline
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="grid_2_2d_sin.h5" dmrpp:href="OPeNDAP_DMRpp_DATA_ACCESS_URL" removed dmrpp:version>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/modify_configuration_test.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/modify_configuration_test.baseline
@@ -56,6 +56,9 @@
     </Float32>
     <Attribute name="g1" type="Container"/>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/output_file_test.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/output_file_test.baseline
@@ -11,6 +11,9 @@
         </dmrpp:chunks>
     </Float32>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/s3_pull_push_test.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/s3_pull_push_test.baseline
@@ -11,6 +11,9 @@
         </dmrpp:chunks>
     </Float32>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/simple_test_1.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/simple_test_1.baseline
@@ -11,6 +11,9 @@
         </dmrpp:chunks>
     </Float32>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/simple_test_2.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/simple_test_2.baseline
@@ -15,6 +15,9 @@
         </dmrpp:chunks>
     </Float32>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/vlsa.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/vlsa.baseline
@@ -10,6 +10,9 @@
         </dmrpp:vlsa>
     </String>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/vlss.baseline
+++ b/modules/dmrpp_module/tests_build_dmrpp/get_dmrpp_baselines/vlss.baseline
@@ -4,6 +4,9 @@
         <dmrpp:compact>QW4gSERGNSB2bGVuIHNjYWxhciBzdHJpbmcu</dmrpp:compact>
     </String>
     <Attribute name="build_dmrpp_metadata" type="Container">
+        <Attribute name="created" type="String">
+            <Value>removed date string</Value>
+        </Attribute>
         <Attribute name="build_dmrpp" type="String">
             <Value>removed version</Value>
         </Attribute>

--- a/modules/dmrpp_module/writer/FODmrppTransmitter.cc
+++ b/modules/dmrpp_module/writer/FODmrppTransmitter.cc
@@ -138,7 +138,7 @@ void FODmrppTransmitter::send_dmrpp(BESResponseObject *obj, BESDataHandlerInterf
         build_dmrpp_util::add_chunk_information(dataset_name, &dmrpp);
 
         if (add_production_metadata) {
-            build_dmrpp_util::inject_version_and_configuration(&dmrpp);
+            build_dmrpp_util::inject_build_dmrpp_metadata(&dmrpp);
         }
 
         XMLWriter dmrpp_writer;


### PR DESCRIPTION
This PR adds the creation time  (as an ISO-8601 formatted string)  in a DAP metadata attribute added the existing build_dmrpp metadata. This will enable us to know exactly when a particular dmr++ was created.

```
        <Attribute name="created" type="String">
            <Value>2024-07-07T12:13:21Z</Value>
        </Attribute>
```
This should also be added to the hdf4 version of build_dmrpp