### PR TITLE
Add test_variable_sleep_interval to dmrpprequesthandler

### DIFF
--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -93,7 +93,7 @@ using namespace std;
 #define prolog std::string("DmrppRequestHandler::").append(__func__).append("() - ")
 #define dmrpp_cache "dmrpp:cache"
 
-int test_variable_sleep_interval = 0;
+const int test_variable_sleep_interval = 0;
 
 namespace dmrpp {
 


### PR DESCRIPTION
Support #1213 (fixes dmrpp_module tests).