### PR TITLE
Fix travis deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -279,6 +279,8 @@ before_deploy:
   - if test "$BES_BUILD" = "srcdist"; then cp bes-*.tar.gz $TRAVIS_BUILD_DIR/package; fi
   # Rocky8  distribution prep
   - if test "$BES_BUILD" = "rocky8"; then ./travis/rpm-to-package-dir.sh "el8"; fi
+  # Rocky9  distribution prep
+  - if test "$BES_BUILD" = "rocky9"; then ./travis/rpm-to-package-dir.sh "el9"; fi
   # Check for the stuff...
   - ls -l $TRAVIS_BUILD_DIR/package
 


### PR DESCRIPTION
## Description

Remove invalid `name` fields added in #1213, which weren't caught until the PR merged to master.

Also add back pre-deploy prep for the rocky9 rpms that were inadvertently removed

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [ ] Ticket exists and is linked in title
- [x] Tests added/updated
- [x] Dead code removed
- [x] No TODOs added
