### PR TITLE
[HYRAX-1901] Clean up the AWS SDK support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,11 @@ AM_CXXFLAGS=
 AM_LDFLAGS =
 include $(top_srcdir)/coverage.mk
 
-SUBDIRS = dispatch xmlcommand ppt server http cmdln standalone docs bin templates hello_world aws
+SUBDIRS = dispatch xmlcommand ppt server http cmdln standalone docs bin templates hello_world
+
+if USE_AWS_SDK
+SUBDIRS += aws
+endif
 
 if LIBDAP
 SUBDIRS += dap dapreader
@@ -65,7 +69,16 @@ bes-tmpfiles-conf besd.logrotate README.md rapidjson nlohmann pugixml
 HTML_DOCS=html
 DOXYGEN_CONF=doxy.conf
 
-framework_dirs = dispatch xmlcommand ppt server http aws dap dapreader
+framework_dirs = dispatch xmlcommand ppt server http cmdln standalone docs bin templates hello_world
+
+if USE_AWS_SDK
+framework_dirs += aws
+endif
+
+if LIBDAP
+framework_dirs += dap dapreader
+endif
+
 .PHONY: framework
 framework:
 	for d in $(framework_dirs); do $(MAKE) -C $$d $(MFLAGS); done

--- a/aws/Makefile.am
+++ b/aws/Makefile.am
@@ -19,18 +19,9 @@ SUBDIRS = . unit-tests
 
 noinst_LTLIBRARIES = libbes_aws.la
 
-# AWS_SDK_C_LIBS = -laws-c-common -laws-c-cal -laws-c-compression -laws-c-event-stream
-#                 -laws-c-http -laws-c-io -laws-c-mqtt -laws-c-s3 -laws-c-auth -laws-c-sdkutils
-# AWS_SDK_CPP_LIBS = -laws-crt-cpp -laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-checksums
-
 libbes_aws_la_SOURCES = $(SRCS) $(HDRS)
 libbes_aws_la_LDFLAGS =
-# -L/Users/jimg/src/opendap/hyrax/build/deps/lib
 libbes_aws_la_LIBADD =
-#-L/Users/jimg/src/opendap/hyrax/build/deps/lib $(AWS_SDK_CPP_LIBS) $(AWS_SDK_C_LIBS)
-
-# TODO how to deal with the convenience lib - can the AWS libs be linked to it? Prob not,
-# but worth checking. jhrg 10/15/25
 
 pkginclude_HEADERS = $(HDRS)
 

--- a/aws/unit-tests/Makefile.am
+++ b/aws/unit-tests/Makefile.am
@@ -4,45 +4,30 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/aws -I$(top_srcdir)/dispatch
 
-aws_libdir = $(AWS_PREFIX)/lib
-
-AWS_LIBS = -laws-crt-cpp -laws-cpp-sdk-s3 -laws-cpp-sdk-core \
-          -laws-c-http -laws-c-io -laws-c-auth -laws-c-cal -laws-c-compression \
-          -laws-c-event-stream -laws-c-mqtt -laws-c-s3 -laws-c-sdkutils -laws-c-common \
-          -lxml2 -lz -lbz2 -lcurl
-
 # Help the link step find libs at build time too (not just run time)
 AM_LDFLAGS = -L$(aws_libdir)
 
 # This should be 'AM_LDADD' but for some reason the check_PROGRAMS variable doesn't work
 # like bin_PROGRAMS.
-LDADD = $(top_builddir)/dispatch/libbes_dispatch.la $(top_builddir)/aws/libbes_aws.la $(AWS_LIBS)
+# NB: aws_libs is set in configure.ac. jhrg 10/16/25
 
+LDADD = $(top_builddir)/dispatch/libbes_dispatch.la $(top_builddir)/aws/libbes_aws.la $(aws_libs)
+
+# aws_libdir is set in configure.ac. jhrg 10/16/25
 
 if DARWIN
-AWS_SDK_Test_LDFLAGS = \
-  $(AM_LDFLAGS) \
-  -Wl,-rpath,$(aws_libdir) \
-  -Wl,-rpath,@loader_path \
-  -Wl,-rpath,@loader_path/../lib
+AM_LDFLAGS += -Wl,-rpath,$(aws_libdir) -Wl,-rpath,@loader_path
 else
