### PR TITLE
[HYRAX-1732] Extract s3 credentials urls from CMR granule

### DIFF
--- a/modules/dmrpp_module/ngap_container/NgapApi.h
+++ b/modules/dmrpp_module/ngap_container/NgapApi.h
@@ -35,6 +35,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <tuple>
 
 #include "rapidjson/document.h"
 
@@ -52,8 +53,9 @@ class NgapApi {
     static bool append_hyrax_edl_client_id(std::string &cmr_url);
 
     static std::string get_cmr_search_endpoint_url();
-    static std::string find_get_data_url_in_granules_umm_json_v1_4(const std::string &rest_path,
-                                                                   rapidjson::Document &cmr_granule_response);
+
+    typedef std::tuple<std::string, std::string, std::string> DataAccessUrls;
+    static DataAccessUrls get_urls_from_granules_umm_json_v1_4(const std::string &rest_path, rapidjson::Document &cmr_granule_response);
     static std::string build_cmr_query_url(const std::string &restified_path);
     static std::string build_cmr_query_url_old_rpath_format(const std::string &restified_path);
 

--- a/modules/dmrpp_module/ngap_container/NgapNames.h
+++ b/modules/dmrpp_module/ngap_container/NgapNames.h
@@ -47,6 +47,7 @@ constexpr static auto NGAP_GRANULES_KEY = "/granules/";
 constexpr static auto DEFAULT_CMR_ENDPOINT_URL = "https://cmr.earthdata.nasa.gov";
 constexpr static auto DEFAULT_CMR_SEARCH_ENDPOINT_PATH = "/search/granules.umm_json_v1_4";
 constexpr static auto CMR_URL_TYPE_GET_DATA = "GET DATA";
+constexpr static auto CMR_URL_TYPE_GET_S3CREDENTIALS = "VIEW RELATED INFORMATION";
 
 constexpr static auto USE_CMR_CACHE = "NGAP.UseCMRCache";
 constexpr static auto CMR_CACHE_THRESHOLD = "NGAP.CMRCacheSize.Items";

--- a/modules/dmrpp_module/ngap_container/unit-tests/NgapApiTest.cc
+++ b/modules/dmrpp_module/ngap_container/unit-tests/NgapApiTest.cc
@@ -261,21 +261,21 @@ public:
     }
 
     // Test the 'no hits' case
