### PR TITLE
Prune files from `bes_core` docker image to reduce size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,12 +130,10 @@ before_script:
 
 stages:
   - name: build-and-test
-    if: branch = never
   - name: build-rpms
-    if: branch = never
   - name: build-docker
   - name: scan
-    if: branch = never
+    if:  branch = master
   - name: hyrax-olfs-trigger
     if: type != pull_request OR branch =~ ^(.*-test-deploy)$
     # A way to skip a stage. jhrg 1/26/23


### PR DESCRIPTION
Remove installed bes/*.a and bes/*.la files.

Old `bes_core-el8`: `2.41GB`
New: `1.28GB`

Reduction of 1.13 GB

---
Old `bes_core-el9`: `2.35GB`
New: `1.2GB`

Reduction of 1.15 GB