### PR TITLE
Revert "Revert "Merge remote-tracking branch 'origin/master'" (#1147)"

### DIFF
--- a/dap/BESDapFunctionResponseCache.h
+++ b/dap/BESDapFunctionResponseCache.h
@@ -27,6 +27,7 @@
 #define _bes_dap_function_response_cache_h
 
 #include <string>
+#include <mutex>
 
 #include "BESFileLockingCache.h"
 
@@ -72,22 +73,17 @@ class BaseTypeFactory;
 class BESDapFunctionResponseCache: public BESFileLockingCache {
 private:
     static bool d_enabled;
+    static std::once_flag d_initialize;
+#if 0
     static BESDapFunctionResponseCache *d_instance;
+#endif
 
-//    /**
-//     * Called by atexit()
-//     */
-//    static void delete_instance() {
-//        delete d_instance;
-//        d_instance = 0;
-//    }
 
     /** @name Suppressed constructors
      *  Do not use.
      */
     ///@{
-    BESDapFunctionResponseCache();
-    // BESDapFunctionResponseCache(const BESDapFunctionResponseCache &src);
+    BESDapFunctionResponseCache() = default;
     ///@}
 
     bool is_valid(const std::string &cache_file_name, const std::string &dataset);
@@ -105,6 +101,7 @@ private:
     friend class FunctionResponseCacheTest;
     friend class StoredResultTest;
 
+#if 0
 protected:
     /**
      * @brief Protected constructor that takes as arguments keys to the cache directory,
@@ -124,6 +121,7 @@ protected:
         BESFileLockingCache(cache_dir, prefix, size)
     {
     }
+#endif
 
 public:
     static const std::string PATH_KEY;
@@ -133,8 +131,11 @@ public:
     BESDapFunctionResponseCache(const BESDapFunctionResponseCache&) = delete;
     BESDapFunctionResponseCache& operator=(const BESDapFunctionResponseCache&) = delete;
 
+#if 0
     static BESDapFunctionResponseCache *get_instance(const std::string &cache_dir, const std::string &prefix,
                                                      unsigned long long size);
+#endif
+
     static BESDapFunctionResponseCache *get_instance();
 
     ~BESDapFunctionResponseCache() override = default;

--- a/dap/BESStoredDapResultCache.cc
+++ b/dap/BESStoredDapResultCache.cc
@@ -89,6 +89,8 @@
 using namespace std;
 using namespace libdap;
 
+std::once_flag BESStoredDapResultCache::d_initialize;
+
 BESStoredDapResultCache *BESStoredDapResultCache::d_instance = 0;
 bool BESStoredDapResultCache::d_enabled = true;
 
@@ -180,6 +182,7 @@ string BESStoredDapResultCache::getBesDataRootDirFromConfig()
 
 }
 
+#if 0
 BESStoredDapResultCache::BESStoredDapResultCache()
 {
     BESDEBUG("cache", "BESStoredDapResultCache::BESStoredDapResultCache() -  BEGIN" << endl);
@@ -198,6 +201,7 @@ BESStoredDapResultCache::BESStoredDapResultCache()
 
     BESDEBUG("cache", "BESStoredDapResultCache::BESStoredDapResultCache() -  END" << endl);
 }
+#endif
 
 /** Get the default instance of the BESStoredDapResultCache object. This will read "TheBESKeys" looking for the values
  * of SUBDIR_KEY, PREFIX_KEY, an SIZE_KEY to initialize the cache.
@@ -206,6 +210,18 @@ BESStoredDapResultCache *
 BESStoredDapResultCache::get_instance()
 {
     static BESStoredDapResultCache cache;
+    std::call_once(d_initialize, [](){
+
+        string tmp_resultsDir = BESUtil::assemblePath(getSubDirFromConfig(), getBesDataRootDirFromConfig());
+
+        if(tmp_resultsDir.empty()){
+            cache.disable();
+        }
+        else{
+            cache.enable();
+            cache.initialize(tmp_resultsDir, getResultPrefixFromConfig(), getCacheSizeFromConfig());
+        }
+    });
     if (cache.cache_enabled()){
         return &cache;
     }

--- a/dap/BESStoredDapResultCache.h
+++ b/dap/BESStoredDapResultCache.h
@@ -26,6 +26,7 @@
 #define _bes_store_result_cache_h
 
 #include <string>
+#include <mutex>
 
 #include <libdap/DapXmlNamespaces.h>   // needed for libdap::DAPVersion
 //#include <libdap/DMR.h>
@@ -57,6 +58,7 @@ class BESStoredDapResultCache: public BESFileLockingCache {
 private:
     static bool d_enabled;
     static BESStoredDapResultCache *d_instance;
+    static std::once_flag d_initialize;
 
     string d_storedResultsSubdir;
     string d_dataRootDir;
@@ -64,7 +66,7 @@ private:
     unsigned long d_maxCacheSize;
 
     /** Initialize the cache using the default values for the cache. */
-    BESStoredDapResultCache();
+    BESStoredDapResultCache() = default;
 
     bool is_valid(const std::string &cache_file_name, const std::string &dataset);
 #ifdef DAP2_STORED_RESULTS
@@ -78,10 +80,10 @@ private:
 
     string get_stored_result_local_id(const string &dataset, const string &ce, libdap::DAPVersion version);
 
-    string getBesDataRootDirFromConfig();
-    string getSubDirFromConfig();
-    string getResultPrefixFromConfig();
-    unsigned long getCacheSizeFromConfig();
+    static string getBesDataRootDirFromConfig();
+    static string getSubDirFromConfig();
+    static string getResultPrefixFromConfig();
+    static unsigned long getCacheSizeFromConfig();
 
 public:
 #if 0

--- a/dap/tests/bes.conf.in
+++ b/dap/tests/bes.conf.in
@@ -33,9 +33,9 @@ BES.UncompressCache.dir=/tmp/hyrax_ux
 BES.UncompressCache.prefix=ux_
 BES.UncompressCache.size=500
 
-DAP.FunctionResponseCache.path=./response_cache
-DAP.FunctionResponseCache.prefix=/rc
-DAP.FunctionResponseCache.size=500
+# DAP.FunctionResponseCache.path=response_cache
+# DAP.FunctionResponseCache.prefix=/rc_
+# DAP.FunctionResponseCache.size=500
 
 #
 # Setting BES.MaxResponseSize.bytes and BES.MaxVariableSize.bytes

--- a/dap/unit-tests/.gitignore
+++ b/dap/unit-tests/.gitignore
@@ -10,3 +10,4 @@ mds_inventory
 /pathinfo_files/
 /ShowPathInfoTest
 /DapUtilsTest
+/FunctionResponseCacheTest2

--- a/dap/unit-tests/Makefile.am
+++ b/dap/unit-tests/Makefile.am
@@ -91,7 +91,8 @@ bes.conf: $(srcdir)/$(BES_CONF_IN) $(top_srcdir)/configure.ac
 
 if CPPUNIT
 UNIT_TESTS = ResponseBuilderTest ObjMemCacheTest FunctionResponseCacheTest \
-ShowPathInfoTest TemporaryFileTest GlobalMetadataStoreTest DapUtilsTest
+ShowPathInfoTest TemporaryFileTest GlobalMetadataStoreTest DapUtilsTest \
+FunctionResponseCacheTest2
 
 else
 UNIT_TESTS =
@@ -119,6 +120,11 @@ FunctionResponseCacheTest_SOURCES = FunctionResponseCacheTest.cc $(TEST_SRC)
 FunctionResponseCacheTest_OBJS = ../BESDapFunctionResponseCache.o ../DapFunctionUtils.o \
 ../CachedSequence.o ../CacheTypeFactory.o ../CacheMarshaller.o ../CacheUnMarshaller.o 
 FunctionResponseCacheTest_LDADD = $(FunctionResponseCacheTest_OBJS) $(LDADD)
+
+FunctionResponseCacheTest2_SOURCES = FunctionResponseCacheTest2.cc $(TEST_SRC)
+# FunctionResponseCacheTest2_OBJS = ../BESDapFunctionResponseCache.o ../DapFunctionUtils.o \
+# ../CachedSequence.o ../CacheTypeFactory.o ../CacheMarshaller.o ../CacheUnMarshaller.o
+FunctionResponseCacheTest2_LDADD = $(FunctionResponseCacheTest_OBJS) $(LDADD)
 
 ObjMemCacheTest_SOURCES = ObjMemCacheTest.cc
 ObjMemCacheTest_OBJS = ../ObjMemCache.o

--- a/dispatch/BESFileLockingCache.cc
+++ b/dispatch/BESFileLockingCache.cc
@@ -1149,10 +1149,18 @@ void BESFileLockingCache::purge_file(const string &file)
                     throw BESInternalError(
                             prolog + "Unable to purge the file " + file + " from the cache: " + get_errno(), __FILE__,
                             __LINE__);
+#if 0
+                //  The exception above could result in a leak. jhrg 11/16/22 fixed 8/29/25
+                  fd = m_remove_descriptor(file);
+                  if (fd != cfile_fd){
+                    throw BESInternalError(
+                            prolog + "File descriptor does not match purged file descriptor for " + file, __FILE__,
+                            __LINE__);
+                }
 
-                // FIXME The exception above could result in a leak. jhrg 11/16/22
                 unlock(cfile_fd);
-                cfile_fd = -1;
+#endif
+                unlock_and_close(file);
                 unsigned long long cache_size = get_cache_size() - size;
 
                 if (lseek(d_cache_info_fd, 0, SEEK_SET) == -1)
@@ -1165,8 +1173,11 @@ void BESFileLockingCache::purge_file(const string &file)
             }
         }
         catch (...) {
-            if (cfile_fd != -1)
+            unlock_and_close(file);
+#if 0
+              if (cfile_fd != -1)
                 unlock(cfile_fd);
+#endif
         }
 #if 0
         unlock_cache();

