### PR TITLE
Build on OSX w/o GDAL

### DIFF
--- a/.github/scripts/upload-test-results.sh
+++ b/.github/scripts/upload-test-results.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Upload the results of failed GitHub Actions tests to S3.
+
+set -e
+
+RUN_ID=${GITHUB_RUN_ID:-unknown-run}
+RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT:-1}
+JOB_NAME=${GITHUB_JOB:-unknown-job}
+RUNNER_LABEL=${GHA_RUNNER_LABEL:-unknown-runner}
+
+LOG_FILE_TGZ=bes-autotest-gha-${RUN_ID}-${RUN_ATTEMPT}-${JOB_NAME}-${RUNNER_LABEL}-logs.tar.gz
+LOG_FILE_TGZ=$(printf '%s' "$LOG_FILE_TGZ" | tr '/ ' '__')
+LOG_FILE_PATH=/tmp/${LOG_FILE_TGZ}
+S3_URI=s3://opendap.github.actions.test/${LOG_FILE_TGZ}
+
+if test -z "$AWS_ACCESS_KEY_ID"
+then
+    echo "AWS_ACCESS_KEY_ID is not set; skipping test log upload."
+    exit 0
+fi
+
+if ! find . -name timing -prune -o -name '*.log' -print -o -name '*site_map.txt' -print | grep -q .
+then
+    echo "No test log files found to upload."
+    exit 0
+fi
+
+echo "Packaging GitHub Actions test logs into ${LOG_FILE_PATH}"
+tar -czf "${LOG_FILE_PATH}" `find . -name timing -prune -o -name '*.log' -print -o -name '*site_map.txt' -print`
+
+echo "Uploading ${LOG_FILE_PATH} to ${S3_URI}"
+aws s3 cp "${LOG_FILE_PATH}" "${S3_URI}"

--- a/.github/workflows/.build-osx.yml
+++ b/.github/workflows/.build-osx.yml
@@ -12,12 +12,16 @@ on:
       - ".vscode/**"
       - "*.md"
       - "Dockerfile"
+      - "README*"
+      - "docs/**"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - ".vscode/**"
       - "*.md"
       - "Dockerfile"
+      - "README*"
+      - "docs/**"
 
 concurrency:
   # Cancel intermediate builds only on pull requests
@@ -39,6 +43,7 @@ jobs:
       CMAC_ON: "yes"
       LDFLAGS: "-L/opt/homebrew/opt/bison/lib -L/opt/homebrew/opt/jpeg/lib -L/opt/homebrew/opt/openssl/lib"
       CPPFLAGS: "-I/opt/homebrew/opt/jpeg/include -I/opt/homebrew/opt/openssl/include"
+      TESTSUITEFLAGS: "-j16"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/.build-osx.yml
+++ b/.github/workflows/.build-osx.yml
@@ -31,7 +31,7 @@ jobs:
     name: Build on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
     env:
-      CONFIGURE_OPTIONS: "--disable-ncml"
+      CONFIGURE_OPTIONS: "--disable-ncml --without-gdal"
       CMAC_ID: "${{ secrets.AWS_GHA_BES_ID }}"
       CMAC_ACCESS_KEY: "${{ secrets.AWS_GHA_BES_SECRET_KEY }}"
       CMAC_URL: "https://s3.amazonaws.com/cloudydap/"

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -101,7 +101,7 @@ jobs:
           export prefix="$HOME/install"
           pwd
           autoreconf --force --install --verbose
-          ./configure --disable-dependency-tracking --prefix=$prefix --with-dependencies=$prefix/deps $CONFIGURE_OPTIONS --enable-developer
+          ./configure --disable-dependency-tracking --prefix=$prefix --with-dependencies=$prefix/deps $CONFIGURE_OPTIONS
           set +x
         shell: bash
       - name: Build and test bes

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -160,12 +160,12 @@ jobs:
       - name: Post failure logs to aws
         if: steps.build-and-test.outcome == 'failure'
         run: |
-          ./travis/upload-test-results.sh
+          sh ./.github/scripts/upload-test-results.sh
           # Because previous job failed, we need to re-throw failure
           # now that logs are uploaded
           exit 1
         shell: bash
         env:
-          TRAVIS_JOB_NUMBER: gha-${{ github.run_id }}-${{ github.job }}
+          GHA_RUNNER_LABEL: ${{ matrix.runs-on }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GHA_BES_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GHA_BES_SECRET_KEY }}

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -139,7 +139,7 @@ jobs:
           ccache --show-stats || true
           pwd
           autoreconf --force --install --verbose
