### PR TITLE
No longer log get requests using "return as dap2" for DAP4 responses.

### DIFF
--- a/dap/BESDapModule.cc
+++ b/dap/BESDapModule.cc
@@ -102,17 +102,17 @@ void BESDapModule::initialize(const string &modname)
 	BESDEBUG("dap", "Adding " << OPENDAP_SERVICE << " services:" << endl);
 	BESServiceRegistry *registry = BESServiceRegistry::TheRegistry();
 	registry->add_service(OPENDAP_SERVICE);
-	registry->add_to_service(OPENDAP_SERVICE, DAS_SERVICE, DAS_DESCRIPT, DAP2_FORMAT);
-	registry->add_to_service(OPENDAP_SERVICE, DDS_SERVICE, DDS_DESCRIPT, DAP2_FORMAT);
-	registry->add_to_service(OPENDAP_SERVICE, DDX_SERVICE, DDX_DESCRIPT, DAP2_FORMAT);
-	registry->add_to_service(OPENDAP_SERVICE, DATA_SERVICE, DATA_DESCRIPT, DAP2_FORMAT);
-	registry->add_to_service(OPENDAP_SERVICE, DATADDX_SERVICE, DATADDX_DESCRIPT, DAP2_FORMAT);
+	registry->add_to_service(OPENDAP_SERVICE, DAS_SERVICE, DAS_DESCRIPT, DAP_FORMAT);
+	registry->add_to_service(OPENDAP_SERVICE, DDS_SERVICE, DDS_DESCRIPT, DAP_FORMAT);
+	registry->add_to_service(OPENDAP_SERVICE, DDX_SERVICE, DDX_DESCRIPT, DAP_FORMAT);
+	registry->add_to_service(OPENDAP_SERVICE, DATA_SERVICE, DATA_DESCRIPT, DAP_FORMAT);
+	registry->add_to_service(OPENDAP_SERVICE, DATADDX_SERVICE, DATADDX_DESCRIPT, DAP_FORMAT);
 
-	registry->add_to_service(OPENDAP_SERVICE, DMR_SERVICE, DMR_DESCRIPT, DAP2_FORMAT);
-	registry->add_to_service(OPENDAP_SERVICE, DAP4DATA_SERVICE, DAP4DATA_DESCRIPT, DAP2_FORMAT);
+	registry->add_to_service(OPENDAP_SERVICE, DMR_SERVICE, DMR_DESCRIPT, DAP_FORMAT);
+	registry->add_to_service(OPENDAP_SERVICE, DAP4DATA_SERVICE, DAP4DATA_DESCRIPT, DAP_FORMAT);
 
 	BESDEBUG("dap", "Initializing DAP Basic Transmitters:" << endl);
-	BESReturnManager::TheManager()->add_transmitter(DAP2_FORMAT, new BESDapTransmit());
+	BESReturnManager::TheManager()->add_transmitter(DAP_FORMAT, new BESDapTransmit());
 	// TODO ?? BESReturnManager::TheManager()->add_transmitter( DAP4_FORMAT, new BESDapTransmit( ) );
 
     BESDEBUG("dap", "    adding DAP Utility Function 'wrapitup'()" << endl);
@@ -154,7 +154,7 @@ void BESDapModule::terminate(const string &modname)
 	BESRequestHandler *rh = BESRequestHandlerList::TheList()->remove_handler(modname);
 	if (rh) delete rh;
 
-	BESReturnManager::TheManager()->del_transmitter(DAP2_FORMAT);
+	BESReturnManager::TheManager()->del_transmitter(DAP_FORMAT);
 	// TODO ?? BESReturnManager::TheManager()->del_transmitter( DAP4_FORMAT );
 
 	BESDEBUG("dap", "Done Removing DAP Modules:" << endl);

--- a/dap/BESDapNames.h
+++ b/dap/BESDapNames.h
@@ -50,7 +50,6 @@
  */
 
 #define OPENDAP_SERVICE "dap"
