### PR TITLE
HYRAX-2079 Remove libdap testing from OSX CI

### DIFF
--- a/.github/workflows/.build-osx.yml
+++ b/.github/workflows/.build-osx.yml
@@ -70,7 +70,7 @@ jobs:
           echo "PATH: $(cat $GITHUB_PATH)"
           ls $prefix
         shell: bash
-      - name: Build, check, and install libdap
+      - name: Build and install libdap
         run: |
           # In the future, consider moving this to the libdap repo...
           set -x
@@ -80,7 +80,6 @@ jobs:
           autoreconf -fiv
           ./configure --prefix=$prefix --enable-developer
           make -j16
-          make check
           make install
           ls $prefix
         shell: bash


### PR DESCRIPTION
## Description

The libdap tests have spurious failures that are unrelated to bes changes; remove them to improve build reliability.
HYRAX-2079

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [ ] Tests added/updated
- [x] Dead code removed
- [x] No TODOs added
