### PR TITLE
BES-1236: Add gha workflow for building on mac

### DIFF
--- a/.github/workflows/.build-osx.yml
+++ b/.github/workflows/.build-osx.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     env:
       GDAL_OPTION: "--without-gdal"
-      CMAC_ID: "${ secrets.AWS_GHA_BES_ID }"
-      CMAC_ACCESS_KEY: "${ secrets.AWS_GHA_BES_SECRET_KEY }"
+      CMAC_ID: "${{ secrets.AWS_GHA_BES_ID }}"
+      CMAC_ACCESS_KEY: "${{ secrets.AWS_GHA_BES_SECRET_KEY }}"
       CMAC_URL: "https://s3.amazonaws.com/cloudydap/"
       CMAC_REGION: "us-east-1"
       CMAC_ON: "yes"


### PR DESCRIPTION
## Description

Fix #1236. 

Add GHA CI job to build and run tests on mac (m4, intel), to try to maintain good repo state for local development.

~~Tests themselves will fail until #1229 is merged. EDIT: Complete~~

