### PR TITLE
HYRAX-1913, make HDF5 handler compile with HDF5 1.14.6.

### DIFF
--- a/modules/hdf5_handler/HDF5Array.cc
+++ b/modules/hdf5_handler/HDF5Array.cc
@@ -837,7 +837,7 @@ void HDF5Array:: m_array_of_object_reference(hid_t d_dset_id, vector<string>& v_
     }
 }
 
-bool HDF5Array::m_array_of_reference_new_h5_apis(hid_t dset_id,hid_t dtype_id) const {
+bool HDF5Array::m_array_of_reference_new_h5_apis(hid_t dset_id,hid_t dtype_id) {
 
 #if (H5_VERS_MAJOR == 1 && (H5_VERS_MINOR == 10 || H5_VERS_MINOR == 8 || H5_VERS_MINOR == 6))
     throw BESInternalError(

--- a/modules/hdf5_handler/HDF5Array.h
+++ b/modules/hdf5_handler/HDF5Array.h
@@ -72,7 +72,7 @@ class HDF5Array:public libdap::Array {
     void m_array_of_object_reference(hid_t d_dset_id, std::vector<std::string>& v_str, int64_t nelms,
                                      const std::vector<int64_t>& offset, const std::vector<int64_t> &step) const;
 
-    bool m_array_of_reference_new_h5_apis(hid_t dset_id,hid_t dtype_id) const;
+    bool m_array_of_reference_new_h5_apis(hid_t dset_id,hid_t dtype_id);
 
     void m_intern_plain_array_data(char *convbuf,hid_t memtype);
     void m_array_of_atomic(hid_t, hid_t,int64_t ,const int64_t *,const int64_t *,const int64_t *);

--- a/modules/hdf5_handler/h5get.cc
+++ b/modules/hdf5_handler/h5get.cc
@@ -1642,7 +1642,7 @@ string obtain_enum_def_name(hid_t pid, hid_t datatype) {
 
         // Obtain the object type, such as group or dataset.
         H5O_info_t oinfo;
-        if (H5Oget_info_by_idx(pid, ".", H5_INDEX_NAME, H5_ITER_NATIVE,i,&oinfo,H5P_DEFAULT)<0) {
+        if (H5OGET_INFO_BY_IDX(pid, ".", H5_INDEX_NAME, H5_ITER_NATIVE,i,&oinfo,H5P_DEFAULT)<0) {
             string msg = "H5Oget_info_by_idx fails to obtain enum type name.";
             throw BESInternalError(msg,__FILE__,__LINE__);
         }


### PR DESCRIPTION
## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-1913

<!-- Description of task -->
We need to update the HDF5 handler if we want to use the HDF5 1.14.6 in the hyrax dependencies.
In this ticket, I update the HDF5 handler so that it can work with both with the current hyrax dependencies(HDF5 1.10.10) and HDF5 1.14.6. 

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] No TODOs added
