### PR TITLE
Jhrg/hyrax 2076 fix gctp

### DIFF
--- a/modules/hdf5_handler/gctp/src/gctp.c
+++ b/modules/hdf5_handler/gctp/src/gctp.c
@@ -45,8 +45,8 @@ static long outpj[MAXPROJ + 1];		/* output projection array	*/
 static long outdat[MAXPROJ + 1];	/* output dataum array		*/
 static long outzn[MAXPROJ + 1];		/* output zone array		*/
 static double pdout[MAXPROJ + 1][15]; 	/* output projection parm array	*/
-static long (*hfor_trans[MAXPROJ + 1])();/* forward function pointer array*/
-static long (*hinv_trans[MAXPROJ + 1])();/* inverse function pointer array*/
+static int (*hfor_trans[MAXPROJ + 1])(double, double, double *, double *);/* forward function pointer array*/
+static int (*hinv_trans[MAXPROJ + 1])(double, double, double *, double *);/* inverse function pointer array*/
 
 			/* Table of unit codes as specified by state
 			   laws as of 2/1/92 for NAD 1983 State Plane
@@ -91,11 +91,11 @@ long *jpr,		/* printout flag for projection parameters 0=screen,
 			   1=file, 2 = both*/
 char *pfile,		/* error file name				*/
 double *outcoor,	/* output coordinates				*/
-long *outdatum,		/* output datum					*/
 long *outsys,		/* output projection code			*/
 long *outzone,		/* output zone					*/
 double *outparm,	/* output projection array			*/
 long *outunit,		/* output units					*/
+long *outdatum,		/* output datum					*/
 char fn27[],		/* file name of NAD 1927 parameter file		*/
 char fn83[], 	 	/* file name of NAD 1983 parameter file		*/
 long *iflg)		/* error flag					*/
@@ -106,7 +106,7 @@ double factor;		/* conversion factor				*/
 double lon;		/* longitude					*/
 double lat;		/* latitude					*/
 /*double temp;	*/	/* dummy variable				*/
-double pakr2dm();
+double pakr2dm(double ang);
 long i,j;		/* loop counters				*/
 long ininit_flag;	/* input initilization flag			*/
 long outinit_flag;	/* output initilization flag			*/
@@ -257,10 +257,10 @@ y = incoor[1] * factor;
          dummy[0] = inparm[0];
          dummy[1] = inparm[1];
          }
-      hinv_init((int)*insys,(int)*inzone,dummy,(int)*indatum,fn27,fn83,&iflgval,(int *)hinv_trans);
+      hinv_init((int)*insys,(int)*inzone,dummy,(int)*indatum,fn27,fn83,&iflgval,hinv_trans);
       }
    else
-     hinv_init((int)*insys,(int)*inzone,inparm,(int)*indatum,fn27,fn83,&iflgval,(int *)hinv_trans);
+     hinv_init((int)*insys,(int)*inzone,inparm,(int)*indatum,fn27,fn83,&iflgval,hinv_trans);
    *iflg=(long)iflgval;
 
    if ((int)*iflg != 0)
@@ -319,10 +319,10 @@ else
 	 dummy[0] = outparm[0];
 	 dummy[1] = outparm[1];
 	 }
-      hfor_init((int)*outsys,(int)*outzone,dummy,(int)*outdatum,fn27,fn83,&iflgval,(int *)hfor_trans);
+      hfor_init((int)*outsys,(int)*outzone,dummy,(int)*outdatum,fn27,fn83,&iflgval,hfor_trans);
       }
    else
-     hfor_init((int)*outsys,(int)*outzone,outparm,(int)*outdatum,fn27,fn83,&iflgval,(int *)hfor_trans);
+     hfor_init((int)*outsys,(int)*outzone,outparm,(int)*outdatum,fn27,fn83,&iflgval,hfor_trans);
 
    *iflg=(long)iflgval;
 

--- a/modules/hdf5_handler/gctp/src/merfor.c
+++ b/modules/hdf5_handler/gctp/src/merfor.c
@@ -47,7 +47,6 @@ double false_east,		/* x offset in meters		*/
 double false_north)		/* y offset in meters		*/
 {
 double temp;			/* temporary variable		*/
-double e0fn(),e1fn(),e2fn(),e3fn(); 	/* 	functions	*/
 
 /* Place parameters in static storage for common use
   -------------------------------------------------*/

--- a/modules/hdf5_handler/gctp/src/merinv.c
+++ b/modules/hdf5_handler/gctp/src/merinv.c
@@ -47,7 +47,6 @@ double false_east,		/* x offset in meters		*/
 double false_north)		/* y offset in meters		*/
 {
 double temp;			/* temporary variable		*/
-double e0fn(),e1fn(),e2fn(),e3fn(); 	/* 	functions	*/
 
 /* Place parameters in static storage for common use
   -------------------------------------------------*/

--- a/modules/hdf5_handler/gctp/src/somfor.c
+++ b/modules/hdf5_handler/gctp/src/somfor.c
@@ -57,7 +57,6 @@ double sat_ratio)               /* satellite ratio which specify the
 long i;
 double alf,e2c,e2s,one_es;
 double dlam,fb,fa2,fa4,fc1,fc3,suma2,suma4,sumc1,sumc3,sumb;
-double adjust_lon();
 
 /* Assign satellite ratio to a global variable 
    ------------------------------------------- */


### PR DESCRIPTION
## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2076

<!-- Description of task -->
The GCTP code in the hdf5_handler has at least one function - gctp() - that is using a very old definition form. Modern compilers reject this and it's now tripping up our CICD system on OSX. To see if this works as a fix, run the PR as ready for review even though that's not 100% true (the OSX builds don't run on draft PRs).

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] Tests added/updated
- [x] Dead code removed
- [x] No TODOs added
