### PR TITLE
HYRAX-1924: 64x bit config fixes

### DIFF
--- a/aws/unit-tests/Makefile.am
+++ b/aws/unit-tests/Makefile.am
@@ -24,10 +24,10 @@ AM_LDFLAGS += -Wl,-rpath,$(aws_libdir) -Wl,-rpath,'$$ORIGIN'
         $(info "aws_libdir64 not set, skipping")
     else
         AM_LDFLAGS += -L$(aws_libdir64)
-        AM_LDFLAGS += -Wl,-rpath,$(aws_libdir64) -Wl,-rpath,'$$ORIGIN'
+        AM_LDFLAGS += -Wl,-rpath,$(aws_libdir64)
     endif
 endif
-$(info "AM_LDFLAGS: $(AM_LDFLAGS)")
+# $(info "AM_LDFLAGS: $(AM_LDFLAGS)")
 
 # This will help make 'make check' predictable with varying build environments.
 # jhrg 10/15/25

--- a/configure.ac
+++ b/configure.ac
@@ -608,15 +608,15 @@ AM_COND_IF([LOOK_FOR_AWS],
          AS_IF(
             dnl OSX test
             [echo ${host} | grep -q 'darwin.*'],
-            [aws_libdir=$aws_prefix/lib; AC_MSG_NOTICE([>>> OSX Arch Found: $host])],
+            [aws_libdir=$aws_prefix/lib; AC_MSG_NOTICE([    OSX Arch Found: $host])],
             dnl else
             [
                 ARCH=""
                 AS_CASE([$host_cpu],
                     [x86_64|aarch64*|mips64*|ppc64*|sparc64*],
-                    [ARCH="64"; AC_MSG_NOTICE([>>> 64x Arch Found: $host_cpu])],
+                    [ARCH="64"; AC_MSG_NOTICE([    64x Arch Found: $host_cpu])],
                     [i?86|arm*|mips*|ppc*|sparc],
-                    [ARCH="32"; AC_MSG_NOTICE([>>> 32x Arch Found: $host_cpu])])
+                    [ARCH="32"; AC_MSG_NOTICE([    32x Arch Found: $host_cpu])])
 
                 AS_IF(
                     dnl 64-bit system


### PR DESCRIPTION
## Description
The BES couldn't find AWS libraries needed to run the AWS unit-tests on 64 bit systems
this fixes that problem and handles OSX, 32x and 64x systems 

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [ ] Tests added/updated
- [x] Dead code removed
- [x] No TODOs added
