### PR TITLE
Correcting embedded BES conf string issues:

### DIFF
--- a/modules/dmrpp_module/build_dmrpp_h4/get_dmrpp_h4
+++ b/modules/dmrpp_module/build_dmrpp_h4/get_dmrpp_h4
@@ -152,8 +152,8 @@ def generate_tmp_bes_conf_file(user_conf,out_conf):
         if (out_conf is not None):
             bes_conf_name=out_conf
         else:
-            bes_conf_name= "bes.tmp.conf";
-        bes_tmp_conf_str='''BES.LogName=./bes.log
+            bes_conf_name = "bes.tmp.conf"
+        bes_tmp_conf_str = r'''BES.LogName=./bes.log
 BES.modules=dap,cmd,h4
 BES.module.dap=
 BES.module.cmd=
@@ -168,7 +168,8 @@ BES.Catalog.catalog.FollowSymLinks=Yes
 BES.UncompressCache.dir=/tmp
 BES.UncompressCache.prefix=uncompress_cache
 BES.UncompressCache.size=500
-H4.EnableDirectDMR=true'''
+H4.EnableDirectDMR=true
+'''
         temp_text = add_module_path(bes_tmp_conf_str, "BES.module.dap=", libdap_path)
         temp_text = add_module_path(temp_text, "BES.module.cmd=", libdap_xml_path)
         temp_text = add_module_path(temp_text, "BES.module.h4=", libhdf4_path)

--- a/modules/dmrpp_module/get_dmrpp/get_dmrpp_h5
+++ b/modules/dmrpp_module/get_dmrpp/get_dmrpp_h5
@@ -152,8 +152,8 @@ def generate_tmp_bes_conf_file(user_conf,is_cf,out_conf):
         if (out_conf is not None):
             bes_conf_name=out_conf
         else:
-            bes_conf_name= "bes.tmp.conf";
-        bes_tmp_conf_str='''BES.LogName=./bes.log
+            bes_conf_name = "bes.tmp.conf"
+        bes_tmp_conf_str = r'''BES.LogName=./bes.log
 BES.modules=dap,cmd,h5
 BES.module.dap=
 BES.module.cmd=

--- a/modules/dmrpp_module/get_dmrpp/get_hdf_side_car
+++ b/modules/dmrpp_module/get_dmrpp/get_hdf_side_car
@@ -92,7 +92,7 @@ def generate_tmp_bes_conf_file(enable_cf):
         sys.exit(1)
 
     bes_conf_name = "bes.tmp.conf"
-    bes_tmp_conf_str = '''BES.LogName=./bes.log
+    bes_tmp_conf_str = r'''BES.LogName=./bes.log
 BES.modules=dap,cmd,fonc,h4,h5
 BES.module.dap=
 BES.module.cmd=
@@ -115,7 +115,8 @@ FONc.ChunkSize=4096
 FONc.ClassicModel=false
 FONc.NoGlobalAttrs=true
 H4.EnableDirectDMR=true
-H5.DefaultHandleDimension=true'''
+H5.DefaultHandleDimension=true
+'''
 
     if (enable_cf is True):
         bes_tmp_conf_str = bes_tmp_conf_str + "\nH5.EnableCF=true"


### PR DESCRIPTION
* Switched the bes configuration strings to python raw strings so that the various usages of the back slash character don't break python and cause runtime warnings. 

When I tried to use the software I encountered this error:
```
/Users/ndp/OPeNDAP/hyrax/build/bin/get_dmrpp_h4:156: SyntaxWarning: invalid escape sequence '\.'
  bes_tmp_conf_str='''BES.LogName=./bes.log
```
Which I fixed in this PR.

Also:
* Added new line to the ends of the conf strings
* Removed extraneous end of line semicolons

