### PR TITLE
Add additional regex in mkchk to show failing unit tests

### DIFF
--- a/mkchk
+++ b/mkchk
@@ -25,4 +25,4 @@ then
 fi
 
     
-make -k -j20 check 2>&1 | tee mk.log | grep -e "Making check in" -e "FAILED"
+make -k -j20 check 2>&1 | tee mk.log | grep -e "Making check in" -e "FAILED" -e "^FAIL: "


### PR DESCRIPTION
Previously unit test failures would be excluded from stdout by the `mkchk` script; now they're shown.

Previously:
```
[~/OPeNDAP/hyrax/bes/] ./mkchk
/Users/hrobertson/OPeNDAP/hyrax/build/bin/getdap
/Users/hrobertson/OPeNDAP/hyrax/build/bin/getdap4
Making check in dispatch
Making check in .
Making check in unit-tests
Making check in tests
...
```

Now:
```
[~/OPeNDAP/hyrax/bes/] ./mkchk
/Users/hrobertson/OPeNDAP/hyrax/build/bin/getdap
/Users/hrobertson/OPeNDAP/hyrax/build/bin/getdap4
Making check in dispatch
Making check in .
Making check in unit-tests
FAIL: FileCacheTest
Making check in tests
...
```