### PR TITLE
dap4: optional checksums use updated D4StreamMarshaller

### DIFF
--- a/dap/BESDapFunctionResponseCache.cc
+++ b/dap/BESDapFunctionResponseCache.cc
@@ -48,8 +48,8 @@
 #include <libdap/XDRStreamUnMarshaller.h>
 #include <libdap/XDRFileUnMarshaller.h>
 
-#include <libdap/D4StreamMarshaller.h>
-#include <libdap/D4StreamUnMarshaller.h>
+// #include <libdap/D4StreamMarshaller.h>
+// #include <libdap/D4StreamUnMarshaller.h>
 
 #include <libdap/Sequence.h>   // We have to special-case these; see read_data_ddx()
 

--- a/dap/BESDapResponseBuilder.cc
+++ b/dap/BESDapResponseBuilder.cc
@@ -1477,6 +1477,7 @@ void BESDapResponseBuilder::serialize_dap4_data(std::ostream &out, libdap::DMR &
     bool ucs = use_dap4_checksums();
     BESDEBUG(MODULE, prolog << "use_dap4_checksums: " << (ucs?"true":"false") << "\n");
     dmr.use_checksums(ucs);
+    BESDEBUG(MODULE, prolog << "dmr.use_checksums(): " << (dmr.use_checksums()?"true":"false") << "\n");
 
     if (with_mime_headers) set_mime_binary(out, dap4_data, x_plain, last_modified_time(d_dataset), dmr.dap_version());
 
@@ -1501,7 +1502,7 @@ void BESDapResponseBuilder::serialize_dap4_data(std::ostream &out, libdap::DMR &
     cos << xml.get_doc() << CRLF << flush;
 
     // Write the data, chunked with checksums
-    D4StreamMarshaller m(cos);
+    D4StreamMarshaller m(cos, true, dmr.use_checksums());
     dmr.root()->serialize(m, dmr, !d_dap4ce.empty());
 #ifdef CLEAR_LOCAL_DATA
     dmr.root()->clear_local_data();


### PR DESCRIPTION
## Description

The dap4 checksums were made an optional part of the dap4 data response in a previous PR. 
Unfortunately the checksums could be omitted from the response, but they were still be computed.
The PR addresses the by using the new constructor for D4StreamMarshaller and passing in the checksum request state.
