### PR TITLE
Housekeeping: Update mkchk script to show errors where build failed

### DIFF
--- a/mkchk
+++ b/mkchk
@@ -25,4 +25,4 @@ then
 fi
 
     
-make -k -j20 check 2>&1 | tee mk.log | grep -e "Making check in" -e "FAILED" -e "^FAIL: "
+make -k -j20 check 2>&1 | tee mk.log | grep -e "Making check in" -e "FAILED" -e "^FAIL: " -e " Error 2"

--- a/mkdchk
+++ b/mkdchk
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make -k -j20 GZIP_ENV=--fast distcheck 2>&1 | tee mk.log | grep -e "Making check in" -e "FAILED"
+make -k -j20 GZIP_ENV=--fast distcheck 2>&1 | tee mk.log | grep -e "Making check in" -e "FAILED" -e "^FAIL: " -e " Error 2"


### PR DESCRIPTION
Previously, running `./mkchk` would display:
- lines starting with "Making check in"
- unit test failures
- test failures

Now, include lines with ` Error 2` which indicates that a test failed to be run at all (and therefore could not fail). 

Also update ./mkdchk to match ./mkchk behavior.