-          ./configure --disable-dependency-tracking --prefix=$prefix --with-dependencies=$prefix/deps $CONFIGURE_OPTIONS
+          ./configure --disable-dependency-tracking --prefix=$prefix --with-dependencies=$prefix/deps --enable-developer $CONFIGURE_OPTIONS
           set +x
         shell: bash
       - name: Build and test bes
@@ -150,9 +150,9 @@ jobs:
           export LD_LIBRARY_PATH="$prefix/deps/lib:$LD_LIBRARY_PATH"
           make -j16
           make install
-          sudo -s $prefix/bin/besctl start
+          besctl start
           make check -j16
-          sudo -s $prefix/bin/besctl stop
+          besctl stop
           ccache --show-stats || true
           set +x
         shell: bash

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -44,6 +44,10 @@ jobs:
       LDFLAGS: "-L/opt/homebrew/opt/bison/lib -L/opt/homebrew/opt/jpeg/lib -L/opt/homebrew/opt/openssl/lib"
       CPPFLAGS: "-I/opt/homebrew/opt/jpeg/include -I/opt/homebrew/opt/openssl/include"
       TESTSUITEFLAGS: "-j16"
+      CCACHE_DIR: "$HOME/.ccache"
+      CCACHE_MAXSIZE: "750M"
+      CC: "ccache clang"
+      CXX: "ccache clang++"
     strategy:
       fail-fast: false
       matrix:
