### PR TITLE
BES-1219: In tests, make version replacement OS-agnostic and support build version suffix

### DIFF
--- a/modules/dmrpp_module/tests_build_dmrpp/build_dmrpp_macros.m4
+++ b/modules/dmrpp_module/tests_build_dmrpp/build_dmrpp_macros.m4
@@ -147,9 +147,9 @@ dnl jhrg 12/29/21
 
 m4_define([REMOVE_VERSIONS], [dnl
   awk '{
-    gsub(/<Value>[[0-9]+].[[0-9]+].[[0-9]+](-[[0-9]+])?<\/Value>/, "<Value>removed version</Value>");
-    gsub(/<Value>[[a-zA-Z._]+]-[[0-9]+].[[0-9]+].[[0-9]+](-[[0-9]+])?<\/Value>/, "<Value>removed version</Value>");
-    gsub(/dmrpp:version="[[0-9]+].[[0-9]+].[[0-9]+](-[[0-9]+])?"/, "removed dmrpp:version");
+    gsub(/<Value>[[0-9]+]\.[[0-9]+]\.[[0-9]+](-[[0-9]+])?<\/Value>/, "<Value>removed version</Value>");
+    gsub(/<Value>[[a-zA-Z._]+]-[[0-9]+]\.[[0-9]+]\.[[0-9]+](-[[0-9]+])?<\/Value>/, "<Value>removed version</Value>");
+    gsub(/dmrpp:version="[[0-9]+]\.[[0-9]+]\.[[0-9]+](-[[0-9]+])?"/, "removed dmrpp:version");
     print
   }' < $1 > $1.awk
   mv $1.awk $1


### PR DESCRIPTION
## Description

Support HYRAX-1964 development by (in tests) supporting build numbers with a build suffix, e.g., "1.2.3" AND "1.2.3-411".

In the process, implement #1219, namely make the version replacement agnostic. This was accomplished through switching from sed to awk, to bypass os-specific sed behavior. (The -E flag and -r flag both failed to work on my local dev machine.)

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [ ] Tests added/updated
- [x] Dead code removed
- [x] No TODOs added
