### PR TITLE
HYRAX-2118, makes the HDF5 handler only support the HDF5 library version in the hyrax dependencies

### DIFF
--- a/modules/hdf5_handler/HDF5GMCF.cc
+++ b/modules/hdf5_handler/HDF5GMCF.cc
@@ -988,19 +988,6 @@ void GMFile::Add_UseDimscale_Var_Dim_Names_Mea_SeaWiFS_Ozone(const Var *var,cons
             // The above code works with dereferencing references generated with new H5R(H5R_ref_t) APIs with 1.12 and 1.13.
             // However, in case this h5rdeference2 API stops working with new APIs, the following #if 0 #endif block is a 
             // way to handle this issue.
-#if 0
-     
-            rbuf =((hobj_ref_t*)vl_ref[0].p)[0];
-            H5E_BEGIN_TRY {
-                dset1 =  H5Rdereference2(attr_id,H5P_DEFAULT,H5R_OBJECT,&ds_ref_buf);
-            } H5E_END_TRY;
-
-            H5R_ref_t new_rbuf =((H5R_ref_t*)vlbuf[vlbuf_index].p)[0];
-            if ((ref_dset = H5Ropen_object((H5R_ref_t *)&new_rbuf, H5P_DEFAULT, H5P_DEFAULT))<0)
-                throw2("Cannot dereference from the DIMENSION_LIST attribute  for the variable ",var->name);
-            H5Rdestroy(&new_rbuf);
-
-#endif
             if ((objnamelen= H5Iget_name(ref_dset,nullptr,0))<=0) 
                 throw2("Cannot obtain the dataset name dereferenced from the DIMENSION_LIST attribute  for the variable ",var->name);
             objname.resize(objnamelen+1);

--- a/modules/hdf5_handler/h5apicompatible.h
+++ b/modules/hdf5_handler/h5apicompatible.h
@@ -12,34 +12,10 @@
 #ifndef H5APICOMPITABLE_H
 #define H5APICOMPITABLE_H
 
-
-#if ((H5_VERS_MAJOR == 1) && (H5_VERS_MINOR == 8))
-
-#define H5RDEREFERENCE(obj_id,ref_type,ref) H5Rdereference(obj_id,ref_type,ref)
-#define H5OGET_INFO_BY_IDX(loc_id, group_name, idx_type, order, n, oinfo, lapl_id) H5Oget_info_by_idx(loc_id, group_name, idx_type, order, n, oinfo, lapl_id)
-#define H5OGET_INFO(loc_id, oinfo) H5Oget_info(loc_id,oinfo)
-#define H5OVISIT(obj_id,idx_type,order,op,op_data) H5Ovisit(obj_id,idx_type,order,op,op_data)
-
-#elif ((H5_VERS_MAJOR == 1) && (H5_VERS_MINOR == 10))
-
-  #if (defined H5_USE_18_API)
-  #define H5RDEREFERENCE(obj_id,ref_type,ref) H5Rdereference1(obj_id,ref_type,ref)
-  #define H5OGET_INFO(loc_id, oinfo) H5Oget_info1(loc_id,oinfo)
-  #define H5OGET_INFO_BY_IDX(loc_id, group_name, idx_type, order, n, oinfo, lapl_id) H5Oget_info_by_idx(loc_id, group_name, idx_type, order, n, oinfo, lapl_id)
-  #define H5OVISIT(obj_id,idx_type,order,op,op_data) H5Ovisit(obj_id,idx_type,order,op,op_data)
-  #else                                        
-  #define H5RDEREFERENCE(obj_id,ref_type,ref) H5Rdereference2(obj_id,H5P_DEFAULT,ref_type,ref)
-  #define H5OGET_INFO(loc_id, oinfo) H5Oget_info2(loc_id,oinfo,H5O_INFO_BASIC|H5O_INFO_NUM_ATTRS)
-  #define H5OGET_INFO_BY_IDX(loc_id, group_name, idx_type, order, n, oinfo, lapl_id) H5Oget_info_by_idx2(loc_id, group_name, idx_type, order, n, oinfo, H5O_INFO_BASIC| H5O_INFO_NUM_ATTRS, lapl_id)
-  #define H5OVISIT(obj_id,idx_type,order,op,op_data) H5Ovisit2(obj_id,idx_type,order,op,op_data,H5O_INFO_BASIC)
-  #endif
-
-#else
 #define H5RDEREFERENCE(obj_id,ref_type,ref) H5Rdereference2(obj_id,H5P_DEFAULT,ref_type,ref)
 #define H5OGET_INFO_BY_IDX(loc_id, group_name, idx_type, order, n, oinfo, lapl_id) H5Oget_info_by_idx3(loc_id, group_name, idx_type, order, n, oinfo, H5O_INFO_BASIC | H5O_INFO_NUM_ATTRS, lapl_id)
 #define H5OGET_INFO(loc_id, oinfo) H5Oget_info3(loc_id,oinfo,H5O_INFO_BASIC|H5O_INFO_NUM_ATTRS)
 #define H5OVISIT(obj_id,idx_type,order,op,op_data) H5Ovisit3(obj_id,idx_type,order,op,op_data,H5O_INFO_BASIC)
 
-#endif
 #endif
 

--- a/modules/hdf5_handler/h5dmr.cc
+++ b/modules/hdf5_handler/h5dmr.cc
@@ -2030,7 +2030,7 @@ hsize_t obtain_unlim_pure_dim_size_internal_value(hid_t dset_id, hid_t attr_id, 
 
     if (obj_type == H5O_TYPE_DATASET) {
 
-        hid_t did_ref = H5Rdereference2(dset_id, H5P_DEFAULT, H5R_OBJECT, &((ref_list[0]).s_ref));
+        hid_t did_ref = H5RDEREFERENCE(dset_id, H5R_OBJECT, &((ref_list[0]).s_ref));
         if (did_ref < 0) {
             H5Aclose(attr_id);
             H5Tclose(atype_id);


### PR DESCRIPTION
## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2118

<!-- Description of task -->
The HDF5 handler contains code that uses the HDF5 APIs that are only supported in the older HDF5 library versions. However, BES only depends on the HDF5 library distributed by Hyrax dependencies. So older HDF5 library versions will never be used. This ticket will remove the older version support. It will also make the handler use the newer APIs without considering the backward compatibilities. 

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] Dead code removed
- [x] No TODOs added
