### PR TITLE
Don't trigger gha builds when unrelated files are changed

### DIFF
--- a/.github/workflows/.build-osx.yml
+++ b/.github/workflows/.build-osx.yml
@@ -2,16 +2,23 @@
 # machines, to ensure code changes won't break local development
 name: OSX CI
 on:
-  # For now, run only on manually triggered builds (workflow_dispatch).
-  # Uncomment the "push" and "pull_request" to build on all non-draft PRs
   workflow_dispatch:
   push:
     branches:
       - master
       - main
       - /^(.*-test-deploy)$/
+    paths-ignore:
+      - ".vscode/**"
+      - "*.md"
+      - "Dockerfile"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - ".vscode/**"
+      - "*.md"
+      - "Dockerfile"
+
 concurrency:
   # Cancel intermediate builds only on pull requests
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
A tiny build time improvement by skipping GHA builds when development is only happening on the Dockerfile or documentation.