### PR TITLE
HYRAX-1896, use "_FillValue" instead of _FillValue for netCDF predefi…

### DIFF
--- a/modules/fileout_netcdf/FONcAttributes.cc
+++ b/modules/fileout_netcdf/FONcAttributes.cc
@@ -426,7 +426,7 @@ void FONcAttributes::add_attributes_worker(int ncid, int varid, const string &va
                 for (attri = 1; attri < num_vals; attri++) {
                     val += "\n" + attrs.get_attr(attr, attri);
                 }
-                if (attr_name != _FillValue) {
+                if (attr_name != "_FillValue") {
                     stax = nc_put_att_text(ncid, varid, new_name.c_str(), val.size(), val.c_str());
                 }
                 else {
@@ -739,7 +739,7 @@ void FONcAttributes::add_dap4_attributes_worker(int ncid, int varid, const strin
                     val += "\n" + *vi;
                 }
 
-                if (d4_attr_name != _FillValue) {
+                if (d4_attr_name != "_FillValue") {
                     stax = nc_put_att_text(ncid, varid, new_name.c_str(), val.size(), val.c_str());
                 }
                 else {
@@ -1026,7 +1026,7 @@ FONcAttributes::write_attrs_for_nc4_types(int ncid, int varid, const string &var
                 val += "\n" + attrs.get_attr(attr, attri);
             }
             string attr_name = attrs.get_name(attr);
-            if (attr_name != _FillValue) {
+            if (attr_name != "_FillValue") {
                 stax = nc_put_att_text(ncid, varid, var_attr_name.c_str(), val.size(), val.c_str());
             }
             else {
@@ -1361,7 +1361,7 @@ FONcAttributes::write_dap4_attrs_for_nc4_types(int ncid,
                     val += "\n" + *vi;
                 }
 
-                if (var_attr_name != _FillValue) {
+                if (var_attr_name != "_FillValue") {
                     stax = nc_put_att_text(ncid, varid, var_attr_name.c_str(), val.size(), val.c_str());
                 }
                 else {
@@ -1583,7 +1583,7 @@ switch (attrType) {
             val += "\n" + attrs.get_attr(attr, attri);
         }
         string attr_name = attrs.get_name(attr);
-        if (attr_name != _FillValue) {
+        if (attr_name != "_FillValue") {
             stax = nc_put_att_text(ncid, varid, var_attr_name.c_str(), val.size(), val.c_str());
         } else {
             BESDEBUG("fonc",

--- a/modules/fileout_netcdf/FONcBaseType.cc
+++ b/modules/fileout_netcdf/FONcBaseType.cc
@@ -128,7 +128,7 @@ bool FONcBaseType::isNetCDF4_ENHANCED()
 void FONcBaseType::updateD4AttrType(libdap::D4Attributes *d4_attrs, nc_type t)
 {
     for (auto ii = d4_attrs->attribute_begin(), ee = d4_attrs->attribute_end(); ii != ee; ++ii) {
-        if ((*ii)->name() == _FillValue) {
+        if ((*ii)->name() == "_FillValue") {
             BESDEBUG("fonc", "FONcBaseType - attrtype " << getD4AttrType(t) << endl);
             BESDEBUG("fonc", "FONcBaseType - attr_type " << (*ii)->type() << endl);
             D4AttributeType correct_d4_attr_type = getD4AttrType(t);
@@ -145,7 +145,7 @@ void FONcBaseType::updateAttrType(libdap::AttrTable &attrs, nc_type t)
 {
     if (attrs.get_size()) {
         for (auto iter = attrs.attr_begin(); iter != attrs.attr_end(); iter++) {
-            if (attrs.get_name(iter) == _FillValue) {
+            if (attrs.get_name(iter) == "_FillValue") {
                 BESDEBUG("fonc", "FONcBaseType - attrtype " << getAttrType(t) << endl);
                 BESDEBUG("fonc", "FONcBaseType - attr_type " << attrs.get_attr_type(iter) << endl);
                 if (getAttrType(t) != attrs.get_attr_type(iter)) {


### PR DESCRIPTION
…ned filled value attribute name since newer netCDF version changes the _FillValue macro name.

## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-1896

<!-- Description of task -->
To make sure BES work with the Hyrax dependencies that uses the netcdf-4.9.3. 

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] No TODOs added
