### PR TITLE
Fixes to error reporting

### DIFF
--- a/dispatch/BESError.h
+++ b/dispatch/BESError.h
@@ -70,7 +70,6 @@ private:
     std::string _file;
     unsigned int _line{0};
 
-
 public:
     BESError() = default;
 

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -785,6 +785,8 @@ process_http_code_helper(const long http_code, const string &requested_url, cons
         case 408: // Request Timeout
         {
             // These issues are not considered retryable problems, so we throw immediately.
+            // TODO Remove this redundant call to ERROR_LOG since the thrown exception is
+            //  logged as an error. jhrg 1/24/25
             ERROR_LOG(msg.str());
             throw http::HttpError(msg.str(),
                                   CURLE_OK,

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -69,6 +69,8 @@ using namespace std;
 
 namespace curl {
 
+static void super_easy_perform(CURL *c_handle, int fd);
+
 const unsigned int retry_limit = 3; // 10; // Amazon's suggestion
 const useconds_t url_retry_time = 250'000; // 1/4 second in micro seconds
 
@@ -949,7 +951,34 @@ static void truncate_file(int fd) {
                                __FILE__, __LINE__);
 }
 
-// Used here only. jhrg 3/8/23
+// used only in one place here. jhrg 3/8/23
+/**
+ * @brief Performs a curl_easy_perform(), retrying if certain types of errors are encountered.
+ *
+ * @note Used in dmrpp_module and by three functions here (http_get, http_get, and
+ * retrieve_effective_url). jhrg 3/8/23
+ *
+ * This function contains the operational frame work and state checking for performing retries of
+ * failed requests as necessary.
+ *
+ * The code that contains the state assessment is held in the functions
+ * - curl::eval_curl_easy_perform_code()
+ * - curl::eval_http_get_response()
+ *
+ * These functions have a tri-state behavior:
+ *   - If the assessed operation was a success they return true.
+ *   - If the assessed operation had what is considered a retryable failure, they return false.
+ *   - If the assessed operation had any other failure, a BESInternalError is thrown.
+ * These functions are used in the retry logic of this curl::super_easy_perform() to
+ * determine when there was success, when to keep trying, and if to give up.
+ *
+ * @param c_handle The CURL easy handle on which to operate
+ */
+void super_easy_perform(CURL *c_handle) {
+    int fd = -1;
+    super_easy_perform(c_handle, fd);
+}
+
 static void super_easy_perform(CURL *c_handle, int fd) {
     BESDEBUG(MODULE, prolog << "BEGIN\n");
 
@@ -998,7 +1027,7 @@ static void super_easy_perform(CURL *c_handle, int fd) {
                 msg << filter_aws_url(target_url) << " The retry limit has been exceeded. Giving up! ";
                 msg << "CURLINFO_EFFECTIVE_URL: " << effective_url << " ";
                 msg << "Returned HTTP_STATUS: " << http_code;
-                ERROR_LOG(msg.str());
+                // Remove redundant error log entryvERROR_LOG(msg.str());
                 throw HttpError(msg.str(),
                                 curl_code,
                                 http_code,
@@ -1006,7 +1035,7 @@ static void super_easy_perform(CURL *c_handle, int fd) {
                                 effective_url,
                                 __FILE__, __LINE__);
             } else {
-                ERROR_LOG(prolog + "ERROR - Problem with data transfer. Will retry (url: "
+                INFO_LOG(prolog + "Problem with data transfer. Will retry (url: "
                                  + filter_aws_url(target_url) + " attempt: " + std::to_string(attempts) + "). "
                                  + "CURLINFO_EFFECTIVE_URL: " + effective_url + " "
                                  + "Returned HTTP_STATUS: " + std::to_string(http_code));
@@ -1220,33 +1249,6 @@ void http_get(const string &target_url, string &buf) {
         throw;
     }
     BESDEBUG(MODULE, prolog << "END\n");
-}
-
-/**
- * @brief Performs a curl_easy_perform(), retrying if certain types of errors are encountered.
- *
- * @note Used in dmrpp_module and by three functions here (http_get, http_get, and
- * retrieve_effective_url). jhrg 3/8/23
- *
- * This function contains the operational frame work and state checking for performing retries of
- * failed requests as necessary.
- *
- * The code that contains the state assessment is held in the functions
- * - curl::eval_curl_easy_perform_code()
- * - curl::eval_http_get_response()
- *
- * These functions have a tri-state behavior:
- *   - If the assessed operation was a success they return true.
- *   - If the assessed operation had what is considered a retryable failure, they return false.
- *   - If the assessed operation had any other failure, a BESInternalError is thrown.
- * These functions are used in the retry logic of this curl::super_easy_perform() to
- * determine when there was success, when to keep trying, and if to give up.
- *
- * @param c_handle The CURL easy handle on which to operate
- */
-void super_easy_perform(CURL *c_handle) {
-    int fd = -1;
-    super_easy_perform(c_handle, fd);
 }
 
 // used only in one place here. jhrg 3/8/23

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -785,9 +785,9 @@ process_http_code_helper(const long http_code, const string &requested_url, cons
         case 408: // Request Timeout
         {
             // These issues are not considered retryable problems, so we throw immediately.
-            // TODO Remove this redundant call to ERROR_LOG since the thrown exception is
+            // Remove this redundant call to ERROR_LOG since the thrown exception is
             //  logged as an error. jhrg 1/24/25
-            ERROR_LOG(msg.str());
+            // ERROR_LOG(msg.str());
             throw http::HttpError(msg.str(),
                                   CURLE_OK,
                                   http_code,
@@ -820,7 +820,7 @@ process_http_code_helper(const long http_code, const string &requested_url, cons
             break;
 
         default:
-            ERROR_LOG(msg.str());
+            // ERROR_LOG(msg.str());
             throw BESInternalError(msg.str(), __FILE__, __LINE__);
     }
 }

--- a/http/HttpError.h
+++ b/http/HttpError.h
@@ -41,7 +41,7 @@ namespace http {
 
 class HttpError : public BESError {
     CURLcode d_curl_code = CURLE_OK;
-    long d_http_status;
+    long d_http_status = 200; // TODO Keep this '200'? See the ctor below which fails to init this field. jhrg 1/24/25
     std::string d_origin_url;
     std::string d_redirect_url;
     std::vector<std::string> d_response_headers;

--- a/http/HttpError.h
+++ b/http/HttpError.h
@@ -41,7 +41,7 @@ namespace http {
 
 class HttpError : public BESError {
     CURLcode d_curl_code = CURLE_OK;
-    long d_http_status = 200; // TODO Keep this '200'? See the ctor below which fails to init this field. jhrg 1/24/25
+    long d_http_status = 200;
     std::string d_origin_url;
     std::string d_redirect_url;
     std::vector<std::string> d_response_headers;
@@ -84,7 +84,7 @@ public:
     HttpError(std::string msg, std::string file, unsigned int line) :
             BESError(std::move(msg), BES_HTTP_ERROR, std::move(file), line) {}
 
-    HttpError(const HttpError &src) = default;
+    HttpError(const HttpError &src) noexcept = default;
 
     ~HttpError() override = default;
 

--- a/http/HttpError.h
+++ b/http/HttpError.h
@@ -80,11 +80,10 @@ public:
             d_origin_url(origin_url),
             d_redirect_url(redirect_url) {};
 
-
     HttpError(std::string msg, std::string file, unsigned int line) :
             BESError(std::move(msg), BES_HTTP_ERROR, std::move(file), line) {}
 
-    HttpError(const HttpError &src) noexcept = default;
+    HttpError(const HttpError &src) = default;
 
     ~HttpError() override = default;
 

--- a/modules/ngap_module/NgapApi.cc
+++ b/modules/ngap_module/NgapApi.cc
@@ -425,10 +425,11 @@ string NgapApi::convert_ngap_resty_path_to_data_access_url(const std::string &re
     }
     catch (http::HttpError &http_error) {
         string err_msg = prolog + "Hyrax encountered a Service Chaining Error while "
-                         "attempting to retrieve a CMR record.\n" + http_error.get_message();
+                         "attempting to retrieve a CMR record. " + http_error.get_message();
         http_error.set_message(err_msg);
         throw;
     }
+
     rapidjson::Document cmr_response;
     cmr_response.Parse(cmr_json_string.c_str());
     data_access_url = find_get_data_url_in_granules_umm_json_v1_4(restified_path, cmr_response);

--- a/modules/ngap_module/NgapApi.cc
+++ b/modules/ngap_module/NgapApi.cc
@@ -291,23 +291,23 @@ std::string NgapApi::build_cmr_query_url(const std::string &restified_path) {
  *  1. A TYPE of Type 'GET DATA' with a URL that uses the https:// protocol where that URL does
  *  not end in 'xml'. The latter characteristic was added for records added by LPDAAC. jhrg 5/22/24
  *
- * @param restified_path The restified path used to form the CMR query (only used for error messages)
+ * @param rest_path The REST path used to form the CMR query (only used for error messages)
  * @param cmr_granules The CMR response (granules.umm_json_v1_4) to evaluate
  * @return  The "GET DATA" URL for the granule.
  */
-std::string NgapApi::find_get_data_url_in_granules_umm_json_v1_4(const std::string &restified_path,
+std::string NgapApi::find_get_data_url_in_granules_umm_json_v1_4(const std::string &rest_path,
                                                                  rapidjson::Document &cmr_granule_response) {
     const rapidjson::Value &val = cmr_granule_response["hits"];
     int hits = val.GetInt();
     if (hits < 1) {
-        throw BESNotFoundError(string("The specified path '") + restified_path
-                + "' does not identify a granule in CMR.", __FILE__, __LINE__);
+        throw BESNotFoundError(string("The specified path '") + rest_path
+                               + "' does not identify a granule in CMR.", __FILE__, __LINE__);
     }
 
     rapidjson::Value &items = cmr_granule_response["items"];
     if (!items.IsArray()) {
         throw BESInternalError(string("ERROR! The CMR response did not contain the data URL information: ")
-                               + restified_path, __FILE__, __LINE__);
+                               + rest_path, __FILE__, __LINE__);
     } else {
         // Search the items array for the first item that contains a RelatedUrls array
         if (BESISDEBUG(MODULE)) {
@@ -381,7 +381,7 @@ std::string NgapApi::find_get_data_url_in_granules_umm_json_v1_4(const std::stri
         }
 
         if (data_access_url.empty()) {
-            throw BESInternalError(string("ERROR! Failed to locate a data access URL for the path: ") + restified_path,
+            throw BESInternalError(string("ERROR! Failed to locate a data access URL for the path: ") + rest_path,
                                    __FILE__, __LINE__);
         }
 

--- a/modules/ngap_module/NgapApi.h
+++ b/modules/ngap_module/NgapApi.h
@@ -47,7 +47,7 @@ namespace ngap {
 class NgapApi {
 private:
     static std::string get_cmr_search_endpoint_url();
-    static std::string find_get_data_url_in_granules_umm_json_v1_4(const std::string &restified_path,
+    static std::string find_get_data_url_in_granules_umm_json_v1_4(const std::string &rest_path,
                                                                    rapidjson::Document &cmr_granule_response);
     static std::string build_cmr_query_url(const std::string &restified_path);
     static std::string build_cmr_query_url_old_rpath_format(const std::string &restified_path);

--- a/modules/ngap_module/NgapOwnedContainer.cc
+++ b/modules/ngap_module/NgapOwnedContainer.cc
@@ -392,6 +392,8 @@ bool NgapOwnedContainer::dmrpp_read_from_opendap_bucket(string &dmrpp_string) co
  */
 void NgapOwnedContainer::dmrpp_read_from_daac_bucket(string &dmrpp_string) const {
     BES_MODULE_TIMING(prolog + get_real_name());
+    // TODO Split this up so that we can tell if an exception is thrown from the CMR call
+    //  or the raw http_get() call. jhrg 1/24/25
     try {
         string data_url = build_data_url_to_daac_bucket(get_real_name());
         string dmrpp_url_str = data_url + ".dmrpp"; // This is the URL to the DMR++ in the DAAC-owned bucket. jhrg 8/9/24
@@ -406,6 +408,7 @@ void NgapOwnedContainer::dmrpp_read_from_daac_bucket(string &dmrpp_string) const
         INFO_LOG(prolog + "Found the DMRpp in the DAAC-bucket for: " + dmrpp_url_str);
     }
     catch (http::HttpError &http_error) {
+        // TODO This adds an extra period (.) - change to "This..." and/or make this name this method so we can track it in the error log jhrg 1/24/25
         http_error.set_message(http_error.get_message() + ". This error for a DAAC-owned DMR++ could be from Hyrax, CMR, TEA, or S3.");
         throw;
     }

--- a/modules/ngap_module/NgapOwnedContainer.cc
+++ b/modules/ngap_module/NgapOwnedContainer.cc
@@ -150,6 +150,7 @@ string NgapOwnedContainer::build_data_url_to_daac_bucket(const string &rest_path
         }
     }
 
+    // Not cached or not using the cache; ask CMR. Throws on lookup failure, HTTP failure. jhrg 1/24/25
     data_url = NgapApi::convert_ngap_resty_path_to_data_access_url(rest_path);
 
     // If using the CMR cache, cache the response.
@@ -392,12 +393,12 @@ bool NgapOwnedContainer::dmrpp_read_from_opendap_bucket(string &dmrpp_string) co
  */
 void NgapOwnedContainer::dmrpp_read_from_daac_bucket(string &dmrpp_string) const {
     BES_MODULE_TIMING(prolog + get_real_name());
-    // TODO Split this up so that we can tell if an exception is thrown from the CMR call
-    //  or the raw http_get() call. jhrg 1/24/25
+    // This code may ask CMR and will throw exceptions that mention CMR on error. jhrg 1/24/25
+    string data_url = build_data_url_to_daac_bucket(get_real_name());
+    string dmrpp_url_str = data_url + ".dmrpp"; // This is the URL to the DMR++ in the DAAC-owned bucket. jhrg 8/9/24
+    INFO_LOG(prolog + "Look in the DAAC-bucket for the DMRpp for: " + dmrpp_url_str);
+
     try {
-        string data_url = build_data_url_to_daac_bucket(get_real_name());
-        string dmrpp_url_str = data_url + ".dmrpp"; // This is the URL to the DMR++ in the DAAC-owned bucket. jhrg 8/9/24
-        INFO_LOG(prolog + "Look in the DAAC-bucket for the DMRpp for: " + dmrpp_url_str);
         curl::http_get(dmrpp_url_str, dmrpp_string);
         // filter the DMRPP from the DAAC's bucket to replace the template href with the data_url
         map <string, string, std::less<>> content_filters;
@@ -408,8 +409,7 @@ void NgapOwnedContainer::dmrpp_read_from_daac_bucket(string &dmrpp_string) const
         INFO_LOG(prolog + "Found the DMRpp in the DAAC-bucket for: " + dmrpp_url_str);
     }
     catch (http::HttpError &http_error) {
-        // TODO This adds an extra period (.) - change to "This..." and/or make this name this method so we can track it in the error log jhrg 1/24/25
-        http_error.set_message(http_error.get_message() + ". This error for a DAAC-owned DMR++ could be from Hyrax, CMR, TEA, or S3.");
+        http_error.set_message(http_error.get_message() + "NgapOwnedContainer::dmrpp_read_from_daac_bucket() failed to read the DMR++ from S3.");
         throw;
     }
 }


### PR DESCRIPTION
Some of our HTTP Error messages are repeated twice, making the simple counts of errors hard to match to other counts in other places. It also makes it harder to read the logs (which are plenty hard to read without this). 

Also fixed are some things reported as errors that should be info records.