### PR TITLE
Issues with the BESStoredDapResultCache class.

### DIFF
--- a/dap/BESStoredDapResultCache.cc
+++ b/dap/BESStoredDapResultCache.cc
@@ -89,7 +89,6 @@
 using namespace std;
 using namespace libdap;
 
-BESStoredDapResultCache *BESStoredDapResultCache::d_instance = 0;
 bool BESStoredDapResultCache::d_enabled = true;
 
 #if 0
@@ -202,6 +201,7 @@ BESStoredDapResultCache::BESStoredDapResultCache()
 /**
  *
  */
+/*
 BESStoredDapResultCache::BESStoredDapResultCache(const string &data_root_dir, const string &stored_results_subdir,
     const string &result_file_prefix, unsigned long long max_cache_size)
 {
@@ -212,14 +212,30 @@ BESStoredDapResultCache::BESStoredDapResultCache(const string &data_root_dir, co
     d_maxCacheSize = max_cache_size;
     initialize(BESUtil::assemblePath(d_dataRootDir, stored_results_subdir), d_resultFilePrefix, d_maxCacheSize);
 }
+*/
 
+/*
+BESStoredDapResultCache::init(
+    const string &data_root_dir,
+    const string &stored_results_subdir,
+    const string &result_file_prefix,
+    unsigned long long max_cache_size)
+{
+    get_instance()->d_dataRootDir = data_root_dir;
+    get_instance()->d_storedResultsSubdir = stored_results_subdir;
+    get_instance()->d_resultFilePrefix = result_file_prefix;
+    get_instance()->d_maxCacheSize = max_cache_size;
+
+}
+*/
+/*
 BESStoredDapResultCache *
 BESStoredDapResultCache::get_instance(const string &data_root_dir, const string &stored_results_subdir,
     const string &result_file_prefix, unsigned long long max_cache_size)
 {
-    if (d_enabled && dir_exists(data_root_dir)) {
-        static BESStoredDapResultCache instance;
+    static BESStoredDapResultCache instance;
 
+    if (d_enabled && dir_exists(data_root_dir)) {
         d_enabled = d_instance->cache_enabled(); // Why was this included in the original version of this code? jhrg 6/9/25
         if (!d_enabled)
             return nullptr;
@@ -227,6 +243,7 @@ BESStoredDapResultCache::get_instance(const string &data_root_dir, const string 
         return &instance;
     }
 }
+*/
 
 /** Get the default instance of the BESStoredDapResultCache object. This will read "TheBESKeys" looking for the values
  * of SUBDIR_KEY, PREFIX_KEY, an SIZE_KEY to initialize the cache.
@@ -234,14 +251,8 @@ BESStoredDapResultCache::get_instance(const string &data_root_dir, const string 
 BESStoredDapResultCache *
 BESStoredDapResultCache::get_instance()
 {
-    if (d_enabled && d_instance == 0) {
-        static BESStoredDapResultCache instance;
-        d_enabled = d_instance->cache_enabled();
-        if(!d_enabled){
-            return nullptr;
-        }
-        return &instance;
-    }
+    static BESStoredDapResultCache instance;
+    return &instance;
 }
 
 /**

--- a/dap/BESStoredDapResultCache.h
+++ b/dap/BESStoredDapResultCache.h
@@ -56,11 +56,10 @@ class BESDapResponseBuilder;
 class BESStoredDapResultCache: public BESFileLockingCache {
 private:
     static bool d_enabled;
-    static BESStoredDapResultCache *d_instance;
 
-    string d_storedResultsSubdir;
-    string d_dataRootDir;
-    string d_resultFilePrefix;
+    std::string d_storedResultsSubdir;
+    std::string d_dataRootDir;
+    std::string d_resultFilePrefix;
     unsigned long d_maxCacheSize;
 
     /** Initialize the cache using the default values for the cache. */