--- a/dispatch/BESUncompressCache.cc
+++ b/dispatch/BESUncompressCache.cc
@@ -35,12 +35,12 @@
 using std::endl;
 using std::string;
 
-BESUncompressCache *BESUncompressCache::d_instance = 0;
 bool BESUncompressCache::d_enabled = true;
 
 const string BESUncompressCache::DIR_KEY = "BES.UncompressCache.dir";
 const string BESUncompressCache::PREFIX_KEY = "BES.UncompressCache.prefix";
 const string BESUncompressCache::SIZE_KEY = "BES.UncompressCache.size";
+std::once_flag BESUncompressCache::d_initialize;
 
 #define MODULE "cache"
 #define prolog std::string("BESUncompressCache::").append(__func__).append("() - ")
@@ -142,6 +142,7 @@ string BESUncompressCache::get_cache_file_name(const string &src, bool mangle)
     return cache_file_name;
 }
 
+#if 0
 BESUncompressCache::BESUncompressCache()
 {
     BESDEBUG( MODULE, prolog << "BEGIN" << endl);
@@ -158,6 +159,7 @@ BESUncompressCache::BESUncompressCache()
     BESDEBUG( MODULE, prolog << "END" << endl);
 
 }
+#endif
 
 /** Get the default instance of the GatewayCache object. This will read "TheBESKeys" looking for the values
  * of SUBDIR_KEY, PREFIX_KEY, an SIZE_KEY to initialize the cache.
@@ -167,6 +169,18 @@ BESUncompressCache *
 BESUncompressCache::get_instance()
 {
     static BESUncompressCache cache;
+    std::call_once(d_initialize, [](){
+        d_enabled = true;
+        string tmp_dimCacheDir = getCacheDirFromConfig();
+
+        if (tmp_dimCacheDir.empty()){
+            cache.disable();
+        }
+        else{
+            cache.enable();
+            cache.initialize(tmp_dimCacheDir, getCachePrefixFromConfig(), getCacheSizeFromConfig());
+        }
+    });
     if (cache.cache_enabled()){
         return &cache;
     }

--- a/dispatch/BESUncompressCache.h
+++ b/dispatch/BESUncompressCache.h
@@ -22,6 +22,7 @@
 #define DISPATCH_BESUNCOMPRESSCACHE_H_
 
 #include <string>
+#include <mutex>
 
 #include "BESFileLockingCache.h"
 
@@ -29,19 +30,22 @@ class BESUncompressCache: public BESFileLockingCache {
     friend class uncompressT;
 private:
     static bool d_enabled;
+    static std::once_flag d_initialize;
+#if 0
     static BESUncompressCache * d_instance;
     static void delete_instance()
     {
         delete d_instance;
         d_instance = 0;
     }
+#endif
 
     std::string d_dimCacheDir;
     std::string d_dataRootDir;
     std::string d_dimCacheFilePrefix;
     unsigned long d_maxCacheSize;
 
-    BESUncompressCache();
+    BESUncompressCache() = default;
 
     bool is_valid(const std::string &cache_file_name, const std::string &dataset_file_name);
 

--- a/dispatch/unit-tests/.gitignore
+++ b/dispatch/unit-tests/.gitignore
@@ -13,3 +13,4 @@ uncompressT
 /RequestTimerTest
 /BESFileLockingCacheTest
 /FileCacheTest
+/uncompressT2

--- a/dispatch/unit-tests/Makefile.am
+++ b/dispatch/unit-tests/Makefile.am
@@ -32,7 +32,7 @@ if CPPUNIT
 # This determines what gets run by 'make check.'
 TESTS = keysT constraintT defT pfileT plistT pvolT replistT		\
 reqhandlerT reqlistT resplistT infoT utilT regexT scrubT		\
-checkT servicesT fsT urlT containerT uncompressT			\
+checkT servicesT fsT urlT containerT uncompressT uncompressT2			\
 BESCatalogListTest CatalogNodeTest CatalogItemTest \
 ServerAdministratorTest kvp_utils_test \
 RequestTimerTest BESFileLockingCacheTest FileCacheTest
@@ -146,6 +146,8 @@ resplistT_SOURCES = resplistT.cc TestResponseHandler.cc TestResponseHandler.h
 infoT_SOURCES = infoT.cc
 
 uncompressT_SOURCES = uncompressT.cc
+
+uncompressT2_SOURCES = uncompressT2.cc
 
 if BES_DEVELOPER
 debugT_SOURCES = debugT.cc

--- a/modules/csv_handler/tests/bes.conf.in
+++ b/modules/csv_handler/tests/bes.conf.in
@@ -35,6 +35,10 @@ BES.UncompressCache.dir=/tmp
 BES.UncompressCache.prefix=uncompress_cache
 BES.UncompressCache.size=500
 
+# DAP.FunctionResponseCache.path=response_cache
+# DAP.FunctionResponseCache.prefix=/rc_
+# DAP.FunctionResponseCache.size=500
+
 BES.Container.Persistence=strict
 
 BES.Memory.GlobalArea.EmergencyPoolSize=1

--- a/modules/dmrpp_module/get_dmrpp/unit-tests/Makefile.am
+++ b/modules/dmrpp_module/get_dmrpp/unit-tests/Makefile.am
@@ -1,4 +1,10 @@
 AUTOMAKE_OPTIONS = foreign
+
+# Added NOTPARALLEL because this Makefile.am requires targets to run in a certain
+# order and this makes that requirement explicit. jhrg 8/31/25
+
+.NOTPARALLEL:
+
 HDF_FILES = *.hdf
 HDF5_FILES = *.h5
 PYTHON_FILES = *.py
@@ -6,6 +12,27 @@ BASELINE_FILES = *.baseline
 
 EXTRA_DIST = *.hdf *.h5 *.py *.baseline
 
+# This target shows the values of these variables. For 'make check' they
+# are: srcdir: "."
+#      builddir: "."
+# With 'make distcheck,' the values are
+#   srcdir: "../../../../../../modules/dmrpp_module/get_dmrpp/unit-tests"
+#   builddir: "."
+#
+# jhrg 8/31/25
+#
+echo-variables:
+	@echo "srcdir: \"$(srcdir)\""
+	@echo "builddir: \"$(builddir)\""
+	@echo "srcdir path manipulation: \"`echo $(srcdir) | rev | cut -c 11- | rev`\""
+
+# This target copies the executable scripts from the directory above to either
+# this dir (when 'make check' is run) or the build dir (when 'make distcheck' is
+# run). This is because the scripts must _write_ files and distcheck does not
+# allow writing to the source directory.
+#
+# I do not understand why the module *.so files are copied. jhrg 8/31/25
+#
 cp_build_script:
 	if test $(srcdir) != .; then \
 	cp -f `echo $(srcdir) | rev | cut -c 11- | rev`/gen_dmrpp_side_car $(builddir); \
@@ -27,16 +54,17 @@ cp_build_script:
 	cp -f  ../$(srcdir)/get_dmrpp_h5 $(builddir); \
 	fi;
 
-check-local: check-local-gen-dmrpp 
+# See the comment about NOTPARALLEL above. With parallel make, these target dependencies
+# would run in parallel. jhrg 8/31/25
 
-check-local-gen-dmrpp: cp_build_script
+check-local: echo-variables cp_build_script check-local-gen-dmrpp
 
 check-local-gen-dmrpp:
 	if test $(srcdir) != .; then \
 	(PATH=$(abs_top_builddir)/modules/dmrpp_module:$(abs_top_builddir)/modules/dmrpp_module/build_dmrpp_h4:$(abs_top_builddir)/standalone:$(abs_builddir):$$PATH; python3 -m unittest gen_dmrpp_side_car_test) \
 	else \
 	python3 -m unittest gen_dmrpp_side_car_test; \
-        fi;
+    fi;
 
 clean-local:
 	rm -f $(builddir)/gen_dmrpp_side_car; \

--- a/modules/dmrpp_module/get_dmrpp/unit-tests/gen_dmrpp_side_car_test.py
+++ b/modules/dmrpp_module/get_dmrpp/unit-tests/gen_dmrpp_side_car_test.py
@@ -25,8 +25,8 @@ class TestSample(unittest.TestCase):
         #result = filecmp.cmp("grid_2_2d_ps.hdf.dmrpp","grid_2_2d_ps.hdf.dmrpp.baseline")
         #self.assertEqual(result ,True )
         
-        # Since we also add the dmrpp metadata generation informatio for the HDF4 files,
-        # we need to ignore those information when doing comparision.
+        # Since we also add the dmrpp metadata generation information for the HDF4 files,
+        # we need to ignore that information when doing comparison.
         with open('grid_2_2d_ps.hdf.dmrpp') as f:
             dmrpp_lines_after_79 = f.readlines()[79:]
         with open('grid_2_2d_ps.hdf.dmrpp.baseline') as f1:

--- a/modules/functions/tests/bes.conf.in
+++ b/modules/functions/tests/bes.conf.in
@@ -30,9 +30,9 @@ BES.Catalog.catalog.TypeMatch+=dapreader:.*\.(das|dds|dods|data|dmr|dap)$;
 #                                                                       #
 #-----------------------------------------------------------------------#
 
-DAP.FunctionResponseCache.path=@abs_top_builddir@/functions/tests/dap_cache
-DAP.FunctionResponseCache.prefix=func_
-DAP.FunctionResponseCache.size=20000
+# DAP.FunctionResponseCache.path=@abs_top_builddir@/functions/tests/dap_cache
+# DAP.FunctionResponseCache.prefix=func_
+# DAP.FunctionResponseCache.size=20000
 
 DR.UseTestTypes=true
 


### PR DESCRIPTION
This reverts commit 91ef8af3c9d8e9491e3de4ab449f8e2e76b0cd18, to get the repo back to the same state it was at merge bc468ca46ebcf5fbfd2e9e9122310af785b685dc (i.e., PR #1140). 

The commit it is reverting was itself made to correct an errant/unexpected merge that bypassed the PR process. We have since updated our GitHub repository rules to prevent similar situations from occurring in the future.

I have tested locally that this PR's state and the state we want to get back to (when @sawer297's #1140 had just been merged) by doing
```
git checkout hr/reapply-hyrax-1845-changes  # Check out this current branch 
git diff master                             # Test that there *are* current diffs against master, as expected
git diff bc468ca46ebcf5fbfd2e9e9122310af785b685dc   
```
The only diff is due to [a known commit](https://github.com/OPENDAP/bes/commit/d5620b4603211a22f801bfb1d8504cbc97fcdecd) that happened since #1140 merged down, as expected:
<img width="557" height="261" alt="image" src="https://github.com/user-attachments/assets/3cdf7f6a-8415-423b-a3fb-04d3bb42299f" />
