### PR TITLE
Fix the info message issue and write tests

### DIFF
--- a/http/AllowedHosts.cc
+++ b/http/AllowedHosts.cc
@@ -114,6 +114,8 @@ bool AllowedHosts::is_allowed(shared_ptr<http::url> candidate_url) {
     return is_allowed(candidate_url, error_msg);
 }
 
+// TODO change this so that it does not throw an exception for the last case. OR, it always throws.
+//  jhrg 11/22/24
 bool AllowedHosts::is_allowed(shared_ptr<http::url> candidate_url, std::string &why_not) {
     BESDEBUG(MODULE, prolog << "BEGIN candidate_url: " << candidate_url->str() << endl);
     bool isAllowed = false;

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -1119,14 +1119,14 @@ void http_get_and_write_resource(const std::shared_ptr<http::url> &target_url, i
  * @note Used here and in dmrpp_module in one place. jhrg 3/8/23
  * @param response_code
  * @param error_buf
- * @return
+ * @return A formated error message in a C++ string.
  */
 string error_message(const CURLcode response_code, const char *error_buffer) {
     string msg;
     if (error_buffer) {
         msg = string("cURL_error_buffer: ") + error_buffer + ", ";
     }
-    msg = string("cURL_message: ") + curl_easy_strerror(response_code) + " (code: "
+    msg += string("cURL_message: ") + curl_easy_strerror(response_code) + " (code: "
             + to_string(response_code) + ")\n";
     return msg;
 }
@@ -1471,8 +1471,9 @@ sign_s3_url(const shared_ptr <url> &target_url, AccessCredentials *ac, curl_slis
  * @return True if the URL is signed for S3, false otherwise.
  */
 bool is_url_signed_for_s3(const std::string &url) {
-    static const std::regex s3_signature_regex("X-Amz-Algorithm=|X-Amz-Credential=|X-Amz-Signature=");
-    return std::regex_search(url, s3_signature_regex);
+    return url.find("X-Amz-Algorithm=") != string::npos &&
+           url.find("X-Amz-Credential=") != string::npos &&
+           url.find("X-Amz-Signature=") != string::npos;
 }
 
 /**

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -28,7 +28,6 @@
 #include <fcntl.h>
 #include <ctime>
 #include <cstring>
-#include <regex>
 
 #include <curl/curl.h>
 

--- a/http/CurlUtils.h
+++ b/http/CurlUtils.h
@@ -94,6 +94,10 @@ curl_slist *add_edl_auth_headers(curl_slist *request_headers);
 
 curl_slist *sign_s3_url(const std::shared_ptr<http::url> &target_url, http::AccessCredentials *ac,
                         curl_slist *req_headers);
+
+bool is_url_signed_for_s3(const std::string &url);
+bool is_url_signed_for_s3(const std::shared_ptr<http::url> &target_url);
+
 } // namespace curl
 
 #endif /*  _bes_http_CURL_UTILS_H_ */

--- a/http/unit-tests/CurlUtilsTest.cc
+++ b/http/unit-tests/CurlUtilsTest.cc
@@ -109,6 +109,56 @@ public:
 /*##################################################################################################*/
 /* TESTS BEGIN */
 
+    void test_is_url_signed_for_s3_WithSignedUrl() {
+        // Test a URL that contains all the required S3 signature parameters
+        std::string signedUrl = "https://example.com/myfile?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=some-credential&X-Amz-Signature=abc123";
+        CPPUNIT_ASSERT(curl::is_url_signed_for_s3(signedUrl));
+    }
+
+    void test_is_url_signed_for_s3_with_one_key_only() {
+        // Test a URL that contains all the required S3 signature parameters
+        std::string signedUrl = "https://example.com/myfile?X-Amz-Algorithm=AWS4-HMAC-SHA256";
+        CPPUNIT_ASSERT(!curl::is_url_signed_for_s3(signedUrl));
+    }
+
+    void test_is_url_signed_for_s3_WithoutSignedUrl() {
+        // Test a URL that does not contain any S3 signature parameters
+        std::string unsignedUrl = "https://example.com/myfile";
+        CPPUNIT_ASSERT(!curl::is_url_signed_for_s3(unsignedUrl));
+    }
+
+    void test_is_url_signed_for_s3_EmptyUrl() {
+        // Test an empty URL string
+        std::string emptyUrl = "";
+        CPPUNIT_ASSERT(!curl::is_url_signed_for_s3(emptyUrl));
+    }
+
+    void test_is_url_signed_for_s3_PartialMatch() {
+        // Test a URL with similar parameters but not exact S3 signature keys
+        std::string partialMatchUrl = "https://example.com/myfile?X-Amz-InvalidParam=test";
+        CPPUNIT_ASSERT(!curl::is_url_signed_for_s3(partialMatchUrl));
+    }
+
+    // This does not test if the buffer (arg #2) is corrupted, If that's the case error_message()
+    // response is not reliable. jhrg 11/22/24
+    void test_error_message_with_buffer()
+    {
+        // Test with a non-empty error buffer
+        CPPUNIT_ASSERT_EQUAL(
+                std::string(
+                "cURL_error_buffer: Test error buffer, cURL_message: Couldn't resolve host name (code: 6)\n"),
+                curl::error_message(CURLE_COULDNT_RESOLVE_HOST, "Test error buffer")
+        );
+    }
+    void test_error_message_without_buffer()
+    {
+        // Test with an empty error buffer
+        CPPUNIT_ASSERT_EQUAL(
+                std::string("cURL_message: Couldn't resolve host name (code: 6)\n"),
+                curl::error_message(CURLE_COULDNT_RESOLVE_HOST, nullptr)
+        );
+    }
+
     void is_retryable_test() {
         DBG(cerr << prolog << "BEGIN\n");
         bool isRetryable;
@@ -718,6 +768,15 @@ public:
     }
 
     CPPUNIT_TEST_SUITE(CurlUtilsTest);
+
+        CPPUNIT_TEST(test_is_url_signed_for_s3_WithSignedUrl);
+        CPPUNIT_TEST(test_is_url_signed_for_s3_with_one_key_only);
+        CPPUNIT_TEST(test_is_url_signed_for_s3_WithoutSignedUrl);
+        CPPUNIT_TEST(test_is_url_signed_for_s3_EmptyUrl);
+        CPPUNIT_TEST(test_is_url_signed_for_s3_PartialMatch);
+
+        CPPUNIT_TEST(test_error_message_with_buffer);
+        CPPUNIT_TEST(test_error_message_without_buffer);
 
         CPPUNIT_TEST(how_big);
 

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -165,16 +165,14 @@ int curl_trace(CURL */*handle*/, curl_infotype type, char *data, size_t /*size*/
 }
 #endif
 
-dmrpp_easy_handle::dmrpp_easy_handle(): d_errbuf(CURL_ERROR_SIZE, '\0') {
-
-    CURLcode res;
-
+dmrpp_easy_handle::dmrpp_easy_handle() {
+    //d_errbuf = vector<char>(CURL_ERROR_SIZE, '\0'); // Initialize the error buffer
     d_handle = curl_easy_init();
     if (!d_handle) throw BESInternalError("Could not allocate CURL handle", __FILE__, __LINE__);
 
     curl::set_error_buffer(d_handle, d_errbuf.data());
 
-    res = curl_easy_setopt(d_handle, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+    CURLcode res = curl_easy_setopt(d_handle, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
     curl::eval_curl_easy_setopt_result(res, prolog, "CURLOPT_SSLVERSION", d_errbuf.data(), __FILE__, __LINE__);
 
 #if CURL_VERBOSE

--- a/modules/dmrpp_module/CurlHandlePool.cc
+++ b/modules/dmrpp_module/CurlHandlePool.cc
@@ -166,7 +166,6 @@ int curl_trace(CURL */*handle*/, curl_infotype type, char *data, size_t /*size*/
 #endif
 
 dmrpp_easy_handle::dmrpp_easy_handle() {
-    //d_errbuf = vector<char>(CURL_ERROR_SIZE, '\0'); // Initialize the error buffer
     d_handle = curl_easy_init();
     if (!d_handle) throw BESInternalError("Could not allocate CURL handle", __FILE__, __LINE__);
 

--- a/modules/dmrpp_module/CurlHandlePool.h
+++ b/modules/dmrpp_module/CurlHandlePool.h
@@ -51,7 +51,7 @@ class dmrpp_easy_handle {
 #if 0
     //char d_errbuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
 #endif
-    std::vector<char> d_errbuf; ///< raw error message info from libcurl
+    std::vector<char> d_errbuf = std::vector<char>(CURL_ERROR_SIZE, '\0'); ///< raw error message info from libcurl
 
     CURL *d_handle = nullptr;     ///< The libcurl handle object.
     curl_slist *d_request_headers = nullptr; ///< Holds the list of authorization headers, if needed.

--- a/modules/dmrpp_module/CurlHandlePool.h
+++ b/modules/dmrpp_module/CurlHandlePool.h
@@ -150,7 +150,7 @@ public:
     void initialize();
     dmrpp_easy_handle *get_easy_handle(Chunk *chunk);
 
-    void release_handle(dmrpp_easy_handle *h);
+    static void release_handle(dmrpp_easy_handle *h);
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/CurlHandlePool.h
+++ b/modules/dmrpp_module/CurlHandlePool.h
@@ -48,7 +48,10 @@ class dmrpp_easy_handle {
     bool d_in_use = false;      ///< Is this easy_handle in use?
     std::shared_ptr<http::url> d_url;  ///< The libcurl handle reads from this URL.
     Chunk *d_chunk = nullptr;     ///< This easy_handle reads the data for \arg chunk.
-    char d_errbuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
+#if 0
+    //char d_errbuf[CURL_ERROR_SIZE]; ///< raw error message info from libcurl
+#endif
+    std::vector<char> d_errbuf; ///< raw error message info from libcurl
 
     CURL *d_handle = nullptr;     ///< The libcurl handle object.
     curl_slist *d_request_headers = nullptr; ///< Holds the list of authorization headers, if needed.

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -1218,7 +1218,7 @@ void DmrppArray::read_chunks_unconstrained()
     stringstream sc_id;
     sc_id << name() << "-" << sc_count++;
     queue<shared_ptr<SuperChunk>> super_chunks;
-    auto current_super_chunk = shared_ptr<SuperChunk>(new SuperChunk(sc_id.str(),this)) ;
+    auto current_super_chunk = std::make_shared<SuperChunk>(sc_id.str(), this) ;
     super_chunks.push(current_super_chunk);
 
     // Make the SuperChunks using all the chunks.
@@ -1227,7 +1227,7 @@ void DmrppArray::read_chunks_unconstrained()
         if (!added) {
             sc_id.str(std::string());
             sc_id << name() << "-" << sc_count++;
-            current_super_chunk = shared_ptr<SuperChunk>(new SuperChunk(sc_id.str(),this));
+            current_super_chunk = std::make_shared<SuperChunk>(sc_id.str(), this);
             super_chunks.push(current_super_chunk);
             if (!current_super_chunk->add_chunk(chunk)) {
                 stringstream msg ;

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -1413,7 +1413,9 @@ void DmrppArray::read_linked_blocks(){
     
             char **destp = nullptr;
             char *dest_deflate = nullptr;
+#if 0
             unsigned long long out_buf_size = 0;
+#endif
             unsigned long long dest_len = get_var_chunks_storage_size();
             unsigned long long src_len = get_var_chunks_storage_size();
             dest_deflate = new char[dest_len];

--- a/modules/dmrpp_module/DmrppByte.h
+++ b/modules/dmrpp_module/DmrppByte.h
@@ -41,27 +41,27 @@ class DmrppByte: public libdap::Byte, public DmrppCommon {
 public:
     DmrppByte(const std::string &n) : Byte(n), DmrppCommon() { }
     DmrppByte(const std::string &n, const std::string &d) : Byte(n, d), DmrppCommon() { }
-    DmrppByte(const std::string &n, shared_ptr<DMZ> dmz) : Byte(n), DmrppCommon(dmz) { }
-    DmrppByte(const std::string &n, const std::string &d, shared_ptr<DMZ> dmz) : Byte(n, d), DmrppCommon(dmz) { }
+    DmrppByte(const std::string &n, shared_ptr<DMZ> dmz) : Byte(n), DmrppCommon(std::move(dmz)) { }
+    DmrppByte(const std::string &n, const std::string &d, shared_ptr<DMZ> dmz) : Byte(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppByte(const DmrppByte &) = default;
 
-    virtual ~DmrppByte() = default;
+    ~DmrppByte() override = default;
 
     DmrppByte &operator=(const DmrppByte &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppByte(*this);
     }
 
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(ostream & strm) const;
+    void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppD4Enum.h
+++ b/modules/dmrpp_module/DmrppD4Enum.h
@@ -45,23 +45,23 @@ public:
 
     DmrppD4Enum(const DmrppD4Enum &) = default;
 
-    virtual ~DmrppD4Enum() = default;
+    ~DmrppD4Enum() override = default;
 
     DmrppD4Enum &operator=(const DmrppD4Enum &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppD4Enum(*this);
     }
 
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(ostream & strm) const;
+    void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppD4Group.h
+++ b/modules/dmrpp_module/DmrppD4Group.h
@@ -41,11 +41,11 @@ class DmrppD4Group: public libdap::D4Group, public DmrppCommon {
 public:
     DmrppD4Group(const std::string &n) : D4Group(n), DmrppCommon() { }
     DmrppD4Group(const std::string &n, const std::string &d) : D4Group(n, d), DmrppCommon() { }
-    DmrppD4Group(const std::string &n, std::shared_ptr<DMZ> dmz) : D4Group(n), DmrppCommon(dmz) { }
-    DmrppD4Group(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : D4Group(n, d), DmrppCommon(dmz) { }
+    DmrppD4Group(const std::string &n, std::shared_ptr<DMZ> dmz) : D4Group(n), DmrppCommon(std::move(dmz)) { }
+    DmrppD4Group(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : D4Group(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppD4Group(const DmrppD4Group &) = default;
 
-    virtual ~DmrppD4Group() = default;
+    ~DmrppD4Group() override = default;
 
     DmrppD4Group &operator=(const DmrppD4Group &rhs);
 

--- a/modules/dmrpp_module/DmrppD4Opaque.h
+++ b/modules/dmrpp_module/DmrppD4Opaque.h
@@ -44,15 +44,15 @@ class DmrppD4Opaque: public libdap::D4Opaque, public DmrppCommon {
 public:
     DmrppD4Opaque(const std::string &n) : libdap::D4Opaque(n), DmrppCommon() { }
     DmrppD4Opaque(const std::string &n, const std::string &d) : libdap::D4Opaque(n, d), DmrppCommon() { }
-    DmrppD4Opaque(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::D4Opaque(n), DmrppCommon(dmz) { }
-    DmrppD4Opaque(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::D4Opaque(n, d), DmrppCommon(dmz) { }
+    DmrppD4Opaque(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::D4Opaque(n), DmrppCommon(std::move(dmz)) { }
+    DmrppD4Opaque(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::D4Opaque(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppD4Opaque(const DmrppD4Opaque &) = default;
 
-    virtual ~DmrppD4Opaque() = default;
+    ~DmrppD4Opaque() override = default;
 
     DmrppD4Opaque &operator=(const DmrppD4Opaque &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppD4Opaque(*this);
     }
 
@@ -80,12 +80,12 @@ public:
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(ostream & strm) const;
+    void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppD4Sequence.h
+++ b/modules/dmrpp_module/DmrppD4Sequence.h
@@ -37,21 +37,21 @@ class DmrppD4Sequence: public libdap::D4Sequence, public DmrppCommon {
 public:
     DmrppD4Sequence(const std::string &n) : D4Sequence(n), DmrppCommon() { }
     DmrppD4Sequence(const std::string &n, const std::string &d) : D4Sequence(n, d), DmrppCommon() { }
-    DmrppD4Sequence(const std::string &n, std::shared_ptr<DMZ> dmz) : D4Sequence(n), DmrppCommon(dmz) { }
-    DmrppD4Sequence(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : D4Sequence(n, d), DmrppCommon(dmz) { }
+    DmrppD4Sequence(const std::string &n, std::shared_ptr<DMZ> dmz) : D4Sequence(n), DmrppCommon(std::move(dmz)) { }
+    DmrppD4Sequence(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : D4Sequence(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppD4Sequence(const DmrppD4Sequence &) = default;
 
-    virtual ~DmrppD4Sequence() = default;
+    ~DmrppD4Sequence() override = default;
 
     DmrppD4Sequence &operator=(const DmrppD4Sequence &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppD4Sequence(*this);
     }
 
-    virtual bool read();
+    bool read() override;
 
-    virtual void dump(ostream & strm) const;
+    void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppFloat32.h
+++ b/modules/dmrpp_module/DmrppFloat32.h
@@ -41,27 +41,27 @@ class DmrppFloat32: public libdap::Float32, public DmrppCommon {
 public:
     DmrppFloat32(const std::string &n) : Float32(n), DmrppCommon() { }
     DmrppFloat32(const std::string &n, const std::string &d) : Float32(n, d), DmrppCommon() { }
-    DmrppFloat32(const std::string &n, std::shared_ptr<DMZ> dmz) : Float32(n), DmrppCommon(dmz) { }
-    DmrppFloat32(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : Float32(n, d), DmrppCommon(dmz) { }
+    DmrppFloat32(const std::string &n, std::shared_ptr<DMZ> dmz) : Float32(n), DmrppCommon(std::move(dmz)) { }
+    DmrppFloat32(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : Float32(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppFloat32(const DmrppFloat32 &) = default;
 
-    virtual ~DmrppFloat32() = default;
+    ~DmrppFloat32() override = default;
 
     DmrppFloat32 &operator=(const DmrppFloat32 &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppFloat32(*this);
     }
 
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(ostream & strm) const;
+    void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppFloat64.h
+++ b/modules/dmrpp_module/DmrppFloat64.h
@@ -41,27 +41,27 @@ class DmrppFloat64: public libdap::Float64, public DmrppCommon {
 public:
     DmrppFloat64(const std::string &n) : libdap::Float64(n), DmrppCommon() { }
     DmrppFloat64(const std::string &n, const std::string &d) : libdap::Float64(n, d), DmrppCommon() { }
-    DmrppFloat64(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Float64(n), DmrppCommon(dmz) { }
-    DmrppFloat64(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Float64(n, d), DmrppCommon(dmz) { }
+    DmrppFloat64(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Float64(n), DmrppCommon(std::move(dmz)) { }
+    DmrppFloat64(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Float64(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppFloat64(const DmrppFloat64 &) = default;
 
-    virtual ~DmrppFloat64() = default;
+    ~DmrppFloat64() override = default;
 
     DmrppFloat64 &operator=(const DmrppFloat64 &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppFloat64(*this);
     }
 
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(ostream & strm) const;
+    void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppInt16.h
+++ b/modules/dmrpp_module/DmrppInt16.h
@@ -41,27 +41,27 @@ class DmrppInt16: public libdap::Int16, public DmrppCommon {
 public:
     DmrppInt16(const std::string &n) : libdap::Int16(n), DmrppCommon() { }
     DmrppInt16(const std::string &n, const std::string &d) : libdap::Int16(n, d), DmrppCommon() { }
-    DmrppInt16(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Int16(n), DmrppCommon(dmz) { }
-    DmrppInt16(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Int16(n, d), DmrppCommon(dmz) { }
+    DmrppInt16(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Int16(n), DmrppCommon(std::move(dmz)) { }
+    DmrppInt16(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Int16(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppInt16(const DmrppInt16 &) = default;
 
-    virtual ~DmrppInt16() = default;
+    ~DmrppInt16() override = default;
 
     DmrppInt16 &operator=(const DmrppInt16 &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppInt16(*this);
     }
 
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(ostream & strm) const;
+    void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppInt32.h
+++ b/modules/dmrpp_module/DmrppInt32.h
@@ -45,18 +45,18 @@ public:
     DmrppInt32(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Int32(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppInt32(const DmrppInt32 &) = default;
 
-    virtual ~DmrppInt32() = default;
+    ~DmrppInt32() override = default;
 
     DmrppInt32 &operator=(const DmrppInt32 &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppInt32(*this);
     }
 
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }

--- a/modules/dmrpp_module/DmrppInt32.h
+++ b/modules/dmrpp_module/DmrppInt32.h
@@ -41,8 +41,8 @@ class DmrppInt32: public libdap::Int32, public DmrppCommon {
 public:
     DmrppInt32(const std::string &n) : libdap::Int32(n), DmrppCommon() { }
     DmrppInt32(const std::string &n, const std::string &d) : libdap::Int32(n, d), DmrppCommon() { }
-    DmrppInt32(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Int32(n), DmrppCommon(dmz) { }
-    DmrppInt32(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Int32(n, d), DmrppCommon(dmz) { }
+    DmrppInt32(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Int32(n), DmrppCommon(std::move(dmz)) { }
+    DmrppInt32(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Int32(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppInt32(const DmrppInt32 &) = default;
 
     virtual ~DmrppInt32() = default;
@@ -61,7 +61,7 @@ public:
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(ostream & strm) const;
+    void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppInt64.h
+++ b/modules/dmrpp_module/DmrppInt64.h
@@ -49,7 +49,7 @@ public:
 
     DmrppInt64 &operator=(const DmrppInt64 &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppInt64(*this);
     }
 

--- a/modules/dmrpp_module/DmrppInt64.h
+++ b/modules/dmrpp_module/DmrppInt64.h
@@ -41,11 +41,11 @@ class DmrppInt64: public libdap::Int64, public DmrppCommon {
 public:
     DmrppInt64(const std::string &n) : libdap::Int64(n), DmrppCommon() { }
     DmrppInt64(const std::string &n, const std::string &d) : libdap::Int64(n, d), DmrppCommon() { }
-    DmrppInt64(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Int64(n), DmrppCommon(dmz) { }
-    DmrppInt64(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Int64(n, d), DmrppCommon(dmz) { }
+    DmrppInt64(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Int64(n), DmrppCommon(std::move(dmz)) { }
+    DmrppInt64(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Int64(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppInt64(const DmrppInt64 &) = default;
 
-    virtual ~DmrppInt64() = default;
+    ~DmrppInt64() override = default;
 
     DmrppInt64 &operator=(const DmrppInt64 &rhs);
 
@@ -56,12 +56,12 @@ public:
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(ostream & strm) const;
+     void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppInt8.h
+++ b/modules/dmrpp_module/DmrppInt8.h
@@ -56,7 +56,7 @@ public:
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }

--- a/modules/dmrpp_module/DmrppInt8.h
+++ b/modules/dmrpp_module/DmrppInt8.h
@@ -41,27 +41,27 @@ class DmrppInt8: public libdap::Int8, public DmrppCommon {
 public:
     DmrppInt8(const std::string &n) : libdap::Int8(n), DmrppCommon() { }
     DmrppInt8(const std::string &n, const std::string &d) : libdap::Int8(n, d), DmrppCommon() { }
-    DmrppInt8(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Int8(n), DmrppCommon(dmz) { }
-    DmrppInt8(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Int8(n, d), DmrppCommon(dmz) { }
+    DmrppInt8(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Int8(n), DmrppCommon(std::move(dmz)) { }
+    DmrppInt8(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Int8(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppInt8(const DmrppInt8 &) = default;
 
-    virtual ~DmrppInt8() =default;
+    ~DmrppInt8() override = default;
 
     DmrppInt8 &operator=(const DmrppInt8 &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppInt8(*this);
     }
 
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(ostream & strm) const;
+    void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -81,7 +81,11 @@ using namespace http;
 using namespace libdap;
 using namespace std;
 
+// These should be set in the Makefile.am. jhrg 11/23/24
+#ifndef MODULE_NAME
 #define MODULE_NAME "dmrpp_module"
+#endif
+
 #ifndef MODULE_VERSION
 #define MODULE_VERSION "unset"      // Set this in the Makefile.am
 #endif

--- a/modules/dmrpp_module/DmrppRequestHandler.h
+++ b/modules/dmrpp_module/DmrppRequestHandler.h
@@ -75,7 +75,7 @@ public:
 	explicit DmrppRequestHandler(const std::string &name);
 	~DmrppRequestHandler() override;
 
-    static std::unique_ptr<CurlHandlePool> curl_handle_pool;
+    static CurlHandlePool *curl_handle_pool;
 
     static bool d_use_transfer_threads;
     static unsigned int d_max_transfer_threads;

--- a/modules/dmrpp_module/DmrppStr.h
+++ b/modules/dmrpp_module/DmrppStr.h
@@ -41,8 +41,8 @@ class DmrppStr: public libdap::Str, public DmrppCommon {
 public:
     explicit DmrppStr(const std::string &n) : libdap::Str(n), DmrppCommon() { }
     DmrppStr(const std::string &n, const std::string &d) : libdap::Str(n, d), DmrppCommon() { }
-    DmrppStr(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Str(n), DmrppCommon(dmz) { }
-    DmrppStr(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Str(n, d), DmrppCommon(dmz) { }
+    DmrppStr(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Str(n), DmrppCommon(std::move(dmz)) { }
+    DmrppStr(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Str(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppStr(const DmrppStr &) = default;
 
     ~DmrppStr() override = default;

--- a/modules/dmrpp_module/DmrppStructure.h
+++ b/modules/dmrpp_module/DmrppStructure.h
@@ -37,19 +37,27 @@ class XMLWriter;
 namespace dmrpp {
 
 class DmrppStructure: public libdap::Structure, public DmrppCommon {
+private:
+    void structure_read(vector<char> &values, size_t &values_offset, bool byte_swap);
+    void swap_bytes_in_structure(char*swap_value, libdap::Type t_bt, int64_t num_eles) const;
+    vector<char> d_structure_str_buf;
+    bool is_special_structure = false;
+    friend class DmrppArray;
 
 public:
     DmrppStructure(const std::string &n) : libdap::Structure(n), DmrppCommon() { }
     DmrppStructure(const std::string &n, const std::string &d) : libdap::Structure(n, d), DmrppCommon() { }
-    DmrppStructure(const std::string &n, std::shared_ptr<DMZ> dmz) : libdap::Structure(n), DmrppCommon(dmz) { }
-    DmrppStructure(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Structure(n, d), DmrppCommon(dmz) { }
+    DmrppStructure(const std::string &n, std::shared_ptr<DMZ> dmz)
+        : libdap::Structure(n), DmrppCommon(std::move(dmz)) { }
+    DmrppStructure(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz)
+        : libdap::Structure(n, d), DmrppCommon(std::move(dmz)) { }
     DmrppStructure(const DmrppStructure &) = default;
 
-    virtual ~DmrppStructure() = default;
+    ~DmrppStructure() override = default;
 
     DmrppStructure &operator=(const DmrppStructure &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate()  {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppStructure(*this);
     }
 
@@ -58,18 +66,11 @@ public:
 
     void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override;
 
-    virtual void dump(ostream & strm) const;
-    vector<char> & get_structure_str_buffer() { return d_structure_str_buf;}
+    void dump(ostream & strm) const override;
+    vector<char> & get_structure_str_buffer() { return d_structure_str_buf; }
 
-    void set_special_structure_flag(bool is_special_struct) {is_special_structure = is_special_struct;} 
-    bool get_special_structure_flag() const { return is_special_structure;} 
-
-private:
-    void structure_read(vector<char> &values, size_t &values_offset, bool byte_swap);
-    void swap_bytes_in_structure(char*swap_value, libdap::Type t_bt, int64_t num_eles) const;
-    vector<char> d_structure_str_buf;
-    bool is_special_structure = false;
-    friend class DmrppArray;
+    void set_special_structure_flag(bool is_special_struct) {is_special_structure = is_special_struct; }
+    bool get_special_structure_flag() const { return is_special_structure; }
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppUInt16.h
+++ b/modules/dmrpp_module/DmrppUInt16.h
@@ -45,23 +45,23 @@ public:
     DmrppUInt16(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::UInt16(n, d), DmrppCommon(dmz) { }
     DmrppUInt16(const DmrppUInt16 &) = default;
 
-    virtual ~DmrppUInt16()= default;
+    ~DmrppUInt16() override = default;
 
     DmrppUInt16 &operator=(const DmrppUInt16 &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppUInt16(*this);
     }
 
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(ostream & strm) const;
+    void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppUInt32.h
+++ b/modules/dmrpp_module/DmrppUInt32.h
@@ -49,7 +49,7 @@ public:
 
     DmrppUInt32 &operator=(const DmrppUInt32 &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() override{
+    libdap::BaseType *ptr_duplicate() override{
         return new DmrppUInt32(*this);
     }
 

--- a/modules/dmrpp_module/DmrppUInt32.h
+++ b/modules/dmrpp_module/DmrppUInt32.h
@@ -45,11 +45,11 @@ public:
     DmrppUInt32(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::UInt32(n, d), DmrppCommon(dmz) { }
     DmrppUInt32(const DmrppUInt32 &) = default;
 
-    virtual ~DmrppUInt32() =default;
+    ~DmrppUInt32() override = default;
 
     DmrppUInt32 &operator=(const DmrppUInt32 &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    virtual libdap::BaseType *ptr_duplicate() override{
         return new DmrppUInt32(*this);
     }
 
@@ -57,12 +57,12 @@ public:
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(ostream & strm) const;
+    void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppUInt64.h
+++ b/modules/dmrpp_module/DmrppUInt64.h
@@ -45,11 +45,11 @@ public:
     DmrppUInt64(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::UInt64(n, d), DmrppCommon(dmz) { }
     DmrppUInt64(const DmrppUInt64 &) = default;
 
-    virtual ~DmrppUInt64() = default;
+    ~DmrppUInt64() override = default;
 
     DmrppUInt64 &operator=(const DmrppUInt64 &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    libdap::BaseType *ptr_duplicate() override{
         return new DmrppUInt64(*this);
     }
 
@@ -57,12 +57,12 @@ public:
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(ostream & strm) const;
+    void dump(ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppUrl.h
+++ b/modules/dmrpp_module/DmrppUrl.h
@@ -45,23 +45,23 @@ public:
     DmrppUrl(const std::string &n, const std::string &d, std::shared_ptr<DMZ> dmz) : libdap::Url(n, d), DmrppCommon(dmz) { }
     DmrppUrl(const DmrppUrl &) = default;
 
-    virtual ~DmrppUrl() = default;
+    ~DmrppUrl() override = default;
 
     DmrppUrl &operator=(const DmrppUrl &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() {
+    virtual libdap::BaseType *ptr_duplicate() override {
         return new DmrppUrl(*this);
     }
 
     bool read() override;
     void set_send_p(bool state) override;
 
-    virtual void print_dap4(libdap::XMLWriter &writer, bool constrained = false)
+    void print_dap4(libdap::XMLWriter &writer, bool constrained = false) override
     {
         DmrppCommon::print_dmrpp(writer, constrained);
     }
 
-    virtual void dump(std::ostream & strm) const;
+    void dump(std::ostream & strm) const override;
 };
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/DmrppUrl.h
+++ b/modules/dmrpp_module/DmrppUrl.h
@@ -49,7 +49,7 @@ public:
 
     DmrppUrl &operator=(const DmrppUrl &rhs);
 
-    virtual libdap::BaseType *ptr_duplicate() override {
+    libdap::BaseType *ptr_duplicate() override {
         return new DmrppUrl(*this);
     }
 

--- a/modules/dmrpp_module/Makefile.am
+++ b/modules/dmrpp_module/Makefile.am
@@ -18,7 +18,7 @@ AM_CPPFLAGS += $(OPENSSL_INC)
 M_NAME=dmrpp_module
 M_VER=1.1.7
 
-AM_CPPFLAGS += -DMODULE_VERSION=\"$(M_VER)\"
+AM_CPPFLAGS += -DMODULE_NAME=\"$(M_NAME)\"  -DMODULE_VERSION=\"$(M_VER)\"
 
 # These are not used by automake but are often useful for certain types of
 # debugging. The best way to use these is to run configure as:

--- a/modules/dmrpp_module/SuperChunk.cc
+++ b/modules/dmrpp_module/SuperChunk.cc
@@ -608,10 +608,10 @@ void SuperChunk::read_aggregate_bytes()
 
     try {
         handle->read_data();  // throws if error
-        DmrppRequestHandler::curl_handle_pool->release_handle(handle);
+        dmrpp::CurlHandlePool::release_handle(handle);
     }
     catch(...) {
-        DmrppRequestHandler::curl_handle_pool->release_handle(handle);
+        dmrpp::CurlHandlePool::release_handle(handle);
         throw;
     }
 
@@ -687,6 +687,7 @@ void SuperChunk::retrieve_data() {
         chunk->set_bytes_read(chunk->get_size());
     }
 }
+
 // Direct chunk IO routine for retrieve_data, it clones from retrieve_data(). To ensure
 // the regular operations. Still use a separate method.
 void SuperChunk::retrieve_data_dio() {
@@ -868,8 +869,6 @@ void SuperChunk::read_unconstrained_dio() {
 
         process_chunks_unconstrained_concurrent_dio(d_id,chunks_to_process, chunk_shape, d_parent_array, array_shape);
     }
-
-
 }
 
 } // namespace dmrpp

--- a/modules/dmrpp_module/SuperChunk.h
+++ b/modules/dmrpp_module/SuperChunk.h
@@ -46,13 +46,13 @@ class SuperChunk {
     friend class SuperChunkTest;
 
     std::string d_id;
-    DmrppArray *d_parent_array;
+    DmrppArray *d_parent_array = nullptr;
     std::shared_ptr<http::url> d_data_url;
     std::vector<std::shared_ptr<Chunk>> d_chunks;
-    unsigned long long d_offset;
-    unsigned long long d_size;
-    bool d_is_read;
-    char *d_read_buffer;
+    unsigned long long d_offset = 0;
+    unsigned long long d_size = 0;
+    bool d_is_read = false;
+    char *d_read_buffer = nullptr;
 
     bool d_uses_fill_value{false};
 
@@ -62,10 +62,9 @@ class SuperChunk {
     void read_fill_value_chunk();
 
 public:
-    // TODO Make the sc_id an uint64 and not a string - the code uses sstream to make the value. jhrg 5/7/22
+    // Make the sc_id an uint64 and not a string - the code uses sstream to make the value. jhrg 5/7/22
     explicit SuperChunk(const std::string &sc_id, DmrppArray *parent = nullptr) :
-            d_id(sc_id), d_parent_array(parent), d_data_url(nullptr), d_offset(0), d_size(0), d_is_read(false),
-            d_read_buffer(nullptr)
+            d_id(sc_id), d_parent_array(parent)
     {}
 
     virtual ~SuperChunk(){
@@ -97,7 +96,7 @@ public:
     virtual void process_child_chunks();
     virtual void process_child_chunks_unconstrained();
 
-    virtual bool empty(){ return d_chunks.empty(); }
+    virtual bool empty() const { return d_chunks.empty(); }
 
     std::string to_string(bool verbose) const;
     virtual void dump(std::ostream & strm) const;
@@ -114,7 +113,7 @@ struct one_chunk_args {
     DmrppArray *array;
     const vector<unsigned long long> &array_shape;
 
-    one_chunk_args(const string sc_id, std::shared_ptr<Chunk> c, DmrppArray *a, const vector<unsigned long long> &a_s)
+    one_chunk_args(const std::string &sc_id, std::shared_ptr<Chunk> c, DmrppArray *a, const std::vector<unsigned long long> &a_s)
             : parent_thread_id(std::this_thread::get_id()), parent_super_chunk_id(sc_id), chunk(std::move(c)), array(a), array_shape(a_s) {}
 };
 
@@ -131,8 +130,8 @@ struct one_chunk_unconstrained_args {
     const vector<unsigned long long> &array_shape;
     const vector<unsigned long long> &chunk_shape;
 
-    one_chunk_unconstrained_args(const string sc_id, std::shared_ptr<Chunk> c, DmrppArray *a, const vector<unsigned long long> &a_s,
-                                 const vector<unsigned long long> &c_s)
+    one_chunk_unconstrained_args(const std::string &sc_id, std::shared_ptr<Chunk> c, DmrppArray *a, const std::vector<unsigned long long> &a_s,
+                                 const std::vector<unsigned long long> &c_s)
             : parent_thread_id(std::this_thread::get_id()), parent_super_chunk_id(sc_id), chunk(std::move(c)),
             array(a), array_shape(a_s), chunk_shape(c_s) {}
 };
@@ -156,8 +155,6 @@ void process_chunks_unconstrained_concurrent_dio(
         const std::vector<unsigned long long> &chunk_shape,
         DmrppArray *array,
         const std::vector<unsigned long long> &array_shape);
-
-
 
 } // namespace dmrpp
 

--- a/modules/dmrpp_module/SuperChunk.h
+++ b/modules/dmrpp_module/SuperChunk.h
@@ -63,8 +63,10 @@ class SuperChunk {
 
 public:
     // TODO Make the sc_id an uint64 and not a string - the code uses sstream to make the value. jhrg 5/7/22
-    explicit SuperChunk(const std::string sc_id, DmrppArray *parent=nullptr):
-    d_id(sc_id), d_parent_array(parent), d_data_url(nullptr), d_offset(0), d_size(0), d_is_read(false), d_read_buffer(nullptr){}
+    explicit SuperChunk(const std::string &sc_id, DmrppArray *parent = nullptr) :
+            d_id(sc_id), d_parent_array(parent), d_data_url(nullptr), d_offset(0), d_size(0), d_is_read(false),
+            d_read_buffer(nullptr)
+    {}
 
     virtual ~SuperChunk(){
         delete[] d_read_buffer;

--- a/modules/dmrpp_module/unit-tests/CurlHandlePoolTest.cc
+++ b/modules/dmrpp_module/unit-tests/CurlHandlePoolTest.cc
@@ -416,6 +416,26 @@ public:
         DBG(cerr << prolog << "END" << endl);
     }
 
+#if 0
+Write tests for get_easy_handle() and test the signed URL below. jhrg 11/19/24
+dmrpp_easy_handle *
+CurlHandlePool::get_easy_handle(Chunk *chunk)
+
+Test using:
+https://podaac-ops-cumulus-protected.s3.us-west-2.amazonaws.com/CYGNSS_L1_V3.1/cyg03.ddmi.
+s20180801-000000-e20180801-235959.l1.power-brcs.a31.d32.nc?A-userid=jhrg&X-Amz-Algorithm=AWS4-HMAC-SHA256
+        &X-Amz-Credential=ASIAxxxxxxxxxxxxxxxxus-west-2%2Fs3%2Faws4_request
+&X-Amz-Date=20241119T222214Z
+&X-Amz-Expires=3600
+&X-Amz-Security-Token=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+&X-Amz-SignedHeaders=host
+&X-Amz-Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+#endif
+
     CPPUNIT_TEST_SUITE(CurlHandlePoolTest);
 
     CPPUNIT_TEST(process_one_chunk_test);

--- a/modules/dmrpp_module/unit-tests/CurlHandlePoolTest.cc
+++ b/modules/dmrpp_module/unit-tests/CurlHandlePoolTest.cc
@@ -25,12 +25,12 @@
 #include "config.h"
 
 #include <unistd.h>
-#include <time.h>
 
-#include <cstring>
+#include <ctime>
+//#include <cstring>
 #include <cassert>
-#include <cerrno>
-#include <list>
+//#include <cerrno>
+//#include <list>
 #include <memory>
 
 #include <queue>
@@ -56,16 +56,12 @@
 #include "CurlHandlePool.h"
 
 #include "test_config.h"
+#include "run_tests_cppunit.h"
 
 #define THREAD_SLEEP_TIME 1 // sleep time in seconds
 
 using namespace std;
 
-static bool debug = false;
-static bool bes_debug = false;
-
-#undef DBG
-#define DBG(x) do { if (debug) x; } while(false)
 #define prolog std::string("CurlHandlePoolTest::").append(__func__).append("() - ")
 
 namespace dmrpp {
@@ -78,28 +74,28 @@ public:
     MockChunk(CurlHandlePool *chp, bool sim_err) : Chunk(), d_chp(chp), d_sim_err(sim_err)
     {}
 
-    void inflate_chunk(bool, bool, unsigned int, unsigned int)
+    void inflate_chunk(bool, bool, unsigned int, unsigned int) const
     {
-        return;
+        // Do nothing
     }
 
-    virtual shared_ptr<http::url> get_data_url() const override {
-        return shared_ptr<http::url>(new  http::url("https://httpbin.org/"));
+    shared_ptr<http::url> get_data_url() const override {
+        return std::make_shared<http::url>("https://httpbin.org/");
     }
 
-    virtual unsigned long long get_bytes_read() const  override
+    unsigned long long get_bytes_read() const  override
     {
         return 2;
     }
 
-    virtual unsigned long long get_size() const  override
+    unsigned long long get_size() const  override
     {
         return 2;
     }
 
     std::vector<unsigned long long> mock_pia = {1};
 
-    virtual const std::vector<unsigned long long> &get_position_in_array() const  override
+    const std::vector<unsigned long long> &get_position_in_array() const  override
     {
         return mock_pia;
     }
@@ -120,9 +116,8 @@ public:
             throw BESInternalError(prolog + "No more libcurl handles.", __FILE__, __LINE__);
 
         try {
-            // handle->read_data();  // throws if error
             time_t t;
-            srandom(time(&t));
+            srandom((int)time(&t));
             sleep(THREAD_SLEEP_TIME);
 
             if (d_sim_err)
@@ -157,10 +152,10 @@ public:
     bool is_filters_empty() const override
     { return true; }
 
-    virtual void insert_chunk(unsigned int, vector<unsigned long long> *, vector<unsigned long long> *,
+    void insert_chunk(unsigned int, vector<unsigned long long> *, vector<unsigned long long> *,
                               shared_ptr<Chunk>, const vector<unsigned long long> &) override
     {
-        return;
+        // Do nothing
     }
 
 };
@@ -184,7 +179,6 @@ public:
         // The following will show threads joined after an exception was thrown by a thread
         chp = new CurlHandlePool();
         chp->initialize();
-        if (bes_debug) BESDebug::SetUp("cerr,dmrpp:3");
     }
 
     // Called after each test
@@ -200,12 +194,12 @@ public:
 
         CPPUNIT_ASSERT(true);
 
-        shared_ptr<Chunk> chunk(new MockChunk(chp, true));
-        auto array = new MockDmrppArray;
+        shared_ptr<Chunk> chunk(std::make_shared<MockChunk>(chp, true));
+        auto array = std::make_unique<MockDmrppArray>();
         vector<unsigned long long> array_shape = {1};
 
         try {
-            process_one_chunk(chunk, array, array_shape);
+            process_one_chunk(chunk, array.get(), array_shape);
         }
         catch (BESError &e) {
             DBG(cerr << prolog << "BES Exception: " << e.get_verbose_message() << endl);
@@ -234,20 +228,19 @@ public:
         DBG(cerr << prolog << "BEGIN" << endl);
 
         queue<shared_ptr<Chunk>> chunks_to_read;
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
 
-        //MockDmrppArray *array = new MockDmrppArray;
-        auto array = new MockDmrppArray;
+        auto array = std::make_unique<MockDmrppArray>();
         vector<unsigned long long> array_shape = {1};
 
         vector<unsigned long long> chunk_dim_sizes = {1};
         array->set_chunk_dimension_sizes(chunk_dim_sizes);
 
         try {
-            dmrpp_array_thread_control(chunks_to_read, array, array_shape);
+            dmrpp_array_thread_control(chunks_to_read, array.get(), array_shape);
         }
         catch(BESError &e) {
             CPPUNIT_FAIL(string("Caught BESError: ").append(e.get_verbose_message()));
@@ -263,16 +256,16 @@ public:
     {
         DBG(cerr << prolog << "BEGIN" << endl);
         queue<shared_ptr<Chunk>> chunks_to_read;
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, true)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, true)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
 
-        auto array = new MockDmrppArray;
+        auto array = std::make_unique<MockDmrppArray>();
         vector<unsigned long long> array_shape = {1};
 
         try {
-            dmrpp_array_thread_control(chunks_to_read, array, array_shape);
+            dmrpp_array_thread_control(chunks_to_read, array.get(), array_shape);
             CPPUNIT_FAIL("dmrpp_array_thread_control() should have thrown an exception");
         }
         catch(BESInternalError &e) {
@@ -286,18 +279,18 @@ public:
     {
         DBG(cerr << prolog << "BEGIN" << endl);
         queue<shared_ptr<Chunk>> chunks_to_read;
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, true)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, true)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
 
-        auto array = new MockDmrppArray;
+        auto array = std::make_unique<MockDmrppArray>();
         vector<unsigned long long> array_shape = {1};
 
         try {
-            dmrpp_array_thread_control(chunks_to_read, array, array_shape);
+            dmrpp_array_thread_control(chunks_to_read, array.get(), array_shape);
             CPPUNIT_FAIL("dmrpp_array_thread_control() should have thrown an exception");
         }
         catch(BESInternalError &e) {
@@ -311,19 +304,19 @@ public:
     {
         DBG(cerr << prolog << "BEGIN" << endl);
         queue<shared_ptr<Chunk>> chunks_to_read;
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, true)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, true)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, true)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, true)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
+        chunks_to_read.push(shared_ptr<Chunk>(std::make_shared<MockChunk>(chp, false)));
 
-        auto array = new MockDmrppArray;
+        auto array = std::make_unique<MockDmrppArray>();
         vector<unsigned long long> array_shape = {1};
 
         try {
-            dmrpp_array_thread_control(chunks_to_read, array, array_shape);
+            dmrpp_array_thread_control(chunks_to_read, array.get(), array_shape);
             CPPUNIT_FAIL("dmrpp_array_thread_control() should have thrown an exception");
         }
         catch(BESInternalError &e) {
@@ -338,19 +331,19 @@ public:
     {
         DBG(cerr << prolog << "BEGIN" << endl);
         queue<shared_ptr<Chunk>> chunks_to_read;
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, true)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, true)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, true));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, true));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
 
-        auto array = new MockDmrppArray;
+        auto array = std::make_unique<MockDmrppArray>();
         vector<unsigned long long> array_shape = {1};
 
         try {
-            dmrpp_array_thread_control(chunks_to_read, array, array_shape);
+            dmrpp_array_thread_control(chunks_to_read, array.get(), array_shape);
             CPPUNIT_FAIL("dmrpp_array_thread_control() should have thrown an exception");
         }
         catch(BESInternalError &e) {
@@ -365,19 +358,19 @@ public:
     {
         DBG(cerr << prolog << "BEGIN" << endl);
         queue<shared_ptr<Chunk>> chunks_to_read;
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, true)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, true)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-        chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, true));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, true));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
+        chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
 
-        auto array = new MockDmrppArray;
+        auto array = std::make_unique<MockDmrppArray>();
         vector<unsigned long long> array_shape = {1};
 
         try {
-            dmrpp_array_thread_control(chunks_to_read, array, array_shape);
+            dmrpp_array_thread_control(chunks_to_read, array.get(), array_shape);
             CPPUNIT_FAIL("dmrpp_array_thread_control() should have thrown an exception");
         }
         catch(BESInternalError &e) {
@@ -393,19 +386,19 @@ public:
         DBG(cerr << prolog << "BEGIN" << endl);
         queue<shared_ptr<Chunk>> chunks_to_read;
         for (int i = 0; i < 5; ++i) {
-            chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-            chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-            chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-            chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, true)));
-            chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, true)));
-            chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
-            chunks_to_read.push(shared_ptr<Chunk>(new MockChunk(chp, false)));
+            chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
+            chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
+            chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
+            chunks_to_read.push(std::make_shared<MockChunk>(chp, true));
+            chunks_to_read.push(std::make_shared<MockChunk>(chp, true));
+            chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
+            chunks_to_read.push(std::make_shared<MockChunk>(chp, false));
 
-            auto array = new MockDmrppArray;
+            auto array = std::make_unique<MockDmrppArray>();
             vector<unsigned long long> array_shape = {1};
 
             try {
-                dmrpp_array_thread_control(chunks_to_read, array, array_shape);
+                dmrpp_array_thread_control(chunks_to_read, array.get(), array_shape);
                 CPPUNIT_FAIL("dmrpp_array_thread_control() should have thrown an exception");
             }
             catch (BESInternalError &e) {
@@ -454,43 +447,6 @@ CPPUNIT_TEST_SUITE_REGISTRATION(CurlHandlePoolTest);
 
 } // namespace dmrpp
 
-int main(int argc, char *argv[])
-{
-    CppUnit::TextTestRunner runner;
-    runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
-
-
-    int option_char;
-    while ((option_char = getopt(argc, argv, "db")) != -1)
-        switch (option_char) {
-            case 'd':
-                debug = true;  // debug is a static global
-                break;
-            case 'b':
-                debug = true;  // debug is a static global
-                bes_debug = true;  // debug is a static global
-                break;
-            default:
-                break;
-        }
-
-    argc -= optind;
-    argv += optind;
-
-    bool wasSuccessful = true;
-    if (0 == argc) {
-        // run them all
-        wasSuccessful = runner.run("");
-    }
-    else {
-        int i = 0;
-        while (i < argc) {
-            if (debug) cerr << prolog << "Running " << argv[i] << endl;
-            string test = dmrpp::CurlHandlePoolTest::suite()->getName().append("::").append(argv[i]);
-            wasSuccessful = wasSuccessful && runner.run(test);
-            ++i;
-        }
-    }
-
-    return wasSuccessful ? 0 : 1;
+int main(int argc, char*argv[]) {
+    return bes_run_tests<dmrpp::CurlHandlePoolTest>(argc, argv, "cerr,dmrpp:3") ? 0 : 1;
 }

--- a/modules/dmrpp_module/unit-tests/DmrppArrayTest.cc
+++ b/modules/dmrpp_module/unit-tests/DmrppArrayTest.cc
@@ -61,10 +61,11 @@ namespace dmrpp {
 
 class DmrppArrayTest: public CppUnit::TestFixture {
 private:
+    dmrpp::DmrppRequestHandler *foo;
 
 public:
     DmrppArrayTest() = default;
-    ~DmrppArrayTest() = default;
+    ~DmrppArrayTest() override = default;
 
     // Called before each test
     void setUp() override
@@ -85,12 +86,13 @@ public:
 
         // Various things will gripe about this not being used... This is how the
         // CurlHandlePool gets instantiated. jhrg 4/22/22
-        auto foo = new dmrpp::DmrppRequestHandler("Chaos");
+        foo = new dmrpp::DmrppRequestHandler("Chaos");
     }
 
     // Called after each test
     void tearDown() override
     {
+        delete foo;
     }
 
     void read_contiguous_sc_test() {

--- a/modules/dmrpp_module/unit-tests/Makefile.am
+++ b/modules/dmrpp_module/unit-tests/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = foreign subdir-objects
 # TODO set these with configure. jhrg 11/26/19
 # OPENSSL_LIBS=-lcrypto
 
-AM_CPPFLAGS = $(H5_CPPFLAGS) -I$(top_srcdir)  -I$(top_srcdir)/dispatch -I$(top_srcdir)/dap \
+AM_CPPFLAGS = $(H5_CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/dispatch -I$(top_srcdir)/dap \
     -I$(top_srcdir)/http -I$(top_srcdir)/pugixml/src -I$(top_srcdir)/modules/common \
     -I$(top_srcdir)/modules/dmrpp_module $(DAP_CFLAGS)
 

--- a/modules/dmrpp_module/unit-tests/SuperChunkTest.cc
+++ b/modules/dmrpp_module/unit-tests/SuperChunkTest.cc
@@ -60,43 +60,46 @@ static string bes_conf_file = "/bes.conf";
 namespace dmrpp {
 
 class SuperChunkTest: public CppUnit::TestFixture {
-private:
+    dmrpp::DmrppRequestHandler *foo = nullptr;
 
 public:
     // Called once before everything gets tested
-    SuperChunkTest()
-    {
-    }
+    SuperChunkTest() = default;
 
     // Called at the end of the test
-    ~SuperChunkTest()
-    {
-    }
+    ~SuperChunkTest() override = default;
 
     // Called before each test
-    void setUp()
+    void setUp() override
     {
         DBG(cerr << endl);
         // Contains BES Log parameters but not cache names
         TheBESKeys::ConfigFile = string(TEST_BUILD_DIR).append("/bes.conf");
         DBG(cerr << prolog << "TheBESKeys::ConfigFile: " << TheBESKeys::ConfigFile << endl);
+#if 0
         string val;
         bool found;
         TheBESKeys::TheKeys()->get_value("ff",val,found);
+#endif
 
         if (bes_debug) BESDebug::SetUp("cerr,bes,http,curl,dmrpp");
 
-        unsigned long long int max_threads = 8;
+        unsigned int max_threads = 8;
         dmrpp::DmrppRequestHandler::d_use_transfer_threads = true;
         dmrpp::DmrppRequestHandler::d_max_transfer_threads = max_threads;
 
         // This call instantiates the curlHandlePool. jhrg 5/24/22
-        auto foo = new dmrpp::DmrppRequestHandler("Chaos");
+        foo = new dmrpp::DmrppRequestHandler("Chaos");
     }
 
     // Called after each test
-    void tearDown()
+    void tearDown() override
     {
+        delete foo;
+    }
+
+    void empty_test() {
+        CPPUNIT_ASSERT(true);
     }
 
     void sc_one_chunk_test() {
@@ -288,17 +291,12 @@ public:
                     CPPUNIT_ASSERT(chunk->get_is_read());
                     DBG(cerr << prolog << "chunk->get_bytes_read(): "<< chunk->get_bytes_read() << endl);
                     CPPUNIT_ASSERT(chunk->get_bytes_read() == 100);
-                    char *rbuf = chunk->get_rbuf();
+                    auto const *rbuf = chunk->get_rbuf();
                     for (size_t i = 0; i < 100; i++) {
-                        // DBG( cerr << prolog << "rbuf["<<i<<"]: '"<< rbuf[i] << "'" << endl);
                         CPPUNIT_ASSERT(rbuf[i] == target_is[letter_index]);
                     }
                     letter_index++;
                 }
-
-                //char target_a[] = "a";
-                //char target_test[] = "test";
-
             }
 
         }
@@ -322,6 +320,7 @@ public:
 
     CPPUNIT_TEST_SUITE( SuperChunkTest );
 
+        CPPUNIT_TEST(empty_test);
         CPPUNIT_TEST(sc_one_chunk_test);
         CPPUNIT_TEST(sc_chunks_test_01);
         CPPUNIT_TEST(sc_chunks_test_02);

--- a/modules/dmrpp_module/unit-tests/SuperChunkTest.cc
+++ b/modules/dmrpp_module/unit-tests/SuperChunkTest.cc
@@ -46,15 +46,10 @@
 #include "SuperChunk.h"
 
 #include "test_config.h"
+#include "run_tests_cppunit.h"
 
 using namespace libdap;
 
-static bool debug = false;
-static bool bes_debug = false;
-static string bes_conf_file = "/bes.conf";
-
-#undef DBG
-#define DBG(x) do { if (debug) x; } while(false)
 #define prolog std::string("SuperChunkTest::").append(__func__).append("() - ")
 
 namespace dmrpp {
@@ -76,13 +71,6 @@ public:
         // Contains BES Log parameters but not cache names
         TheBESKeys::ConfigFile = string(TEST_BUILD_DIR).append("/bes.conf");
         DBG(cerr << prolog << "TheBESKeys::ConfigFile: " << TheBESKeys::ConfigFile << endl);
-#if 0
-        string val;
-        bool found;
-        TheBESKeys::TheKeys()->get_value("ff",val,found);
-#endif
-
-        if (bes_debug) BESDebug::SetUp("cerr,bes,http,curl,dmrpp");
 
         unsigned int max_threads = 8;
         dmrpp::DmrppRequestHandler::d_use_transfer_threads = true;
@@ -102,43 +90,43 @@ public:
         CPPUNIT_ASSERT(true);
     }
 
-    void sc_one_chunk_test() {
+    void sc_one_chunk_test()
+    {
         DBG(cerr << prolog << "BEGIN" << endl);
 
         // chunked_gzipped_fourD.h5 is 2,870,087 bytes (2.9 MB on disk)
         string url_s = string("file://").append(TEST_DATA_DIR).append("/").append("chunked_gzipped_fourD.h5");
-        shared_ptr<http::url> data_url(new http::url(url_s));
+        auto data_url(std::make_shared<http::url>(url_s));
         DBG(cerr << prolog << "data_url: " << data_url << endl);
 
         string chunk_position_in_array = "[0]";
-        try  {
-            DBG( cerr << prolog << "Creating: shared_ptr<Chunk> c1" << endl);
-            shared_ptr<Chunk> c1(new Chunk(data_url, "", 1000,0,chunk_position_in_array));
+        try {
+            DBG(cerr << prolog << "Creating: shared_ptr<Chunk> c1" << endl);
+            auto c1(std::make_shared<Chunk>(data_url, "", 1000, 0, chunk_position_in_array));
             {
                 SuperChunk sc(prolog);
-                DBG( cerr << prolog << "Adding c1 to SuperChunk" << endl);
+                DBG(cerr << prolog << "Adding c1 to SuperChunk" << endl);
                 sc.add_chunk(c1);
-                DBG( cerr << prolog << "Calling SuperChunk::retrieve_data()" << endl);
+                DBG(cerr << prolog << "Calling SuperChunk::retrieve_data()" << endl);
                 sc.retrieve_data();
             }
-
         }
-        catch( BESError be){
+        catch (const BESError &be) {
             stringstream msg;
             msg << prolog << "CAUGHT BESError: " << be.get_verbose_message() << endl;
             cerr << msg.str();
             CPPUNIT_FAIL(msg.str());
         }
-        catch( std::exception se ){
+        catch (const std::exception &se) {
             stringstream msg;
             msg << "CAUGHT std::exception: " << se.what() << endl;
             cerr << msg.str();
             CPPUNIT_FAIL(msg.str());
         }
-        catch( ... ){
+        catch (...) {
             cerr << "CAUGHT Unknown Exception." << endl;
         }
-        DBG( cerr << prolog << "END" << endl);
+        DBG(cerr << prolog << "END" << endl);
     }
 
     void sc_chunks_test_01() {
@@ -146,49 +134,50 @@ public:
 
         // chunked_gzipped_fourD.h5 is 2,870,087 bytes (2.9 MB on disk)
         string url_s = string("file://").append(TEST_DATA_DIR).append("/").append("chunked_gzipped_fourD.h5");
-        shared_ptr<http::url> data_url(new http::url(url_s));
+        auto data_url(std::make_shared<http::url>(url_s));
         DBG(cerr << prolog << "data_url: " << data_url << endl);
 
         string chunk_position_in_array = "[0]";
-        try  {
-            DBG( cerr << prolog << "Creating: shared_ptr<Chunk> c1, c2, c3, c4" << endl);
-            shared_ptr<Chunk> c1(new Chunk(data_url, "", 100000,0,chunk_position_in_array));
-            shared_ptr<Chunk> c2(new Chunk(data_url, "", 100000,100000,chunk_position_in_array));
-            shared_ptr<Chunk> c3(new Chunk(data_url, "", 100000,200000,chunk_position_in_array));
-            shared_ptr<Chunk> c4(new Chunk(data_url, "", 100000,300000,chunk_position_in_array));
-
+        try {
+            DBG(cerr << prolog << "Creating: shared_ptr<Chunk> c1, c2, c3, c4" << endl);
+            auto c1 = std::make_shared<Chunk>(data_url, "", 100000, 0, chunk_position_in_array);
+            auto c2 = std::make_shared<Chunk>(data_url, "", 100000, 100000, chunk_position_in_array);
+            auto c3 = std::make_shared<Chunk>(data_url, "", 100000, 200000, chunk_position_in_array);
+            auto c4 = std::make_shared<Chunk>(data_url, "", 100000, 300000, chunk_position_in_array);
             {
                 SuperChunk sc(prolog);
                 bool chunk_was_added;
                 chunk_was_added = sc.add_chunk(c1);
-                DBG( cerr << prolog << "Chunk c1 was "<< (chunk_was_added?"":"NOT ") << "added to SuperChunk" << endl);
+                DBG(cerr << prolog << "Chunk c1 was " << (chunk_was_added ? "" : "NOT ") << "added to SuperChunk"
+                         << endl);
                 CPPUNIT_ASSERT(chunk_was_added);
 
                 chunk_was_added = sc.add_chunk(c2);
-                DBG( cerr << prolog << "Chunk c2 was "<< (chunk_was_added?"":"NOT ") << "added to SuperChunk" << endl);
+                DBG(cerr << prolog << "Chunk c2 was " << (chunk_was_added ? "" : "NOT ") << "added to SuperChunk"
+                         << endl);
                 CPPUNIT_ASSERT(chunk_was_added);
 
                 chunk_was_added = sc.add_chunk(c3);
-                DBG( cerr << prolog << "Chunk c3 was "<< (chunk_was_added?"":"NOT ") << "added to SuperChunk" << endl);
+                DBG(cerr << prolog << "Chunk c3 was " << (chunk_was_added ? "" : "NOT ") << "added to SuperChunk"
+                         << endl);
                 CPPUNIT_ASSERT(chunk_was_added);
 
                 chunk_was_added = sc.add_chunk(c4);
-                DBG( cerr << prolog << "Chunk c4 was "<< (chunk_was_added?"":"NOT ") << "added to SuperChunk" << endl);
+                DBG(cerr << prolog << "Chunk c4 was " << (chunk_was_added ? "" : "NOT ") << "added to SuperChunk"
+                         << endl);
                 CPPUNIT_ASSERT(chunk_was_added);
 
                 // Read the data
                 sc.retrieve_data();
-
             }
-
         }
-        catch( BESError &be){
+        catch(const BESError &be){
             stringstream msg;
             msg << prolog << "CAUGHT BESError: " << be.get_verbose_message() << endl;
             cerr << msg.str();
             CPPUNIT_FAIL(msg.str());
         }
-        catch( std::exception &se ){
+        catch(const std::exception &se){
             stringstream msg;
             msg << "CAUGHT std::exception message: " << se.what() << endl;
             cerr << msg.str();
@@ -197,26 +186,25 @@ public:
         DBG( cerr << prolog << "END" << endl);
     }
 
-    void sc_chunks_test_02() {
+    void sc_chunks_test_02()
+    {
         DBG(cerr << prolog << "BEGIN" << endl);
 
         // this_is_a_test.txt is 1106 bytes and contains human readable text chunk content.
         string url_s = string("file://").append(TEST_DATA_DIR).append("/").append("this_is_a_test.txt");
-        shared_ptr<http::url> data_url(new http::url(url_s));
+        auto data_url(std::make_shared<http::url>(url_s));
         DBG(cerr << prolog << "data_url: " << data_url << endl);
 
         string chunk_position_in_array = "[0]";
-        try  {
-            DBG( cerr << prolog << "Creating shared_ptr<Chunk> l1, c2, c3, c4" << endl);
-            shared_ptr<Chunk> T0(new Chunk(data_url, "", 100, 0, chunk_position_in_array));
-            shared_ptr<Chunk> h0(new Chunk(data_url, "", 100, 100, chunk_position_in_array));
-            shared_ptr<Chunk> i0(new Chunk(data_url, "", 100, 200, chunk_position_in_array));
-            shared_ptr<Chunk> s0(new Chunk(data_url, "", 100, 300, chunk_position_in_array));
-
-            shared_ptr<Chunk> i1(new Chunk(data_url, "", 100, 402, chunk_position_in_array));
-            shared_ptr<Chunk> s1(new Chunk(data_url, "", 100, 502, chunk_position_in_array));
-
-            shared_ptr<Chunk> a0(new Chunk(data_url, "", 100, 604, chunk_position_in_array));
+        try {
+            DBG(cerr << prolog << "Creating shared_ptr<Chunk> T0, h0, i0, s0, i1, s1, a0" << endl);
+            shared_ptr<Chunk> T0 = std::make_shared<Chunk>(data_url, "", 100, 0, chunk_position_in_array);
+            shared_ptr<Chunk> h0 = std::make_shared<Chunk>(data_url, "", 100, 100, chunk_position_in_array);
+            shared_ptr<Chunk> i0 = std::make_shared<Chunk>(data_url, "", 100, 200, chunk_position_in_array);
+            shared_ptr<Chunk> s0 = std::make_shared<Chunk>(data_url, "", 100, 300, chunk_position_in_array);
+            shared_ptr<Chunk> i1 = std::make_shared<Chunk>(data_url, "", 100, 402, chunk_position_in_array);
+            shared_ptr<Chunk> s1 = std::make_shared<Chunk>(data_url, "", 100, 502, chunk_position_in_array);
+            shared_ptr<Chunk> a0 = std::make_shared<Chunk>(data_url, "", 100, 604, chunk_position_in_array);
 #if 0
             // Don't need these yet but, i typed them...
             shared_ptr<Chunk> t0(new Chunk(data_url, "", 100, 706, chunk_position_in_array));
@@ -225,71 +213,80 @@ public:
             shared_ptr<Chunk> t2(new Chunk(data_url, "", 100, 1006, chunk_position_in_array));
 #endif
             {
-
-                SuperChunk word_a(prolog+"word_a");
-                SuperChunk word_test(prolog+"word_test");
+                SuperChunk word_a(prolog + "word_a");
+                SuperChunk word_test(prolog + "word_test");
                 bool chunk_was_added;
 
-                SuperChunk word_this(prolog+"word_this");
+                SuperChunk word_this(prolog + "word_this");
                 chunk_was_added = word_this.add_chunk(T0);
-                DBG( cerr << prolog << "Chunk T0 was "<< (chunk_was_added?"":"NOT ") << "added to SuperChunk word_this" << endl);
+                DBG(cerr << prolog << "Chunk T0 was " << (chunk_was_added ? "" : "NOT ")
+                         << "added to SuperChunk word_this" << endl);
                 CPPUNIT_ASSERT(chunk_was_added);
 
                 chunk_was_added = word_this.add_chunk(h0);
-                DBG( cerr << prolog << "Chunk h0 was "<< (chunk_was_added?"":"NOT ") << "added to SuperChunk word_this" << endl);
+                DBG(cerr << prolog << "Chunk h0 was " << (chunk_was_added ? "" : "NOT ")
+                         << "added to SuperChunk word_this" << endl);
                 CPPUNIT_ASSERT(chunk_was_added);
 
                 chunk_was_added = word_this.add_chunk(i0);
-                DBG( cerr << prolog << "Chunk i0 was "<< (chunk_was_added?"":"NOT ") << "added to SuperChunk word_this" << endl);
+                DBG(cerr << prolog << "Chunk i0 was " << (chunk_was_added ? "" : "NOT ")
+                         << "added to SuperChunk word_this" << endl);
                 CPPUNIT_ASSERT(chunk_was_added);
 
                 chunk_was_added = word_this.add_chunk(s0);
-                DBG( cerr << prolog << "Chunk s0 was "<< (chunk_was_added?"":"NOT ") << "added to SuperChunk word_this" << endl);
+                DBG(cerr << prolog << "Chunk s0 was " << (chunk_was_added ? "" : "NOT ")
+                         << "added to SuperChunk word_this" << endl);
                 CPPUNIT_ASSERT(chunk_was_added);
 
                 // The i1 chunk is not contiguous with s0 and should be rejected by the word_this SuperChunk.
                 chunk_was_added = word_this.add_chunk(i1);
-                DBG( cerr << prolog << "Chunk i1 was "<< (chunk_was_added?"":"NOT ") << "added to SuperChunk word_this" << endl);
+                DBG(cerr << prolog << "Chunk i1 was " << (chunk_was_added ? "" : "NOT ")
+                         << "added to SuperChunk word_this" << endl);
                 CPPUNIT_ASSERT(!chunk_was_added);
 
                 word_this.retrieve_data();
                 char target_this[] = "This";
-                size_t letter_index=0;
-                for(const auto& chunk: word_this.d_chunks) {
-                    DBG(cerr << prolog << "Checking chunk for target char '"<< target_this[letter_index] << "'" << endl);
-                    DBG(cerr << prolog << "chunk->get_is_read(): "<< (chunk->get_is_read()?"true":"false") << endl);
+                size_t letter_index = 0;
+                for (const auto &chunk: word_this.d_chunks) {
+                    DBG(cerr << prolog << "Checking chunk for target char '" << target_this[letter_index] << "'"
+                             << endl);
+                    DBG(cerr << prolog << "chunk->get_is_read(): " << (chunk->get_is_read() ? "true" : "false")
+                             << endl);
                     CPPUNIT_ASSERT(chunk->get_is_read());
-                    DBG(cerr << prolog << "chunk->get_bytes_read(): "<< chunk->get_bytes_read() << endl);
+                    DBG(cerr << prolog << "chunk->get_bytes_read(): " << chunk->get_bytes_read() << endl);
                     CPPUNIT_ASSERT(chunk->get_bytes_read() == 100);
                     char *rbuf = chunk->get_rbuf();
                     for (size_t i = 0; i < 100; i++) {
-                        // DBG( cerr << prolog << "rbuf["<<i<<"]: '"<< rbuf[i] << "'" << endl);
                         CPPUNIT_ASSERT(rbuf[i] == target_this[letter_index]);
                     }
                     letter_index++;
                 }
-                SuperChunk word_is(prolog+"word_is");
+                SuperChunk word_is(prolog + "word_is");
                 chunk_was_added = word_is.add_chunk(i1);
-                DBG( cerr << prolog << "Chunk i1 was "<< (chunk_was_added?"":"NOT ") << "added to SuperChunk word_is" << endl);
+                DBG(cerr << prolog << "Chunk i1 was " << (chunk_was_added ? "" : "NOT ")
+                         << "added to SuperChunk word_is" << endl);
                 CPPUNIT_ASSERT(chunk_was_added);
 
                 chunk_was_added = word_is.add_chunk(s1);
-                DBG( cerr << prolog << "Chunk s1 was "<< (chunk_was_added?"":"NOT ") << "added to SuperChunk word_is" << endl);
+                DBG(cerr << prolog << "Chunk s1 was " << (chunk_was_added ? "" : "NOT ")
+                         << "added to SuperChunk word_is" << endl);
                 CPPUNIT_ASSERT(chunk_was_added);
 
                 // The a0 chunk is not contiguous with s1 and should be rejected by the word_is SuperChunk.
                 chunk_was_added = word_is.add_chunk(a0);
-                DBG( cerr << prolog << "Chunk a0 was "<< (chunk_was_added?"":"NOT ") << "added to SuperChunk word_is" << endl);
+                DBG(cerr << prolog << "Chunk a0 was " << (chunk_was_added ? "" : "NOT ")
+                         << "added to SuperChunk word_is" << endl);
                 CPPUNIT_ASSERT(!chunk_was_added);
 
                 word_is.retrieve_data();
                 char target_is[] = "is";
-                letter_index=0;
-                for(const auto& chunk: word_is.d_chunks) {
-                    DBG(cerr << prolog << "Checking chunk for target char '"<< target_is[letter_index] << "'" << endl);
-                    DBG(cerr << prolog << "chunk->get_is_read(): "<< (chunk->get_is_read()?"true":"false") << endl);
+                letter_index = 0;
+                for (const auto &chunk: word_is.d_chunks) {
+                    DBG(cerr << prolog << "Checking chunk for target char '" << target_is[letter_index] << "'" << endl);
+                    DBG(cerr << prolog << "chunk->get_is_read(): " << (chunk->get_is_read() ? "true" : "false")
+                             << endl);
                     CPPUNIT_ASSERT(chunk->get_is_read());
-                    DBG(cerr << prolog << "chunk->get_bytes_read(): "<< chunk->get_bytes_read() << endl);
+                    DBG(cerr << prolog << "chunk->get_bytes_read(): " << chunk->get_bytes_read() << endl);
                     CPPUNIT_ASSERT(chunk->get_bytes_read() == 100);
                     auto const *rbuf = chunk->get_rbuf();
                     for (size_t i = 0; i < 100; i++) {
@@ -300,22 +297,22 @@ public:
             }
 
         }
-        catch( BESError be){
+        catch (const BESError &be) {
             stringstream msg;
             msg << prolog << "CAUGHT BESError: " << be.get_verbose_message() << endl;
             cerr << msg.str();
             CPPUNIT_FAIL(msg.str());
         }
-        catch( std::exception se ){
+        catch (const std::exception &se) {
             stringstream msg;
             msg << "CAUGHT std::exception: " << se.what() << endl;
             cerr << msg.str();
             CPPUNIT_FAIL(msg.str());
         }
-        catch( ... ){
+        catch (...) {
             cerr << "CAUGHT Unknown Exception." << endl;
         }
-        DBG( cerr << prolog << "END" << endl);
+        DBG(cerr << prolog << "END" << endl);
     }
 
     CPPUNIT_TEST_SUITE( SuperChunkTest );
@@ -331,6 +328,12 @@ public:
 CPPUNIT_TEST_SUITE_REGISTRATION(SuperChunkTest);
 
 } // namespace dmrpp
+
+int main(int argc, char *argv[]) {
+    return bes_run_tests<dmrpp::SuperChunkTest>(argc, argv, "cerr,bes,http,curl,dmrpp") ? 0 : 1;
+}
+
+#if 0
 
 int main(int argc, char*argv[])
 {
@@ -372,3 +375,5 @@ int main(int argc, char*argv[])
 
     return wasSuccessful ? 0 : 1;
 }
+
+#endif


### PR DESCRIPTION
There is an annoying and generally useless info message that is coming out of CurlHandlePool - remove it.

As it turns out, this is true, but also there was some copy-pasta code that duplicated code un CurlUtils. The 
CurlHandlePool code was refactored to use the library function and some other clean up was performed. 

Sonar lint has found 61 smells in this and related code, so there will be some more work on this PR.