### PR TITLE
BES-1248: Post build logs to aws for docker builds

### DIFF
--- a/travis/upload-test-results.sh
+++ b/travis/upload-test-results.sh
@@ -3,8 +3,9 @@
 # Upload the results of tests after running a build on Travis
 
 LOG_FILE_TGZ=bes-autotest-${TRAVIS_JOB_NUMBER}-logs.tar.gz
-if [[ "$BES_BUILD" = "main" || "$BES_BUILD" = "distcheck" || "$BES_BUILD" = "docker"* ]]
+if test "$BES_BUILD" = main -o "$BES_BUILD" = distcheck -o "$BES_BUILD" = "docker-rhel8"
 then
+	echo "Packaging log files for '$BES_BUILD'"
 	tar -czf /tmp/${LOG_FILE_TGZ} `find . -name timing -prune -o -name '*.log' -print -o -name '*site_map.txt' -print`
 
 	# using: 'test -z "$AWS_ACCESS_KEY_ID" || ...' keeps after_script from running


### PR DESCRIPTION
## Description

Feature #1248. Adds parity with other jobs, namely, job log is now posted to AWS for docker jobs. 

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [ ] ~~Tests added/updated~~
- [ ] ~~Dead code removed~~
- [x] No TODOs added
