### PR TITLE
Add default GitHub PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+
+
+## Description
+
+<!-- If no ticket exists for this issue yet, consider creating one -->
+**Reference ticket:** HYRAX-####
+
+<!-- Description of task -->
+TODO
+
+## Task list
+- [ ] PR title is `HYRAX-####: short description`
+- [ ] Tests updated/added

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,3 +6,10 @@
 
 <!-- Description of task -->
 TODO
+
+## Tasks
+<!-- Ignore or delete any irrelevant items -->
+- [ ] Ticket exists and is linked in title
+- [ ] Tests added/updated
+- [ ] Dead code removed
+- [ ] No TODOs added

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,8 @@
-
-
 ## Description
 
+<!-- Update PR title to `HYRAX-####: short description`>
 <!-- If no ticket exists for this issue yet, consider creating one -->
 **Reference ticket:** HYRAX-####
 
 <!-- Description of task -->
 TODO
-
-## Task list
-- [ ] PR title is `HYRAX-####: short description`
-- [ ] Tests updated/added

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ make_files.txt
 merged.txt
 **/unused
 /build
+__pycache__
 
 ## files
 *~


### PR DESCRIPTION
As discussed with @jgallagher59701. 

After merging, when someone opens a PR on this repo the default text will be the contents of .github/pull_request_template.md ; feel free to edit that to better represent what you'd like! Anything commented out with the html flags will be visible to the person filling out the template but not visible to readers once the template is saved.

Unfortunately GH PR templates don't (yet??) support auto-setting a title.

If this ends up being a helpful reminder for linking back to ticket numbers, we can either add it to other repos or set it as a default org-level github template, so that it is the default PR template for all of our repos, unless overridden on a repo-specific basis.