### PR TITLE
 Need to increase one byte for a char array. The file has a vdata cla…

### DIFF
--- a/modules/hdf4_handler/hdfdesc.cc
+++ b/modules/hdf4_handler/hdfdesc.cc
@@ -5028,7 +5028,7 @@ void convert_vdata(int32 fileid, int32 sdfd, int32 vgroup_id,int32 obj_ref ,D4Gr
     }
 
     // Vdata class
-    char vdata_class[VSNAMELENMAX];
+    char vdata_class[VSNAMELENMAX+1];
 
     if (VSgetclass (vdata_id, vdata_class) == FAIL) {
         VSdetach (vdata_id);


### PR DESCRIPTION
…ss with a long name. The name size is exactly equal to the maximum vdata class name length set by the HDF4 library. Without increasing the array size, it fails on MacOS although it works fine on Linux.