### PR TITLE
HYRAX-2119: Make the csv handler fail to test log uploading for GHA CICD builds.

### DIFF
--- a/modules/csv_handler/tests/csv/broken.csv.3.bescmd.baseline.original
+++ b/modules/csv_handler/tests/csv/broken.csv.3.bescmd.baseline.original
@@ -3,7 +3,7 @@
     <getDODS>
         <BESError>
             <Type>3</Type>
-            <Message>FAIL! Deliberate failure!</Message>
+            <Message>Error in CSV dataset, too few data elements on line 2</Message>
             <Administrator>support@opendap.org</Administrator>
             <Location>
                 removed file


### PR DESCRIPTION
## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2119

<!-- Description of task -->
Make the csv handler fail to test log uploading for GHA CICD builds. Those uploads were not working because of a policy error in AWSland

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] Tests added/updated
- [x] Dead code removed
- [x] No TODOs added