-AWS_SDK_Test_LDFLAGS = \
-  $(AM_LDFLAGS) \
-  -Wl,-rpath,'$(aws_libdir)' \
-  -Wl,-rpath,'$$ORIGIN' \
-  -Wl,-rpath,'$$ORIGIN/../lib'
+AM_LDFLAGS += -Wl,-rpath,$(aws_libdir) -Wl,-rpath,'$$ORIGIN'
 endif
-
 
 # This will help make 'make check' predictable with varying build environments.
 # jhrg 10/15/25
-if DARWIN
-TESTS_ENVIRONMENT = DYLD_LIBRARY_PATH=$(aws_libdir):$$DYLD_LIBRARY_PATH
-else
-TESTS_ENVIRONMENT = LD_LIBRARY_PATH=$(aws_libdir):$$LD_LIBRARY_PATH
-endif
-
-#-L/Users/jimg/src/opendap/hyrax/build/deps/lib -L$(top_builddir)/dispatch
+#if DARWIN
+#TESTS_ENVIRONMENT = DYLD_LIBRARY_PATH=$(aws_libdir):$$DYLD_LIBRARY_PATH
+#else
+#TESTS_ENVIRONMENT = LD_LIBRARY_PATH=$(aws_libdir):$$LD_LIBRARY_PATH
+#endif
 
 if CPPUNIT
 AM_CPPFLAGS += $(CPPUNIT_CFLAGS) -Wno-deprecated-declarations

--- a/configure.ac
+++ b/configure.ac
@@ -549,40 +549,69 @@ AS_IF([test $curl_is_ok = no],
     
 ])  dnl End AM_COND_IF BES_DEVELOPER for DMR++/libcurl
 
-dnl Look for the AWS libraries (aws-cpp-sdk-s3 aws-cpp-sdk-core) and headers
-dnl jhrg 3/11/25
+dnl Moved this out of the AWS-specific checks. jhrg 10/16/25
 
-dnl Look for the AWS SDK from the hyrax-dependencies. jhrg 10/9/25
-
-AC_LANG_PUSH([C++])
-saved_CXXFLAGS=$CXXFLAGS
-CXXFLAGS="-I$ac_bes_dependencies_prefix/include"
-AC_CHECK_HEADERS([aws/core/Aws.h], [found_aws_h=true], [found_aws_h=false])
-AC_CHECK_HEADERS([aws/s3/S3Client.h], [found_s3client_h=true], [found_s3client_h=false])
-CXXFLAGS=$saved_CXXFLAGS
-AC_LANG_POP([C++])
-
-AS_IF([$found_aws_h && $found_s3client_h],
-    [AWS_PREFIX=$ac_bes_dependencies_prefix
-     AC_SUBST(AWS_PREFIX)
-
-     AWS_LBS="-laws-crt-cpp -laws-cpp-sdk-s3 -laws-cpp-sdk-core \
-              -laws-c-http -laws-c-io -laws-c-auth -laws-c-cal -laws-c-compression \
-              -laws-c-event-stream -laws-c-mqtt -laws-c-s3 -laws-c-sdkutils -laws-c-common \
-              -lxml2 -lz -lbz2 -lcurl"
-     AC_SUBST(AWS_LIBS)
-
-     AC_MSG_NOTICE([AWS C++ SDK Found.])
-     AM_CONDITIONAL([USE_AWS_SDK], [true])],
-    [AC_MSG_NOTICE([AWS C++ SDK not Found.])
-     AM_CONDITIONAL([USE_AWS_SDK], [false])])
-
-AC_MSG_CHECKING([the OS type for the AWS SDK linkage])
+AC_MSG_CHECKING([the OS type for shared object dependencies linkage])
 AS_CASE([$host],
     [*darwin*], [AM_CONDITIONAL([DARWIN], [true])
                  AC_MSG_NOTICE([OSX found.])],
     [AM_CONDITIONAL([DARWIN], [false])
      AC_MSG_NOTICE([OSX not found.])])
