### PR TITLE
HYRAX-2029, check if a dimension is  unlimited to decide if can do th…

### DIFF
--- a/modules/dmrpp_module/DMZ.cc
+++ b/modules/dmrpp_module/DMZ.cc
@@ -923,17 +923,16 @@ void DMZ::set_up_all_direct_io_flags_phase_2(DMR *dmr) {
 void DMZ::set_up_direct_io_flag_phase_2(D4Group *group) {
     for (auto i = group->var_begin(), e = group->var_end(); i != e; ++i) {
         if ((*i)->type() == dods_array_c)
-            set_up_direct_io_flag_phase_2((*i));
+            set_up_direct_io_flag_phase_2(group, (*i));
     }
 
     for (auto gi = group->grp_begin(), ge = group->grp_end(); gi != ge; ++gi)
         set_up_direct_io_flag_phase_2((*gi));
 }
 
-void DMZ::set_up_direct_io_flag_phase_2(BaseType *btp) {
+void DMZ::set_up_direct_io_flag_phase_2(D4Group * grp, BaseType *btp) {
     bool is_integer_float = false;
     Array *t_a = nullptr;
-
     Type t = btp->type();
     if (t == dods_array_c) {
         t_a = dynamic_cast<Array *>(btp);
@@ -1046,7 +1045,7 @@ void DMZ::set_up_direct_io_flag_phase_2(BaseType *btp) {
     bool chunk_less_dim = true;
     if (chunk_dim_sizes.size() == dim_sizes.size()) {
         for (unsigned int i = 0; i < dim_sizes.size(); i++) {
-            if (chunk_dim_sizes[i] > dim_sizes[i]) {
+            if (chunk_dim_sizes[i] > dim_sizes[i]  && has_unlimited_dim(grp)==false) {
                 chunk_less_dim = false;
                 break;
             }
@@ -1091,6 +1090,18 @@ void DMZ::set_up_direct_io_flag_phase_2(BaseType *btp) {
     t_a->set_dio_flag();
 }
 
+bool DMZ::has_unlimited_dim(libdap::D4Group *group) {
+
+    bool ret_value = false;
+    D4Attribute *d4_container = group->attributes()->get("DODS_EXTRA");
+    if (d4_container) {
+        // The current HDF5 handler implementation ensures the unlimited dimension name and size
+        // are passed to the variable level. So we don't need to check them.
+        if (d4_container->attributes()->get("Unlimited_Dimension"))
+            ret_value = true;
+    }
+    return ret_value;
+}
 
 /**
  * Check to see if the current tag is either an \c Attribute or an \c Alias

--- a/modules/dmrpp_module/DMZ.h
+++ b/modules/dmrpp_module/DMZ.h
@@ -160,7 +160,8 @@ public:
 
     virtual void set_up_all_direct_io_flags_phase_2(libdap::DMR *dmr);
     virtual void set_up_direct_io_flag_phase_2(libdap::D4Group *group);
-    virtual void set_up_direct_io_flag_phase_2(libdap::BaseType *btp);
+    virtual void set_up_direct_io_flag_phase_2(libdap::D4Group *group, libdap::BaseType *btp);
+    virtual bool has_unlimited_dim(libdap::D4Group *group);
 
 
     virtual void load_attributes(libdap::BaseType *btp);

--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -346,6 +346,7 @@ void DmrppRequestHandler::get_dmrpp_from_container_or_cache(BESContainer *contai
             dmz->parse_xml_string(dmrpp_content);
 
             dmz->build_thin_dmr(dmr);
+            dmz->load_all_attributes(dmr);
 
             BESDEBUG("dmrpp","Before calling set_up_all_direct_io_flags"<<endl);
             if (DmrppRequestHandler::is_netcdf4_enhanced_response == true &&
@@ -358,7 +359,6 @@ void DmrppRequestHandler::get_dmrpp_from_container_or_cache(BESContainer *contai
                 }
             }
 
-            dmz->load_all_attributes(dmr);
         }
         else {
             string data_pathname = container->access();
@@ -376,6 +376,7 @@ void DmrppRequestHandler::get_dmrpp_from_container_or_cache(BESContainer *contai
             dmz->parse_xml_doc(data_pathname);
 
             dmz->build_thin_dmr(dmr);
+            dmz->load_all_attributes(dmr);
             BESDEBUG("dmrpp","Before calling set_up_all_direct_io_flags: second"<<endl);
             if (DmrppRequestHandler::is_netcdf4_enhanced_response == true &&
                 DmrppRequestHandler::disable_direct_io == false) { 
@@ -387,7 +388,6 @@ void DmrppRequestHandler::get_dmrpp_from_container_or_cache(BESContainer *contai
                 }
             }
  
-            dmz->load_all_attributes(dmr);
         }
     }
     catch (...) {


### PR DESCRIPTION
…e direct IO

## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2029

<!-- Description of task -->
When a dimension is unlimited and the dimension size is smaller than the chunk size, this ticket makes direct chunk IO still apply to this variable. We already have a test that covers this case.  ncdump data and header are the same.  We can see the new file keep the original chunk and compression level with the HDF5 tool. 

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] Dead code removed
- [x] No TODOs added
