### PR TITLE
Rocky8 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,8 +135,8 @@ stages:
   - name: hyrax-olfs-trigger
     if: type != pull_request OR branch =~ ^(.*-test-deploy)$
     # A way to skip a stage. jhrg 1/26/23
-  - name: off
-    if: branch = off
+  - name: never
+    if: branch = never
 
 jobs:
   include:
@@ -160,12 +160,12 @@ jobs:
     - stage: build-and-package
       name: "Enterprise Linux 8 RPMs (via Rocky8)"
       script:
-        - export BES_BUILD=centos-stream8
+        - export BES_BUILD=rocky8
         - mkdir -p $prefix/rpmbuild
         - echo "branch name ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
         - docker run --env prefix=/root/install --volume $prefix/rpmbuild:/root/rpmbuild 
             --volume $TRAVIS_BUILD_DIR:/root/travis
-            --env OS=centos-stream8
+            --env OS=rocky8
             --env DIST=el8
             --env LIBDAP_RPM_VERSION=$LIBDAP_RPM_VERSION
             --env BES_BUILD_NUMBER=$BES_BUILD_NUMBER
@@ -253,10 +253,10 @@ before_deploy:
   - export DEPLOY="S3"
   # Make sure that we have the target dir...
   - mkdir -p $TRAVIS_BUILD_DIR/package;
-  # Source distribution prep (copies both the 'version' and 'snapshot'
+  # Source distribution prep (copies both the 'version' and 'snapshot')
   - if test "$BES_BUILD" = "srcdist"; then cp bes-*.tar.gz $TRAVIS_BUILD_DIR/package; fi
-  # CentOS-Stream8  distribution prep
-  - if test "$BES_BUILD" = "centos-stream8"; then ./travis/rpm-to-package-dir.sh "el8"; fi
+  # Rocky8  distribution prep
+  - if test "$BES_BUILD" = "rocky8"; then ./travis/rpm-to-package-dir.sh "el8"; fi
   # Check for the stuff...
   - ls -l $TRAVIS_BUILD_DIR/package
 
@@ -271,4 +271,4 @@ deploy:
     local_dir: $TRAVIS_BUILD_DIR/package
     on:
       all_branches: true
-      condition: $BES_BUILD =~ ^centos-stream8|srcdist$
+      condition: $BES_BUILD =~ ^rocky8|srcdist$

--- a/http/AllowedHosts.cc
+++ b/http/AllowedHosts.cc
@@ -4,7 +4,7 @@
 
 // This file is part of the OPeNDAP Back-End Server (BES)
 // and creates an allowed hosts list of which systems that may be
-// accessed by the server as part of it's routine operation.
+// accessed by the server as part of its routine operation.
 
 // Copyright (c) 2018 OPeNDAP, Inc.
 // Author: Nathan D. Potter <ndp@opendap.org>

--- a/http/AllowedHosts.h
+++ b/http/AllowedHosts.h
@@ -4,7 +4,7 @@
 
 // This file is part of the OPeNDAP Back-End Server (BES)
 // and creates a set of allowed hosts that may be
-// accessed by the server as part of it's routine operation.
+// accessed by the server as part of its routine operation.
 
 // Copyright (c) 2018 OPeNDAP, Inc.
 // Author: Nathan D. Potter <ndp@opendap.org>

--- a/http/unit-tests/AllowedHostsTest.cc
+++ b/http/unit-tests/AllowedHostsTest.cc
@@ -2,7 +2,7 @@
 
 // This file is part of the OPeNDAP Back-End Server (BES)
 // and creqates an allowed hosts list od systems that may be
-// accessed by the server as part of it's routine operation.
+// accessed by the server as part of its routine operation.
 
 // Copyright (c) 2018 OPeNDAP, Inc.
 // Author: Nathan D. Potter <ndp@opendap.org>


### PR DESCRIPTION
Switched from Centos8 to Rocky8 for the 'el8' RPM packages.

This change was made in the .travis.yml file. As a second round, we could
make the actual string used a parameter set in a single place.