@@ -55,9 +59,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-${{ matrix.runs-on }}-ccache-${{ hashFiles('libdap4-snapshot', '.github/workflows/build-osx.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.runs-on }}-ccache-
       - name: Install system dependencies
         run: |
           brew install bison \
+                       ccache \
                        jpeg \
                        cppunit \
                        autoconf \
@@ -77,28 +89,54 @@ jobs:
       - name: Update PATH
         run: |
           export prefix="$HOME/install"
-          echo -e "$prefix/bin:$prefix/deps/bin:/opt/homebrew/opt/bison/bin:/opt/homebrew/opt/jpeg/bin:$(cat $GITHUB_PATH)" > $GITHUB_PATH
+          {
+            echo "$prefix/bin"
+            echo "$prefix/deps/bin"
+            echo "/opt/homebrew/opt/bison/bin"
+            echo "/opt/homebrew/opt/jpeg/bin"
+          } >> "$GITHUB_PATH"
           echo "prefix: $prefix"
-          echo "PATH: $(cat $GITHUB_PATH)"
+          echo "Configured entries in GITHUB_PATH:"
+          cat "$GITHUB_PATH"
           ls $prefix
         shell: bash
+      - name: Restore libdap install cache
+        id: cache-libdap
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/install/bin
+            ~/install/include
+            ~/install/lib
+            ~/install/share
+          key: ${{ runner.os }}-${{ matrix.runs-on }}-libdap-${{ hashFiles('libdap4-snapshot', '.github/workflows/build-osx.yml') }}
       - name: Build and install libdap
         run: |
           # In the future, consider moving this to the libdap repo...
           set -x
           export prefix="$HOME/install"
+          ccache --set-config=max_size="$CCACHE_MAXSIZE"
+          ccache --show-stats || true
+          if [[ "${{ steps.cache-libdap.outputs.cache-hit }}" == "true" ]] && [[ -x "$prefix/bin/dap-config" ]]; then
+            echo "Using cached libdap install from $prefix"
+            "$prefix/bin/dap-config" --version || true
+            exit 0
+          fi
           git clone https://github.com/opendap/libdap4
           cd libdap4
           autoreconf -fiv
           ./configure --prefix=$prefix --enable-developer
           make -j16
           make install
+          ccache --show-stats || true
           ls $prefix
         shell: bash
       - name: Configure bes build
         run: |
           set -x
           export prefix="$HOME/install"
+          ccache --set-config=max_size="$CCACHE_MAXSIZE"
+          ccache --show-stats || true
           pwd
           autoreconf --force --install --verbose
           ./configure --disable-dependency-tracking --prefix=$prefix --with-dependencies=$prefix/deps $CONFIGURE_OPTIONS
@@ -112,9 +150,10 @@ jobs:
           export LD_LIBRARY_PATH="$prefix/deps/lib:$LD_LIBRARY_PATH"
           make -j16
           make install
-          besctl start
+          sudo -s $prefix/bin/besctl start
           make check -j16
-          besctl stop
+          sudo -s $prefix/bin/besctl stop
+          ccache --show-stats || true
           set +x
         shell: bash
         continue-on-error: true

--- a/docs/build-osx-runtime-plan.md
+++ b/docs/build-osx-runtime-plan.md
@@ -1,0 +1,65 @@
+# Reduce macOS CI Runtime in `build-osx.yml`
+
+## Summary
+
+Cut macOS workflow time primarily by reducing duplicate PR coverage and caching the expensive parts that are currently rebuilt every run.
+
+Defaults chosen:
+
+- Keep building `libdap4` from source, but cache that build output and compile results rather than introducing a new prebuilt artifact flow.
+- Keep both `macos-15` and `macos-15-intel` for pull requests, `main`/`master` pushes, and `workflow_dispatch`.
+
+## Key Changes
+
+- Split the current matrix behavior by event:
+  - PRs: run both `macos-15` and `macos-15-intel`.
+  - Pushes to `main`/`master` and manual runs: run both `macos-15` and `macos-15-intel`.
+  - Keep existing draft-PR skip behavior and current path filters.
+- Add compiler caching with `ccache`:
+  - Install `ccache` via Homebrew.
+  - Export `CC="ccache clang"` and `CXX="ccache clang++"` before both `libdap4` and BES configure/build steps.
+  - Set `CCACHE_DIR` under `$HOME/.ccache`, cap size explicitly, and print `ccache --show-stats` before and after build for observability.
+- Add GitHub Actions caches keyed by runner architecture and dependency inputs:
+  - Cache Homebrew downloads and installed formula state only if done via a well-supported action path; otherwise do not try to hand-roll Homebrew cellar caching.
+  - Cache `~/.ccache`.
+  - Cache the built `libdap4` install prefix under `$HOME/install` only for the `libdap4` portion, keyed by:
+    - runner (`matrix.runs-on`)
+    - `libdap4-snapshot` contents from this repo
+    - workflow file hash for relevant build flags
+  - Restore the cached prefix before the `libdap4` step; skip clone/build/install when the cache hits and the expected `libdap` files are present.
+- Replace raw `brew install ...` with a maintained setup action if possible:
+  - Prefer `Homebrew/actions/setup-homebrew` plus a package install step, or a commonly used cache-aware action for Brew formulas.
+  - If that is not acceptable, keep `brew install` as-is and rely on `ccache` and `libdap4` caching as the primary savings.
+- Tighten the workflow structure without changing BES behavior:
+  - Keep `autoreconf`, `./configure`, `make`, `make install`, `besctl start`, `make check`, `besctl stop`.
+  - Keep `CONFIGURE_OPTIONS`, `--with-dependencies=$prefix/deps`, and current Homebrew include/lib flags unchanged unless required for `ccache`.
+  - Preserve AWS-fetched `hyrax-dependencies` tarball behavior for now; do not redesign that artifact flow in this plan.
+
+## Public and Interface Changes
+
+- Workflow behavior changes:
+  - Pull requests retain dual-architecture macOS coverage.
+  - `main`/`master` pushes and manual runs retain dual-architecture macOS coverage.
+- No intended changes to BES build flags, install layout, runtime configuration, or test semantics.
+
+## Test Plan
+
+- Validate workflow syntax locally by inspecting the rendered YAML and checking matrix/job conditions.
+- For one cache-cold run on each architecture:
+  - Confirm `brew`, `hyrax-dependencies`, `libdap4`, and BES still build successfully.
+  - Confirm `make check` still runs after `besctl start`.
+- For one cache-warm rerun on the same branch and same runner:
+  - Confirm `ccache` hits increase materially.
+  - Confirm `libdap4` step is skipped or reduced to a validation step on cache hit.
+  - Compare end-to-end runtime against the current workflow.
+- On a PR:
+  - Confirm both macOS runners execute.
+- On a `main`/`master` push or manual dispatch:
+  - Confirm both architectures execute.
+
+## Assumptions
+
+- `libdap4-snapshot` is the canonical repo-controlled version input for the macOS workflow’s `libdap4` dependency.
+- Caching compiled `libdap4` under `$HOME/install` is acceptable as long as the cache key includes runner architecture and dependency-version inputs.
+- Introducing a new external prebuilt `libdap4` artifact pipeline is out of scope for this change.
+- Full validation remains `make check`; no `distcheck` or Docker validation is added to this macOS workflow optimization.


### PR DESCRIPTION
## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2119

<!-- Description of task -->
The macos-15-intel CICD step is linking with GDAL but missing a needed library.

Patch so that it does not link with GDAL (configure using --without-gdal) to unblock the pipeline. Then,...
Check that the hyrax-dependencies are built with GDAL for both macos-15 intel and arm64.
Debug both builds once that is the case.

I can see that the current arm64 hyrax-deps binary is missing GDAL while the intel version has GDAL but not the missing libdefalte that causes the build to fail.

Work debug potion of this issue on a second branch so that we can merge the patch ASAP.

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [ ] ~Tests added/updated~
- [ ] ~Dead code removed~
- [x] No TODOs added
