### PR TITLE
HYRAX-1921: Fix the test/unit-tests Makefile fail in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1298,7 +1298,7 @@ AM_COND_IF([DAP_BUILTIN_MODULES],
         
     AC_CONFIG_TESTDIR(modules/httpd_catalog_module/tests, [standalone])
 
-    AC_CONFIG_TESTDIR(modules/cmr_module/tests, [standalone])
+    dnl AC_CONFIG_TESTDIR(modules/cmr_module/tests, [standalone]) HYRAX-1921 jhrg 10/29/25
     AC_CONFIG_TESTDIR(modules/s3_reader/tests, [standalone])
     AC_CONFIG_TESTDIR(modules/fileout_json/tests, [standalone])
     AC_CONFIG_TESTDIR(modules/fileout_covjson/tests, [standalone])


### PR DESCRIPTION
AC_CONFIG_FILES is pretty sensitive when SUBDIRS changes what gets built and also does not much like comments in its arguments.

## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-1921

<!-- Description of task -->


## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [ ] Tests added/updated N/A
- [x] Dead code removed
- [x] No TODOs added