+
+dnl Should we look for the AWS C++ SDK? By default, 'yes' but --without-aws will
+dnl disable the check. jhrg 10/16/25
+
+AC_ARG_WITH([aws],
+    AS_HELP_STRING([--without-aws],
+    [Disable support for the AWS C++ SDK. Do not look for, or use, the AWS SDK. (Used by default)]))
+
+AM_CONDITIONAL([LOOK_FOR_AWS], [test "x$with_aws" != "xno"])
+AM_COND_IF([LOOK_FOR_AWS],
+    [AC_MSG_NOTICE([Looking for the AWS C++ SDK])],
+    [AC_MSG_NOTICE([Not looking for the AWS C++ SDK])
+     AM_CONDITIONAL([USE_AWS_SDK], [false])])
+
+dnl Define these no matter what we do. This prevents errors in teh Makefile.am files when the
+dnl libraries are not found/used. jhrg 10/16/25
+
+aws_prefix=
+aws_libs=
+aws_libdir=
+
+AM_COND_IF([LOOK_FOR_AWS],
+    [
+    dnl Look for the AWS libraries (aws-cpp-sdk-s3 aws-cpp-sdk-core) and headers
+    dnl jhrg 3/11/25
+
+    dnl Look for the AWS SDK from the hyrax-dependencies. jhrg 10/9/25
+
+    AC_LANG_PUSH([C++])
+    saved_CPPFLAGS=$CPPFLAGS
+    CPPFLAGS="$CPPFLAGS -I$ac_bes_dependencies_prefix/include"
+    AC_CHECK_HEADERS([aws/core/Aws.h], [found_aws_h=true], [found_aws_h=false])
+    AC_CHECK_HEADERS([aws/s3/S3Client.h], [found_s3client_h=true], [found_s3client_h=false])
+    CPPFLAGS=$saved_CPPFLAGS
+    AC_LANG_POP([C++])
+
+    AS_IF([$found_aws_h && $found_s3client_h],
+        [aws_prefix=$ac_bes_dependencies_prefix
+
+         aws_libs="-laws-crt-cpp -laws-cpp-sdk-s3 -laws-cpp-sdk-core \
+                  -laws-c-http -laws-c-io -laws-c-auth -laws-c-cal -laws-c-compression \
+                  -laws-c-event-stream -laws-c-mqtt -laws-c-s3 -laws-c-sdkutils -laws-c-common \
+                  -lxml2 -lz -lbz2 -lcurl"
+
+         aws_libdir=$aws_prefix/lib
+
+         AC_MSG_NOTICE([AWS C++ SDK Found.])
+         AM_CONDITIONAL([USE_AWS_SDK], [true])],
+        [AC_MSG_NOTICE([AWS C++ SDK not Found.])
+         AM_CONDITIONAL([USE_AWS_SDK], [false])])
+    ])
+
+AC_SUBST(aws_prefix)
+AC_SUBST(aws_libs)
+AC_SUBST(aws_libdir)
 
 dnl Freeform hacks
 
@@ -994,7 +1023,7 @@ OPTIONAL_FEATURES=
 
 AM_COND_IF([OPENJPEG_FOUND], [OPTIONAL_FEATURES="openjpeg"])
 AM_COND_IF([BUILD_GDAL], [OPTIONAL_FEATURES="gdal $OPTIONAL_FEATURES"])
-AM_COND_IF([USE_AWS_SDK], [OPTIONAL_FEATURES="AWS C++ SDK $OPTIONAL_FEATURES"])
+AM_COND_IF([USE_AWS_SDK], [OPTIONAL_FEATURES="AWS_C++_SDK $OPTIONAL_FEATURES"])
 dnl NETCDF4_TESTS are not considered an 'optional feature' since netcdf is netCDF4
 AM_COND_IF([BUILD_NETCDF], [OPTIONAL_FEATURES="netcdf $OPTIONAL_FEATURES"])
 AM_COND_IF([BUILD_FITS], [OPTIONAL_FEATURES="fits $OPTIONAL_FEATURES"])


### PR DESCRIPTION
## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-1901

<!-- Description of task -->
The SDK build is now controlled both by a --with/without-aws option to configure and a search for library headers. The link-time behavior is set using variables defined in configure.ac.

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
--Tests added/updated-- There are no automated tests for these CICD features
- [x] Dead code removed
- [x] No TODOs added