-#define DAP_FORMAT "dap2"
 
 // Use this to indicate that the BESDapModule should be used; it will then use the DAP2 or DAP4 format as appropriate.
 // jhrg 1/6/25

--- a/dap/BESDapNames.h
+++ b/dap/BESDapNames.h
@@ -50,7 +50,7 @@
  */
 
 #define OPENDAP_SERVICE "dap"
-#define DAP2_FORMAT "dap2"
+#define DAP_FORMAT "dap2"
 
 // Use this to indicate that the BESDapModule should be used; it will then use the DAP2 or DAP4 format as appropriate.
 // jhrg 1/6/25

--- a/dap/BESDapNames.h
+++ b/dap/BESDapNames.h
@@ -52,6 +52,10 @@
 #define OPENDAP_SERVICE "dap"
 #define DAP2_FORMAT "dap2"
 
+// Use this to indicate that the BESDapModule should be used; it will then use the DAP2 or DAP4 format as appropriate.
+// jhrg 1/6/25
+#define DAP_FORMAT "dap"
+
 #define DAS_RESPONSE "get.das"
 #define DAS_SERVICE "das"
 #define DAS_DESCRIPT "OPeNDAP Data Attribute Structure"

--- a/dap/BESDapService.cc
+++ b/dap/BESDapService.cc
@@ -47,6 +47,6 @@ void
 BESDapService::add_to_dap_service( const string &cmd, const string &desc )
 {
     BESServiceRegistry *registry = BESServiceRegistry::TheRegistry() ;
-    registry->add_to_service( OPENDAP_SERVICE, cmd, desc, DAP2_FORMAT ) ;
+    registry->add_to_service( OPENDAP_SERVICE, cmd, desc, DAP_FORMAT ) ;
 }
 

--- a/modules/usage/BESUsageModule.cc
+++ b/modules/usage/BESUsageModule.cc
@@ -79,7 +79,7 @@ BESUsageModule::initialize( const string &modname )
     BESDapService::add_to_dap_service( Usage_SERVICE,
 				       "OPeNDAP Data Information Page" ) ;
 
