### PR TITLE
HYRAX-1986, fix the .at so that the CF option tests will be turned on.

### DIFF
--- a/modules/hdf5_handler/bes-testsuite/hdf5_handlerTest.at
+++ b/modules/hdf5_handler/bes-testsuite/hdf5_handlerTest.at
@@ -73,7 +73,7 @@ m4_define([_AT_BESCMD_TEST],
 AT_KEYWORDS([bescmd])
 
 # Use the following AT_CHECK lines to generate baseline file.
-AT_CHECK([besstandalone -c $abs_builddir/bes.cfdmr.conf -i $1 > $2|| true], [], [stdout], [stderr])
+#AT_CHECK([besstandalone -c $abs_builddir/bes.cfdmr.conf -i $1 > $2|| true], [], [stdout], [stderr])
 
 # This looks like a copy of the older logic we used and it will pass a test
 # if the baseline is empty and the test wrote nothing to stderr. It's better


### PR DESCRIPTION
## Description
Make the HDF5 handler test the CF option again. Previously it simply regenerates the baseline files.


<!-- Description of task -->

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] Tests added/updated

