### PR TITLE
Repair AWS query string filtering

### DIFF
--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -635,7 +635,7 @@ static string get_effective_url(CURL *ceh, const string &requested_url) {
 
 /**
  * @brief A helper function for filter_aws_url()
- * @param kvp_string The string to be valuated and possibly added to the vector
+ * @param kvp_string The string to be evaluated and possibly added to the vector
  * @param kvp A vector of strings to hold the kvp strings that are not obviously AWS things.
  */
 void add_if_not_aws(const string &kvp_string, std::vector<std::string> &kvp) {

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -690,7 +690,7 @@ string filter_aws_url(const string &eff_url) {
             // Add it (or not if it's an AWS thing) to the kvp vector
             add_if_not_aws(kvp_string, kvp);
             // Start at the beginning of the next field (if there is one)
-            start = end + 1;
+            start = position + 1;
             position = eff_url.find(delimiter, start);
         }
         // Handle any remaining chars in the query...
@@ -701,8 +701,12 @@ string filter_aws_url(const string &eff_url) {
         // Now rebuild the URL, but now without the AWS stuff.
         bool first = true;
         for (auto kvp_str:kvp) {
+
             if (!first)
                 filtered_url += delimiter;
+            else
+                filtered_url += "?";
+
             filtered_url += kvp_str;
             first = false;
         }

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -674,7 +674,7 @@ string filter_aws_url(const string &eff_url) {
 #endif
 
     std::vector<std::string> kvp;
-    string filtered_url = eff_url;;
+    string filtered_url = eff_url;
     size_t start = 0;
     char delimiter = '&';
     auto position = eff_url.find('?');
@@ -709,7 +709,7 @@ string filter_aws_url(const string &eff_url) {
 
         // Now rebuild the URL, but without the AWS stuff.
         bool first = true;
-        for (auto &kvp_str:kvp) {
+        for (const auto &kvp_str:kvp) {
             if (!first) {
                 filtered_url += delimiter;
             }

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -650,7 +650,7 @@ void add_if_not_aws(const string &kvp_string, std::vector<std::string> &kvp) {
 /**
  * @brief Remove AWS tokens from the URL
  * This function will look for the first ampersand and remove everything after it. Then
- * it will look any thing with an X-Amz- prefix if that is found it will remove the whole
+ * it will look anything with an X-Amz- prefix if that is found it will remove the whole
  * query string. This code should only be called if an error is being reported, so high
  * performance is not required.
  * @note Public only to enable testing.

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -710,14 +710,12 @@ string filter_aws_url(const string &eff_url) {
         // Now rebuild the URL, but without the AWS stuff.
         bool first = true;
         for (auto &kvp_str:kvp) {
-
             if (!first) {
                 filtered_url += delimiter;
             }
             else {
                 filtered_url += '?';
             }
-
             filtered_url += kvp_str;
             first = false;
         }

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -658,28 +658,14 @@ void add_if_not_aws(const string &kvp_string, std::vector<std::string> &kvp) {
  * @return The URL with the tokens removed
  */
 string filter_aws_url(const string &eff_url) {
-#if 0
-    // It seems unlikely that the X-Amz prefix will be in the first part of the query string
-    // and the first part will likely be useful for the error message, so looking for the first
-    // '&' is a good start.
-    auto pos = eff_url.find('&');
-    string filtered_url = eff_url.substr(0, pos);
-    // Check to make sure that the X-Amz prefix is not in the first part of the query string
-    if (filtered_url.find("X-Amz-") == string::npos) {
-        return filtered_url;
-    } else {
-        pos = filtered_url.find('?');
-        return filtered_url.substr(0, pos);
-    }
-#endif
 
     std::vector<std::string> kvp;
     string filtered_url = eff_url;
     size_t start = 0;
-    char delimiter = '&';
     auto position = eff_url.find('?');
 
     if (position != string::npos) {
+        constexpr char delimiter = '&';
         // We found a '?' which indicates that there may be a query string.
         start = position + 1;
 
@@ -689,23 +675,17 @@ string filter_aws_url(const string &eff_url) {
         // Find the first delimiter in the query_string
         position  = eff_url.find(delimiter, start);
 
-        string kvp_string;
         while (position != std::string::npos) {
-            // Find the current kvp thing
-            kvp_string = eff_url.substr(start, position - start);
 
-            // Add it (or not if it's an AWS thing) to the kvp vector
-            add_if_not_aws(kvp_string, kvp);
+            // Find the current kvp record and add it (or not if it's an AWS thing) to the kvp vector
+            add_if_not_aws(eff_url.substr(start, position - start), kvp);
 
             // Start at the beginning of the next field (if there is one)
             start = position + 1;
             position = eff_url.find(delimiter, start);
         }
-        // Handle any remaining chars in the query...
-        kvp_string = eff_url.substr(start);
-
-        // Add them (or not if they're an AWS thing) to the kvp vector
-        add_if_not_aws(kvp_string, kvp);
+        // Handle any remaining chars in the query, add them (or not if they're an AWS thing) to the kvp vector
+        add_if_not_aws(eff_url.substr(start, position - start), kvp);
 
         // Now rebuild the URL, but without the AWS stuff.
         bool first = true;

--- a/http/unit-tests/CurlUtilsTest.cc
+++ b/http/unit-tests/CurlUtilsTest.cc
@@ -207,19 +207,35 @@ public:
 
     void filter_effective_url_test() {
         DBG(cerr << prolog << "BEGIN\n");
-        string url = "https://ghrcwuat-protected.s3.us-west-2.amazonaws.com/rss_demo/rssmif16d__7/f16_ssmis_20031229v7.nc?A-userid=hyrax&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIASF4N-AWS-Creds-00808%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20200808T032623Z&X-Amz-Expires=86400&X-Amz-Security-Token=Foo&X-Amz-SignedHeaders=host&X-Amz-Signature=...";
-        string filtered_url = "https://ghrcwuat-protected.s3.us-west-2.amazonaws.com/rss_demo/rssmif16d__7/f16_ssmis_20031229v7.nc?A-userid=hyrax";
+
+        string source_url = "https://ghrcwuat-protected.s3.us-west-2.amazonaws.com/rss_demo/rssmif16d__7/f16_ssmis_20031229v7.nc?A-userid=hyrax&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIASF4N-AWS-Creds-00808%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20200808T032623Z&X-Amz-Expires=86400&X-Amz-Security-Token=Foo&X-Amz-SignedHeaders=host&X-Amz-Signature=smooze&boogie=woogie";
+        DBG(cerr << prolog << "source_url: " << source_url << "\n");
+
+        string baseline = "https://ghrcwuat-protected.s3.us-west-2.amazonaws.com/rss_demo/rssmif16d__7/f16_ssmis_20031229v7.nc?A-userid=hyrax&boogie=woogie";
+        DBG(cerr << prolog << "  baseline: " << baseline << "\n");
+
+        string result_url = curl::filter_aws_url(source_url);
+        DBG(cerr << prolog << "result_url: " << result_url << "\n");
+
         CPPUNIT_ASSERT_MESSAGE("The URL should have the AWS security tokens removed",
-                               filtered_url == curl::filter_aws_url(url));
+                               baseline == result_url);
         DBG(cerr << prolog << "END\n");
     }
 
     void filter_effective_url_token_first_test() {
         DBG(cerr << prolog << "BEGIN\n");
-        string url = "https://ghrcwuat-protected.s3.us-west-2.amazonaws.com/rss_demo/rssmif16d__7/f16_ssmis_20031229v7.nc?X-Amz-Security-Token=Foo&A-userid=hyrax&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIASF4N-AWS-Creds-00808%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20200808T032623Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=...";
-        string filtered_url = "https://ghrcwuat-protected.s3.us-west-2.amazonaws.com/rss_demo/rssmif16d__7/f16_ssmis_20031229v7.nc";
+
+        string source_url = "https://ghrcwuat-protected.s3.us-west-2.amazonaws.com/rss_demo/rssmif16d__7/f16_ssmis_20031229v7.nc?X-Amz-Security-Token=Foo&A-userid=hyrax&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIASF4N-AWS-Creds-00808%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20200808T032623Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=...";
+        DBG(cerr << prolog << "source_url: " << source_url << "\n");
+
+        string baseline = "https://ghrcwuat-protected.s3.us-west-2.amazonaws.com/rss_demo/rssmif16d__7/f16_ssmis_20031229v7.nc?A-userid=hyrax";
+        DBG(cerr << prolog << "  baseline: " << baseline << "\n");
+
+        string result_url = curl::filter_aws_url(source_url);
+        DBG(cerr << prolog << "result_url: " << result_url << "\n");
+
         CPPUNIT_ASSERT_MESSAGE("The URL should have the AWS security tokens removed",
-                               filtered_url == curl::filter_aws_url(url));
+                               baseline == result_url);
         DBG(cerr << prolog << "END\n");
     }
 
@@ -265,7 +281,6 @@ public:
             DBG(cerr << prolog << "effective_url is " << (effective_url->is_trusted() ? "" : "NOT ") << "trusted."
                      << "\n");
             CPPUNIT_ASSERT(effective_url->is_trusted() == trusted_target_url->is_trusted());
-
 
         }
         catch (const BESError &be) {


### PR DESCRIPTION
The previous incarnation of this dropped everything after the first kvp. Now only keys beginning with "X-Amz-" will be removed and the rest preserved.