-    BESTransmitter *t = BESReturnManager::TheManager()->find_transmitter( DAP2_FORMAT ) ;
+    BESTransmitter *t = BESReturnManager::TheManager()->find_transmitter( DAP_FORMAT ) ;
     if( t )
     {
 	BESDEBUG( "usage", "    adding basic " << Usage_TRANSMITTER
@@ -110,7 +110,7 @@ BESUsageModule::terminate( const string &modname )
     BESResponseHandlerList::TheList()->remove_handler( Usage_RESPONSE ) ;
 
     BESTransmitter *t =
-	BESReturnManager::TheManager()->find_transmitter( DAP2_FORMAT ) ;
+	BESReturnManager::TheManager()->find_transmitter( DAP_FORMAT ) ;
     if( t )
     {
 	BESDEBUG( "usage", "    removing basic " << Usage_TRANSMITTER
@@ -118,7 +118,7 @@ BESUsageModule::terminate( const string &modname )
 	t->remove_method( Usage_TRANSMITTER ) ;
     }
 
-    t = BESReturnManager::TheManager()->find_transmitter( DAP2_FORMAT ) ;
+    t = BESReturnManager::TheManager()->find_transmitter( DAP_FORMAT ) ;
     if( t )
     {
 	BESDEBUG( "usage", "    removing http " << Usage_TRANSMITTER

--- a/modules/www-interface/BESWWWModule.cc
+++ b/modules/www-interface/BESWWWModule.cc
@@ -58,7 +58,7 @@ using std::string;
 
 #include "BESXMLWWWGetCommand.h"
 
-void BESWWWModule::initialize(const string & modname)
+void BESWWWModule::initialize(const string &modname)
 {
     BESDEBUG("www", "Initializing OPeNDAP WWW module " << modname << endl);
 
@@ -69,19 +69,19 @@ void BESWWWModule::initialize(const string & modname)
 
     BESDapService::add_to_dap_service(WWW_SERVICE, "OPeNDAP HTML Form for data constraints and access");
 
-    BESTransmitter *t = BESReturnManager::TheManager()->find_transmitter( DAP2_FORMAT);
+    BESTransmitter *t = BESReturnManager::TheManager()->find_transmitter(DAP_FORMAT);
     if (t) {
-        t->add_method( WWW_TRANSMITTER, BESWWWTransmit::send_basic_form);
+        t->add_method(WWW_TRANSMITTER, BESWWWTransmit::send_basic_form);
     }
 
-    BESXMLCommand::add_command( WWW_RESPONSE, BESXMLWWWGetCommand::CommandBuilder);
+    BESXMLCommand::add_command(WWW_RESPONSE, BESXMLWWWGetCommand::CommandBuilder);
 
     BESDebug::Register("www");
 
     BESDEBUG("www", "Done Initializing OPeNDAP WWW module " << modname << endl);
 }
 
-void BESWWWModule::terminate(const string & modname)
+void BESWWWModule::terminate(const string &modname)
 {
     BESDEBUG("www", "Cleaning OPeNDAP WWW module " << modname << endl);
 
@@ -90,14 +90,14 @@ void BESWWWModule::terminate(const string & modname)
 
     BESResponseHandlerList::TheList()->remove_handler(WWW_RESPONSE);
 
-    BESXMLCommand::del_command( WWW_RESPONSE);
+    BESXMLCommand::del_command(WWW_RESPONSE);
 
-    BESTransmitter *t = BESReturnManager::TheManager()->find_transmitter( DAP2_FORMAT);
+    BESTransmitter *t = BESReturnManager::TheManager()->find_transmitter(DAP_FORMAT);
     if (t) {
         t->remove_method(WWW_TRANSMITTER);
     }
 
-    t = BESReturnManager::TheManager()->find_transmitter( DAP2_FORMAT);
+    t = BESReturnManager::TheManager()->find_transmitter(DAP_FORMAT);
     if (t) {
         t->remove_method(WWW_TRANSMITTER);
     }
@@ -111,7 +111,7 @@ void BESWWWModule::terminate(const string & modname)
  *
  * @param strm C++ i/o stream to dump the information to
  */
-void BESWWWModule::dump(ostream & strm) const
+void BESWWWModule::dump(ostream &strm) const
 {
     strm << BESIndent::LMarg << "BESWWWModule::dump - (" << (void *) this << ")" << endl;
 }

--- a/modules/xml_data_handler/BESXDModule.cc
+++ b/modules/xml_data_handler/BESXDModule.cc
@@ -62,7 +62,7 @@ void BESXDModule::initialize(const string &modname)
 
     BESDapService::add_to_dap_service(XD_SERVICE, "OPeNDAP xml data representation");
 
-    BESTransmitter *t = BESReturnManager::TheManager()->find_transmitter(DAP2_FORMAT);
+    BESTransmitter *t = BESReturnManager::TheManager()->find_transmitter(DAP_FORMAT);
     if (t)
         t->add_method(XD_TRANSMITTER, BESXDTransmit::send_basic_ascii);
 
@@ -81,11 +81,11 @@ void BESXDModule::terminate(const string &modname)
 
     BESResponseHandlerList::TheList()->remove_handler(XD_RESPONSE);
 
-    BESTransmitter *t = BESReturnManager::TheManager()->find_transmitter(DAP2_FORMAT);
+    BESTransmitter *t = BESReturnManager::TheManager()->find_transmitter(DAP_FORMAT);
     if (t)
         t->remove_method(XD_TRANSMITTER);
 
-    t = BESReturnManager::TheManager()->find_transmitter(DAP2_FORMAT);
+    t = BESReturnManager::TheManager()->find_transmitter(DAP_FORMAT);
     if (t)
         t->remove_method(XD_TRANSMITTER);
 

--- a/xmlcommand/BESXMLGetCommand.cc
+++ b/xmlcommand/BESXMLGetCommand.cc
@@ -133,25 +133,39 @@ void BESXMLGetCommand::parse_basic_get(const string &type, map<string, string> &
     if (_definition.empty())
         throw BESSyntaxUserError("get command: Must specify definition", __FILE__, __LINE__);
 
-    // TODO Lookup the definition and get the container. Then lookup the container and
-    //   get the path and constraint. jhrg 11/14/17
     d_cmd_log_info.append(" for ").append(_definition);
 
     _space = props["space"];
 
     if (!_space.empty()) d_cmd_log_info.append(" in ").append(_space);
 
+#if 0
     string returnAs = props["returnAs"];
     if (returnAs.empty()) {
         returnAs = DAP2_FORMAT;
     }
+#endif
 
-    d_xmlcmd_dhi.data[RETURN_CMD] = returnAs;
+    // This is a holdover from before there was DAP4. An empty 'return as' value means
+    // 'return a DAP response'. If the value is not empty, then it's the name of the
+    // file format like netCDF4. jhrg 1/6/25
+    if (props["returnAs"].empty()) {
+        d_xmlcmd_dhi.data[RETURN_CMD] = DAP2_FORMAT;
+    }
+    else {
+        d_xmlcmd_dhi.data[RETURN_CMD] = props["returnAs"];
+    }
+
+    if (!props["returnAs"].empty()) {
+        d_cmd_log_info.append(" return as ").append(props["returnAs"]);
+    }
+
+#if 0
+    d_cmd_log_info.append(" return as ").append(returnAs);
+#endif
 
     d_xmlcmd_dhi.data[STORE_RESULT] = props[STORE_RESULT];
     d_xmlcmd_dhi.data[ASYNC] = props[ASYNC];
-
-    d_cmd_log_info.append(" return as ").append(returnAs);
 
     d_xmlcmd_dhi.action = "get.";
     d_xmlcmd_dhi.action.append(BESUtil::lowercase(type));

--- a/xmlcommand/BESXMLGetCommand.cc
+++ b/xmlcommand/BESXMLGetCommand.cc
@@ -139,18 +139,11 @@ void BESXMLGetCommand::parse_basic_get(const string &type, map<string, string> &
 
     if (!_space.empty()) d_cmd_log_info.append(" in ").append(_space);
 
-#if 0
-    string returnAs = props["returnAs"];
-    if (returnAs.empty()) {
-        returnAs = DAP2_FORMAT;
-    }
-#endif
-
-    // This is a holdover from before there was DAP4. An empty 'return as' value means
-    // 'return a DAP response'. If the value is not empty, then it's the name of the
-    // file format like netCDF4. jhrg 1/6/25
+    // An empty 'return as' value means 'return a DAP response'. The DAP Module handles
+    // both versions of the protocol. If the value is not empty,  then it's the name of
+    // the file format like netCDF4. jhrg 1/6/25
     if (props["returnAs"].empty()) {
-        d_xmlcmd_dhi.data[RETURN_CMD] = DAP2_FORMAT;
+        d_xmlcmd_dhi.data[RETURN_CMD] = DAP_FORMAT;
     }
     else {
         d_xmlcmd_dhi.data[RETURN_CMD] = props["returnAs"];
@@ -159,10 +152,6 @@ void BESXMLGetCommand::parse_basic_get(const string &type, map<string, string> &
     if (!props["returnAs"].empty()) {
         d_cmd_log_info.append(" return as ").append(props["returnAs"]);
     }
-
-#if 0
-    d_cmd_log_info.append(" return as ").append(returnAs);
-#endif
 
     d_xmlcmd_dhi.data[STORE_RESULT] = props[STORE_RESULT];
     d_xmlcmd_dhi.data[ASYNC] = props[ASYNC];


### PR DESCRIPTION
This has been bugging me for a long time and I thought I'd knock it out. The first of two commits.