### PR TITLE
Rename `get_chunks_size` to `get_chunk_count`

### DIFF
--- a/modules/dmrpp_module/DMZ.cc
+++ b/modules/dmrpp_module/DMZ.cc
@@ -2326,7 +2326,7 @@ void DMZ::load_chunks(BaseType *btp)
             auto const &array_shape = get_array_dims(array);
             size_t num_logical_chunks = logical_chunks(array_shape, dc(btp));
             // do we need to run this code?
-            if (num_logical_chunks != dc(btp)->get_chunks_size()) {
+            if (num_logical_chunks != dc(btp)->get_chunk_count()) {
                 auto const &chunk_map = get_chunk_map(dc(btp)->get_immutable_chunks());
                 // Since the variable has some chunks that hold only fill values, add those chunks
                 // to the vector of chunks.

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -838,7 +838,7 @@ void DmrppArray::read_contiguous()
     BES_STOPWATCH_START(MODULE, prolog + "Timing array name: "+name());
 
     // Get the single chunk that makes up this CONTIGUOUS variable.
-    if (get_chunks_size() != 1)
+    if (get_chunk_count() != 1)
         throw BESInternalError(string("Expected only a single chunk for variable ") + name(), __FILE__, __LINE__);
 
     // This is the original chunk for this 'contiguous' variable.
@@ -1021,7 +1021,7 @@ void DmrppArray::read_one_chunk_dio() {
 
     BESDEBUG(dmrpp_3, prolog << "Using direct IO " << endl);
     // Get the single chunk that makes up this one-chunk compressed variable.
-    if (get_chunks_size() != 1)
+    if (get_chunk_count() != 1)
         throw BESInternalError(string("Expected only a single chunk for variable ") + name(), __FILE__, __LINE__);
 
     // This is the chunk for this variable.
@@ -1128,7 +1128,7 @@ void DmrppArray::insert_chunk_unconstrained_dio(shared_ptr<Chunk> chunk) {
  */
 void DmrppArray::read_chunks_unconstrained()
 {
-    if (get_chunks_size() < 2)
+    if (get_chunk_count() < 2)
         throw BESInternalError(string("Expected chunks for variable ") + name(), __FILE__, __LINE__);
 
     // Find all the required chunks to read. I used a queue to preserve the chunk order, which
@@ -1201,7 +1201,7 @@ void DmrppArray::read_chunks_unconstrained()
 void DmrppArray::read_chunks_dio_unconstrained()
 {
 
-    if (get_chunks_size() < 2)
+    if (get_chunk_count() < 2)
         throw BESInternalError(string("Expected chunks for variable ") + name(), __FILE__, __LINE__);
 
     // Find all the required chunks to read. I used a queue to preserve the chunk order, which
@@ -1970,7 +1970,7 @@ void DmrppArray::insert_chunk(
  */
 void DmrppArray::read_chunks()
 {
-    if (get_chunks_size() < 2)
+    if (get_chunk_count() < 2)
         throw BESInternalError(string("Expected chunks for variable ") + name(), __FILE__, __LINE__);
 
     // Find all the required chunks to read. I used a queue to preserve the chunk order, which
@@ -2051,7 +2051,7 @@ void DmrppArray::read_buffer_chunks()
 {
 
     BESDEBUG(dmrpp_3, prolog << "coming to read_buffer_chunks()  "  << endl);
-    if (get_chunks_size() < 2)
+    if (get_chunk_count() < 2)
         throw BESInternalError(string("Expected chunks for variable ") + name(), __FILE__, __LINE__);
 
     // Prepare buffer size.
@@ -2714,7 +2714,7 @@ bool DmrppArray::read()
             BESDEBUG(MODULE, prolog << msg << endl);
         }
         // Single chunk and 'contiguous' are the same for this code.
-        if (array_to_read->get_chunks_size() == 1) {
+        if (array_to_read->get_chunk_count() == 1) {
             BESDEBUG(MODULE, prolog << "Reading data from a single contiguous chunk." << endl);
             // KENT: here we need to add the handling of direct chunk IO for one chunk. 
             if (this->get_dio_flag())
@@ -3247,7 +3247,7 @@ void DmrppArray::print_dap4(XMLWriter &xml, bool constrained /*false*/) {
     // jhrg 5/10/18
     // Update: print the <chunks> element even if the chinks_size value is zero since this
     // might be a variable with all fill values. jhrg 4/24/22
-    if (DmrppCommon::d_print_chunks && (get_chunks_size() > 0 || get_uses_fill_value()))
+    if (DmrppCommon::d_print_chunks && (get_chunk_count() > 0 || get_uses_fill_value()))
         print_chunks_element(xml, DmrppCommon::d_ns_prefix);
 
     // If this variable uses the COMPACT layout, encode the values for
@@ -3483,7 +3483,7 @@ void DmrppArray::read_buffer_chunks_unconstrained() {
     // Here we can adjust the buffer size as needed, for now we just use the whole array size as the starting point.
     unsigned long long buffer_size = bytes_per_element * this->get_size(false);
     
-    if (get_chunks_size() < 2)
+    if (get_chunk_count() < 2)
         throw BESInternalError(string("Expected chunks for variable ") + name(), __FILE__, __LINE__);
 
     // Follow the general superchunk way.

--- a/modules/dmrpp_module/DmrppCommon.cc
+++ b/modules/dmrpp_module/DmrppCommon.cc
@@ -478,7 +478,7 @@ unsigned long DmrppCommon::add_chunk(
 char *
 DmrppCommon::read_atomic(const string &name)
 {
-    if (get_chunks_size() != 1)
+    if (get_chunk_count() != 1)
         throw BESInternalError(string("Expected only a single chunk for variable ") + name, __FILE__, __LINE__);
 
     auto chunk = get_immutable_chunks()[0];
@@ -491,7 +491,7 @@ DmrppCommon::read_atomic(const string &name)
 // Need to obtain the buffer size for scalar structure.
 char * DmrppCommon::read_atomic(const string &name, size_t & buf_size)
 {
-    if (get_chunks_size() != 1)
+    if (get_chunk_count() != 1)
         throw BESInternalError(string("Expected only a single chunk for variable ") + name, __FILE__, __LINE__);
 
     auto chunk = get_immutable_chunks()[0];
@@ -794,7 +794,7 @@ void DmrppCommon::print_dmrpp(XMLWriter &xml, bool constrained /*false*/)
 
     // This is the code added to libdap::BaseType::print_dap4(). jhrg 5/10/18
     // If the scalar variable with contiguous contains a fillvalue, also needs to output. ky 07/12/22
-    if (DmrppCommon::d_print_chunks && (get_chunks_size() > 0 || get_uses_fill_value()))
+    if (DmrppCommon::d_print_chunks && (get_chunk_count() > 0 || get_uses_fill_value()))
         print_chunks_element(xml, DmrppCommon::d_ns_prefix);
 
     // print scalar value for special missing variables. 

--- a/modules/dmrpp_module/DmrppCommon.h
+++ b/modules/dmrpp_module/DmrppCommon.h
@@ -267,7 +267,7 @@ public:
 
     /// @brief Use this when the number of chunks is needed
     /// @return the number of Chunk objects for this variable
-    virtual size_t get_chunks_size() const { return d_chunks.size(); }
+    virtual size_t get_chunk_count() const { return d_chunks.size(); }
 
     /// @brief The chunk dimension sizes held in a const vector
     /// @return A reference to a const vector of chunk dimension sizes

--- a/modules/dmrpp_module/DmrppStr.cc
+++ b/modules/dmrpp_module/DmrppStr.cc
@@ -65,7 +65,7 @@ DmrppStr::read()
     // string code requires special processing of the data array and requires information
     // about the chunk size to produce correct answers.
 
-    if (get_chunks_size() != 1)
+    if (get_chunk_count() != 1)
         throw BESInternalError(string("Expected only a single chunk for variable ") + name(), __FILE__, __LINE__);
 
     auto chunk = get_immutable_chunks()[0];

--- a/modules/dmrpp_module/DmrppStructure.cc
+++ b/modules/dmrpp_module/DmrppStructure.cc
@@ -274,7 +274,7 @@ DmrppStructure::print_dap4(libdap::XMLWriter &writer, bool constrained) {
         bt->print_dap4(writer);
     }
 
-    if (DmrppCommon::d_print_chunks && (get_chunks_size() > 0 || get_uses_fill_value()))
+    if (DmrppCommon::d_print_chunks && (get_chunk_count() > 0 || get_uses_fill_value()))
         print_chunks_element(writer, DmrppCommon::d_ns_prefix);
 
     // Special structure string array.


### PR DESCRIPTION
Rename for clarity, prompted by addition of similar function in #1141.