### PR TITLE
Use Python `unittest`'s `addCleanup` to handle asset deletion

### DIFF
--- a/modules/dmrpp_module/get_dmrpp/unit-tests/gen_dmrpp_side_car_test.py
+++ b/modules/dmrpp_module/get_dmrpp/unit-tests/gen_dmrpp_side_car_test.py
@@ -3,6 +3,9 @@
 Test gen_dmrpp_side_car script.
 python3 -m unittest gen_dmrpp_side_car_test
 
+To persist generated assets (e.g. for debugging) set environment
+variable `PRESERVE_TEST_ASSETS` to any value:
+PRESERVE_TEST_ASSETS=yes python3 -m unittest gen_dmrpp_side_car_test
 """
 import unittest
 import subprocess
@@ -15,8 +18,9 @@ class TestSample(unittest.TestCase):
         
         print("Testing grid_2_2d_ps.hdf")
         subprocess.run(["./gen_dmrpp_side_car", "-i", "grid_2_2d_ps.hdf","-H"])
-        self.addCleanup(os.remove, "grid_2_2d_ps.hdf.dmrpp")
-        self.addCleanup(os.remove, "grid_2_2d_ps.hdf_mvs.h5")
+        if not os.environ.get('PRESERVE_TEST_ASSETS'):
+            self.addCleanup(os.remove, "grid_2_2d_ps.hdf.dmrpp")
+            self.addCleanup(os.remove, "grid_2_2d_ps.hdf_mvs.h5")
         result = filecmp.cmp("grid_2_2d_ps.hdf.dmrpp","grid_2_2d_ps.hdf.dmrpp.baseline")
         self.assertEqual(result ,True )
    
@@ -25,8 +29,9 @@ class TestSample(unittest.TestCase):
         
         print("Testing grid_2_2d_sin.h5")
         subprocess.run(["./gen_dmrpp_side_car", "-i", "grid_2_2d_sin.h5"])
-        self.addCleanup(os.remove, "grid_2_2d_sin.h5.dmrpp")
-        self.addCleanup(os.remove, "grid_2_2d_sin.h5_mvs.h5")
+        if not os.environ.get('PRESERVE_TEST_ASSETS'):
+            self.addCleanup(os.remove, "grid_2_2d_sin.h5.dmrpp")
+            self.addCleanup(os.remove, "grid_2_2d_sin.h5_mvs.h5")
         with open('grid_2_2d_sin.h5.dmrpp') as f:
             dmrpp_lines_after_19 = f.readlines()[19:]
         with open('grid_2_2d_sin.h5.dmrpp.baseline') as f1:

--- a/modules/dmrpp_module/get_dmrpp/unit-tests/gen_dmrpp_side_car_test.py
+++ b/modules/dmrpp_module/get_dmrpp/unit-tests/gen_dmrpp_side_car_test.py
@@ -19,7 +19,6 @@ class TestSample(unittest.TestCase):
         self.addCleanup(os.remove, "grid_2_2d_ps.hdf_mvs.h5")
         result = filecmp.cmp("grid_2_2d_ps.hdf.dmrpp","grid_2_2d_ps.hdf.dmrpp.baseline")
         self.assertEqual(result ,True )
-        
    
 
     def test_gen_dmrpp_side_car2(self):

--- a/modules/dmrpp_module/get_dmrpp/unit-tests/gen_dmrpp_side_car_test.py
+++ b/modules/dmrpp_module/get_dmrpp/unit-tests/gen_dmrpp_side_car_test.py
@@ -7,6 +7,7 @@ python3 -m unittest gen_dmrpp_side_car_test
 import unittest
 import subprocess
 import filecmp
+import os
 
 class TestSample(unittest.TestCase):
 
@@ -14,24 +15,25 @@ class TestSample(unittest.TestCase):
         
         print("Testing grid_2_2d_ps.hdf")
         subprocess.run(["./gen_dmrpp_side_car", "-i", "grid_2_2d_ps.hdf","-H"])
+        self.addCleanup(os.remove, "grid_2_2d_ps.hdf.dmrpp")
+        self.addCleanup(os.remove, "grid_2_2d_ps.hdf_mvs.h5")
         result = filecmp.cmp("grid_2_2d_ps.hdf.dmrpp","grid_2_2d_ps.hdf.dmrpp.baseline")
         self.assertEqual(result ,True )
-        subprocess.run(["rm", "-rf", "grid_2_2d_ps.hdf.dmrpp"])
-        subprocess.run(["rm", "-rf", "grid_2_2d_ps.hdf_mvs.h5"])
+        
    
 
     def test_gen_dmrpp_side_car2(self):
         
         print("Testing grid_2_2d_sin.h5")
         subprocess.run(["./gen_dmrpp_side_car", "-i", "grid_2_2d_sin.h5"])
+        self.addCleanup(os.remove, "grid_2_2d_sin.h5.dmrpp")
+        self.addCleanup(os.remove, "grid_2_2d_sin.h5_mvs.h5")
         with open('grid_2_2d_sin.h5.dmrpp') as f:
             dmrpp_lines_after_19 = f.readlines()[19:]
         with open('grid_2_2d_sin.h5.dmrpp.baseline') as f1:
             baseline_lines_after_19 = f1.readlines()[19:]
         self.assertEqual(dmrpp_lines_after_19 ,baseline_lines_after_19)
-        subprocess.run(["rm", "-rf", "grid_2_2d_sin.h5.dmrpp"])
-        subprocess.run(["rm", "-rf", "grid_2_2d_sin.h5_mvs.h5"])
- 
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously, if the `test_gen_dmrpp_side_car` or `test_gen_dmrpp_side_car2` tests failed, the files they created persisted, which was confusing in cases where later runs seemed to (but did not actually) generate those same files. Now, using the `addCleanup` functionality, the cleanup happens at the end of the test execution, regardless of its outcome. 