@@ -70,22 +69,22 @@ private:
 #ifdef DAP2_STORED_RESULTS
     bool read_dap2_data_from_cache(const string &cache_file_name, libdap::DDS *fdds);
 #endif
-    bool read_dap4_data_from_cache(const string &cache_file_name, libdap::DMR *dmr);
+    bool read_dap4_data_from_cache(const std::string &cache_file_name, libdap::DMR *dmr);
 
     friend class StoredDap2ResultTest;
     friend class StoredDap4ResultTest;
     friend class ResponseBuilderTest;
 
-    string get_stored_result_local_id(const string &dataset, const string &ce, libdap::DAPVersion version);
+    std::string get_stored_result_local_id(const std::string &dataset, const std::string &ce, libdap::DAPVersion version);
 
-    string getBesDataRootDirFromConfig();
-    string getSubDirFromConfig();
-    string getResultPrefixFromConfig();
+    std::string getBesDataRootDirFromConfig();
+    std::string getSubDirFromConfig();
+    std::string getResultPrefixFromConfig();
     unsigned long getCacheSizeFromConfig();
 
 protected:
 
-    BESStoredDapResultCache(const string &data_root_dir, const string &stored_results_subdir, const string &prefix,
+    BESStoredDapResultCache(const std::string &data_root_dir, const std::string &stored_results_subdir, const std::string &prefix,
         unsigned long long size);
 
 public:
@@ -99,9 +98,9 @@ public:
     BESStoredDapResultCache& operator=(const BESStoredDapResultCache&) = delete;
 
     ~BESStoredDapResultCache() override = default;
-
-    static BESStoredDapResultCache *get_instance(const string &bes_catalog_root_dir,
-        const string &stored_results_subdir, const string &prefix, unsigned long long size);
+    // void init();
+    // static BESStoredDapResultCache *get_instance(const string &bes_catalog_root_dir,
+    //    const string &stored_results_subdir, const string &prefix, unsigned long long size);
     static BESStoredDapResultCache *get_instance();
 
 #ifdef DAP2_STORED_RESULTS

--- a/dap/unit-tests/ResponseBuilderTest.cc
+++ b/dap/unit-tests/ResponseBuilderTest.cc
@@ -80,6 +80,7 @@
 
 #include "test_utils.h"
 #include "test_config.h"
+#include "../../dispatch/TheBESKeys.h"
 
 using namespace CppUnit;
 using namespace std;
@@ -540,6 +541,11 @@ public:
 
         TheBESKeys::ConfigFile = (string) TEST_SRC_DIR + "/input-files/test.keys";
         TheBESKeys::TheKeys()->set_key(BES_CATALOG_ROOT, (string) TEST_SRC_DIR);
+        TheBESKeys::TheKeys()->set_key(DAP_STORED_RESULTS_CACHE_SUBDIR_KEY, d_stored_result_subdir);
+        TheBESKeys::TheKeys()->set_key(DAP_STORED_RESULTS_CACHE_PREFIX_KEY, "sdrt-");
+        TheBESKeys::TheKeys()->set_key(DAP_STORED_RESULTS_CACHE_SIZE_KEY, "10000");
+
+
         ConstraintEvaluator ce;
 
         // Set this to be a stored result request
@@ -811,10 +817,10 @@ public:
 #endif
         CPPUNIT_TEST(dummy_test);
 
-#if 0
+#if 1
         // FIXME These tests have baselines that rely on hash values that are
         // machine dependent. jhrg 3/4/15
-        CPPUNIT_TEST(store_dap2_result_test);
+        //CPPUNIT_TEST(store_dap2_result_test);
         CPPUNIT_TEST(store_dap4_result_test);
 #endif
     CPPUNIT_TEST_SUITE_END();


### PR DESCRIPTION
I think there are real problems with this class (and its tests) The default (no parameter) constructor throws exceptions. It should be rewritten to utilize well known defaults rather than searching the BESKeys and throwing exceptions when it doesn't find the required things.