### PR TITLE
HYRAX-1882, we need to delete transmitter RETURNAS_DMRPP when termina…

### DIFF
--- a/modules/dmrpp_module/DmrppModule.cc
+++ b/modules/dmrpp_module/DmrppModule.cc
@@ -85,6 +85,8 @@ void DmrppModule::terminate(const string &modname)
 {
     BESDEBUG(modname, prolog << "Cleaning DMR++ Reader Module " << modname << endl);
 
+    BESReturnManager::TheManager()->del_transmitter(RETURNAS_DMRPP);
+
     BESRequestHandler *rh = BESRequestHandlerList::TheList()->remove_handler(modname);
     delete rh;
 


### PR DESCRIPTION
…ting the service. Otherwise, the memory leak will occur.

## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-####

<!-- Description of task -->
TODO

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [ ] Ticket exists and is linked in title
- [ ] Tests added/updated
- [ ] Dead code removed
- [ ] No TODOs added
