### PR TITLE
meyers applied to BESStoreDapResultCache

### DIFF
--- a/dap/BESStoredDapResultCache.cc
+++ b/dap/BESStoredDapResultCache.cc
@@ -229,9 +229,6 @@ BESStoredDapResultCache::get_instance(const string &data_root_dir, const string 
                     "Cache is DISABLED"<< endl);
            }
             else {
-#ifdef HAVE_ATEXIT
-                atexit(delete_instance);
-#endif
                 BESDEBUG("cache", "BESStoredDapResultCache::"<<__func__ << "() - " <<
                     "Cache is ENABLED"<< endl);
             }
@@ -256,9 +253,6 @@ BESStoredDapResultCache::get_instance()
                 "Cache is DISABLED"<< endl);
        }
         else {
-#ifdef HAVE_ATEXIT
-            atexit(delete_instance);
-#endif
             BESDEBUG("cache", "BESStoredDapResultCache::"<<__func__ << "() - " <<
                 "Cache is ENABLED"<< endl);
         }

--- a/dap/BESStoredDapResultCache.h
+++ b/dap/BESStoredDapResultCache.h
@@ -57,11 +57,6 @@ class BESStoredDapResultCache: public BESFileLockingCache {
 private:
     static bool d_enabled;
     static BESStoredDapResultCache *d_instance;
-    static void delete_instance()
-    {
-        delete d_instance;
-        d_instance = 0;
-    }
 
     string d_storedResultsSubdir;
     string d_dataRootDir;
@@ -70,8 +65,6 @@ private:
 
     /** Initialize the cache using the default values for the cache. */
     BESStoredDapResultCache();
-
-    BESStoredDapResultCache(const BESStoredDapResultCache &src);
 
     bool is_valid(const std::string &cache_file_name, const std::string &dataset);
 #ifdef DAP2_STORED_RESULTS
@@ -102,7 +95,10 @@ public:
     static const string SIZE_KEY;
 #endif
 
-    virtual ~BESStoredDapResultCache() { }
+    BESStoredDapResultCache(const BESStoredDapResultCache&) = delete;
+    BESStoredDapResultCache& operator=(const BESStoredDapResultCache&) = delete;
+
+    ~BESStoredDapResultCache() override = default;
 
     static BESStoredDapResultCache *get_instance(const string &bes_catalog_root_dir,
         const string &stored_results_subdir, const string &prefix, unsigned long long size);

--- a/dap/unit-tests/ResponseBuilderTest.cc
+++ b/dap/unit-tests/ResponseBuilderTest.cc
@@ -682,9 +682,7 @@ public:
         catch (Error &e) {
             CPPUNIT_FAIL("Error: " + e.get_error_message());
         }
-
-        BESStoredDapResultCache *sdrc = BESStoredDapResultCache::get_instance();
-        sdrc->delete_instance();
+        
         TheBESKeys::TheKeys()->set_key(BES_CATALOG_ROOT, "");
         TheBESKeys::TheKeys()->set_key(DAP_STORED_RESULTS_CACHE_SUBDIR_KEY, "");
         TheBESKeys::TheKeys()->set_key(DAP_STORED_RESULTS_CACHE_PREFIX_KEY, "");


### PR DESCRIPTION
modified the BESStoreDapResultCache.h and *.cc file to follow the meyers pattern
removed a few lines in the unit-tests/ResponseBuilderTest.cc