-    static void test_find_get_data_url_in_granules_umm_json_v1_4_no_hits() {
+    static void test_get_urls_from_granules_umm_json_v1_4_no_hits() {
         DBG(cerr << prolog << "BEGIN" << endl);
         const string json = bes::read_test_baseline(string(TEST_SRC_DIR) + "/cmr_json_responses/no_hits.json");
         rapidjson::Document cmr_response;
         cmr_response.Parse(json.c_str());
 
         CPPUNIT_ASSERT_THROW_MESSAGE("Hits < 1, should have thrown BESNotFoundError",
-                                     NgapApi::find_get_data_url_in_granules_umm_json_v1_4("placeholder", cmr_response),
+                                     NgapApi::get_urls_from_granules_umm_json_v1_4("placeholder", cmr_response),
                                      BESNotFoundError);
         DBG(cerr << prolog << "END" << endl);
     }
 
 
     // Test the 'items' not an array case
-    static void test_find_get_data_url_in_granules_umm_json_v1_4_items_not_an_array() {
+    static void test_get_urls_from_granules_umm_json_v1_4_items_not_an_array() {
         DBG(cerr << prolog << "BEGIN" << endl);
         const string json = bes::read_test_baseline(
             string(TEST_SRC_DIR) + "/cmr_json_responses/items_not_an_array.json");
@@ -283,13 +283,13 @@ public:
         cmr_response.Parse(json.c_str());
 
         CPPUNIT_ASSERT_THROW_MESSAGE("items not an array, should have thrown BESInternalError",
-                                     NgapApi::find_get_data_url_in_granules_umm_json_v1_4("placeholder", cmr_response),
+                                     NgapApi::get_urls_from_granules_umm_json_v1_4("placeholder", cmr_response),
                                      BESInternalError);
         DBG(cerr << prolog << "end" << endl);
     }
 
     // no RelatedUrls part case
-    static void test_find_get_data_url_in_granules_umm_json_v1_4_no_related_urls() {
+    static void test_get_urls_from_granules_umm_json_v1_4_no_related_urls() {
         DBG(cerr << prolog << "BEGIN" << endl);
         const string json = bes::read_test_baseline(string(TEST_SRC_DIR) + "/cmr_json_responses/no_related_urls.json");
         rapidjson::Document cmr_response;
@@ -297,14 +297,14 @@ public:
 
         string url;
         CPPUNIT_ASSERT_THROW_MESSAGE("no related urls, should have thrown BESInternalError" + url,
-                                     url = NgapApi::find_get_data_url_in_granules_umm_json_v1_4("placeholder",
+                                     NgapApi::get_urls_from_granules_umm_json_v1_4("placeholder",
                                          cmr_response),
                                      BESInternalError);
         DBG(cerr << prolog << "end" << endl);
     }
 
     // RelatedUrls not an array
-    static void test_find_get_data_url_in_granules_umm_json_v1_4_related_urls_not_an_array() {
+    static void test_get_urls_from_granules_umm_json_v1_4_related_urls_not_an_array() {
         DBG(cerr << prolog << "BEGIN" << endl);
         const string json = bes::read_test_baseline(
             string(TEST_SRC_DIR) + "/cmr_json_responses/related_urls_not_an_array.json");
@@ -313,14 +313,14 @@ public:
 
         string url;
         CPPUNIT_ASSERT_THROW_MESSAGE("related urls not an array, should have thrown BESNotFoundError" + url,
-                                     url = NgapApi::find_get_data_url_in_granules_umm_json_v1_4("placeholder",
+                                     NgapApi::get_urls_from_granules_umm_json_v1_4("placeholder",
                                          cmr_response),
                                      BESNotFoundError);
         DBG(cerr << prolog << "end" << endl);
     }
 
     // no valid related url
-    static void test_find_get_data_url_in_granules_umm_json_v1_4_no_valid_related_url() {
+    static void test_get_urls_from_granules_umm_json_v1_4_no_valid_related_url() {
         DBG(cerr << prolog << "BEGIN" << endl);
         const string json = bes::read_test_baseline(
             string(TEST_SRC_DIR) + "/cmr_json_responses/no_valid_related_url.json");
@@ -328,13 +328,13 @@ public:
         cmr_response.Parse(json.c_str());
 
         CPPUNIT_ASSERT_THROW_MESSAGE("no valid related url, should have thrown BESInternalError",
-                                     NgapApi::find_get_data_url_in_granules_umm_json_v1_4("placeholder", cmr_response),
+                                     NgapApi::get_urls_from_granules_umm_json_v1_4("placeholder", cmr_response),
                                      BESInternalError);
         DBG(cerr << prolog << "end" << endl);
     }
 
     // No URL member
-    static void test_find_get_data_url_in_granules_umm_json_v1_4_related_url_wo_URL() {
+    static void test_get_urls_from_granules_umm_json_v1_4_related_url_wo_URL() {
         DBG(cerr << prolog << "BEGIN" << endl);
         const string json = bes::read_test_baseline(
             string(TEST_SRC_DIR) + "/cmr_json_responses/related_url_wo_URL.json");
@@ -342,12 +342,12 @@ public:
         cmr_response.Parse(json.c_str());
 
         CPPUNIT_ASSERT_THROW_MESSAGE("related url without URL member, should have thrown BESInternalError",
-                                     NgapApi::find_get_data_url_in_granules_umm_json_v1_4("placeholder", cmr_response),
+                                     NgapApi::get_urls_from_granules_umm_json_v1_4("placeholder", cmr_response),
                                      BESInternalError);
         DBG(cerr << prolog << "end" << endl);
     }
 
-    static void test_find_get_data_url_in_granules_umm_json_v1_4_related_url_wo_Type() {
+    static void test_get_urls_from_granules_umm_json_v1_4_related_url_wo_Type() {
         DBG(cerr << prolog << "BEGIN" << endl);
         const string json = bes::read_test_baseline(
             string(TEST_SRC_DIR) + "/cmr_json_responses/related_url_wo_Type.json");
@@ -355,18 +355,19 @@ public:
         cmr_response.Parse(json.c_str());
 
         CPPUNIT_ASSERT_THROW_MESSAGE("related url without Type member, should have thrown BESInternalError",
-                                     NgapApi::find_get_data_url_in_granules_umm_json_v1_4("placeholder", cmr_response),
+                                     NgapApi::get_urls_from_granules_umm_json_v1_4("placeholder", cmr_response),
                                      BESInternalError);
         DBG(cerr << prolog << "end" << endl);
     }
 
-    static void test_find_get_data_url_in_granules_umm_json_v1_4_minimal_json() {
+    static void test_get_urls_from_granules_umm_json_v1_4_minimal_json() {
         // not a test baseline, but a canned response from LPDAAC
         const string minimal_json = bes::read_test_baseline(string(TEST_SRC_DIR) + "/cmr_json_responses/minimal.json");
         rapidjson::Document cmr_response;
         cmr_response.Parse(minimal_json.c_str());
 
-        string data_url = NgapApi::find_get_data_url_in_granules_umm_json_v1_4("placeholder", cmr_response);
+        string data_url, data_s3_url, s3credentials_url;
+        tie(data_url, data_s3_url, s3credentials_url) = NgapApi::get_urls_from_granules_umm_json_v1_4("placeholder", cmr_response);
 
         DBG(cerr << prolog << "data_url: " << data_url << endl);
         CPPUNIT_ASSERT_MESSAGE("data_url should not be empty", !data_url.empty());
@@ -374,14 +375,15 @@ public:
         CPPUNIT_ASSERT_MESSAGE("data_url should be '" + expected + " but was '" + data_url, data_url == expected);
     }
 
-    static void test_find_get_data_url_in_granules_umm_json_v1_4_lpdaac() {
+    static void test_get_urls_from_granules_umm_json_v1_4_lpdaac() {
         // not a test baseline, but a canned response from LPDAAC
         const string cmr_canned_response_lpdaac = bes::read_test_baseline(
             string(TEST_SRC_DIR) + "/cmr_json_responses/ECOv002_L1B_GEO_22172_008_20220604T024955_0700_01.json");
         rapidjson::Document cmr_response;
         cmr_response.Parse(cmr_canned_response_lpdaac.c_str());
 
-        string data_url = NgapApi::find_get_data_url_in_granules_umm_json_v1_4(
+        string data_url, data_s3_url, s3credentials_url;
+        tie(data_url, data_s3_url, s3credentials_url) = NgapApi::get_urls_from_granules_umm_json_v1_4(
             "placeholder_for_restified_url", cmr_response);
 
         DBG(cerr << prolog << "data_url: " << data_url << endl);
@@ -389,17 +391,28 @@ public:
         string expected =
                 "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/ECO_L1B_GEO.002/ECOv002_L1B_GEO_22172_008_20220604T024955_0700_01/ECOv002_L1B_GEO_22172_008_20220604T024955_0700_01.h5";
         CPPUNIT_ASSERT_MESSAGE("data_url should be '" + expected + " but was '" + data_url, data_url == expected);
+
+        DBG(cerr << prolog << "data_s3_url: " << data_s3_url << endl);
+        CPPUNIT_ASSERT_MESSAGE("data_s3_url should not be empty", !data_s3_url.empty());
+        string expected_s3 = "s3://lp-prod-protected/ECO_L1B_GEO.002/ECOv002_L1B_GEO_22172_008_20220604T024955_0700_01/ECOv002_L1B_GEO_22172_008_20220604T024955_0700_01.h5";
+        CPPUNIT_ASSERT_MESSAGE("data_s3_url should be '" + expected_s3 + " but was '" + data_s3_url, data_s3_url == expected_s3);
+
+        DBG(cerr << prolog << "s3credentials_url: " << s3credentials_url << endl);
+        CPPUNIT_ASSERT_MESSAGE("s3credentials_url should not be empty", !s3credentials_url.empty());
+        string expected_s3credentials = "https://data.lpdaac.earthdatacloud.nasa.gov/s3credentials";
+        CPPUNIT_ASSERT_MESSAGE("s3credentials_url should be '" + expected_s3credentials + " but was '" + s3credentials_url, s3credentials_url == expected_s3credentials);
     }
 
     // C2251464384-POCLOUD, cyg04.ddmi.s20230410-000000-e20230410-235959.l1.power-brcs.a21.d21.json. jhrg 5/22/24
-    static void test_find_get_data_url_in_granules_umm_json_v1_4_podaac() {
+    static void test_get_urls_from_granules_umm_json_v1_4_podaac() {
         const string cmr_canned_response_podaac = bes::read_test_baseline(
             string(TEST_SRC_DIR) +
             "/cmr_json_responses/cyg04.ddmi.s20230410-000000-e20230410-235959.l1.power-brcs.a21.d21.json");
         rapidjson::Document cmr_response;
         cmr_response.Parse(cmr_canned_response_podaac.c_str());
 
-        string data_url = NgapApi::find_get_data_url_in_granules_umm_json_v1_4(
+        string data_url, data_s3_url, s3credentials_url;
+        tie(data_url, data_s3_url, s3credentials_url) = NgapApi::get_urls_from_granules_umm_json_v1_4(
             "placeholder_for_restified_url", cmr_response);
 
         DBG(cerr << prolog << "data_url: " << data_url << endl);
@@ -407,6 +420,16 @@ public:
         string expected =
                 "https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-protected/CYGNSS_L1_V2.1/2023/100/cyg04.ddmi.s20230410-000000-e20230410-235959.l1.power-brcs.a21.d21.nc";
         CPPUNIT_ASSERT_MESSAGE("data_url should be '" + expected + " but was '" + data_url, data_url == expected);
+
+        DBG(cerr << prolog << "data_s3_url: " << data_s3_url << endl);
+        CPPUNIT_ASSERT_MESSAGE("data_s3_url should not be empty", !data_s3_url.empty());
+        string expected_s3 = "s3://podaac-ops-cumulus-protected/CYGNSS_L1_V2.1/2023/100/cyg04.ddmi.s20230410-000000-e20230410-235959.l1.power-brcs.a21.d21.nc";
+        CPPUNIT_ASSERT_MESSAGE("data_s3_url should be '" + expected_s3 + " but was '" + data_s3_url, data_s3_url == expected_s3);
+
+        DBG(cerr << prolog << "s3credentials_url: " << s3credentials_url << endl);
+        CPPUNIT_ASSERT_MESSAGE("s3credentials_url should not be empty", !s3credentials_url.empty());
+        string expected_s3credentials = "https://archive.podaac.earthdata.nasa.gov/s3credentials";
+        CPPUNIT_ASSERT_MESSAGE("s3credentials_url should be '" + expected_s3credentials + " but was '" + s3credentials_url, s3credentials_url == expected_s3credentials);
     }
 
     /**
@@ -575,16 +598,16 @@ public:
     CPPUNIT_TEST (resty_path_to_cmr_query_test_04);
     CPPUNIT_TEST (signed_url_is_expired_test);
 
-    CPPUNIT_TEST (test_find_get_data_url_in_granules_umm_json_v1_4_no_hits);
-    CPPUNIT_TEST (test_find_get_data_url_in_granules_umm_json_v1_4_items_not_an_array);
-    CPPUNIT_TEST (test_find_get_data_url_in_granules_umm_json_v1_4_no_related_urls);
-    CPPUNIT_TEST (test_find_get_data_url_in_granules_umm_json_v1_4_related_urls_not_an_array);
-    CPPUNIT_TEST (test_find_get_data_url_in_granules_umm_json_v1_4_no_valid_related_url);
-    CPPUNIT_TEST (test_find_get_data_url_in_granules_umm_json_v1_4_related_url_wo_URL);
-    CPPUNIT_TEST (test_find_get_data_url_in_granules_umm_json_v1_4_minimal_json);
+    CPPUNIT_TEST (test_get_urls_from_granules_umm_json_v1_4_no_hits);
+    CPPUNIT_TEST (test_get_urls_from_granules_umm_json_v1_4_items_not_an_array);
+    CPPUNIT_TEST (test_get_urls_from_granules_umm_json_v1_4_no_related_urls);
+    CPPUNIT_TEST (test_get_urls_from_granules_umm_json_v1_4_related_urls_not_an_array);
+    CPPUNIT_TEST (test_get_urls_from_granules_umm_json_v1_4_no_valid_related_url);
+    CPPUNIT_TEST (test_get_urls_from_granules_umm_json_v1_4_related_url_wo_URL);
+    CPPUNIT_TEST (test_get_urls_from_granules_umm_json_v1_4_minimal_json);
 
-    CPPUNIT_TEST (test_find_get_data_url_in_granules_umm_json_v1_4_lpdaac);
-    CPPUNIT_TEST (test_find_get_data_url_in_granules_umm_json_v1_4_podaac);
+    CPPUNIT_TEST (test_get_urls_from_granules_umm_json_v1_4_lpdaac);
+    CPPUNIT_TEST (test_get_urls_from_granules_umm_json_v1_4_podaac);
     CPPUNIT_TEST (test_dmrpp_is_removed_from_data_url);
 
     CPPUNIT_TEST (append_hyrax_edl_client_id_appends_after_qmark_without_extra_amp);


### PR DESCRIPTION
Previously, we pulled only the http/s url from the CMR granule's json document. Now we pull three URLs: the original one, the s3credentials endpoint, and the s3 data url.

We don't do anything with them yet; this PR purely adds and tests functionality for accessing them.