### PR TITLE
Fix the Max compute threads config option.

### DIFF
--- a/.vscode/jhrg/settings.json
+++ b/.vscode/jhrg/settings.json
@@ -7,20 +7,9 @@
     "C_Cpp.default.configurationProvider": "ms-vscode.makefile-tools",
     "C_Cpp.default.compileCommands": "${workspaceFolder}/compile_commands.json",
     "C_Cpp.default.includePath": [
-        "${workspaceFolder}",
-        "${workspaceFolder}/cmdln",
-        "${workspaceFolder}/dap",
-        "${workspaceFolder}/dapreader",
-        "${workspaceFolder}/dispatch/**",
-        "${workspaceFolder}/hello_world",
-        "${workspaceFolder}/http/**",
-        "${workspaceFolder}/ppt/**",
-        "${workspaceFolder}/pugixml/**",
-        "${workspaceFolder}/rapidjson/**",
-        "${workspaceFolder}/server/**",
-        "${workspaceFolder}/standalone/**",
-        "${workspaceFolder}/xmlcommand/**",
-        "${workspaceFolder}/modules/**"
+        "${config:prefix}/include",
+        "${config:prefix}/deps/include",
+        "${workspaceFolder}/**"
     ],
     "C_Cpp.default.cppStandard": "c++14",
     "C_Cpp.default.intelliSenseMode": "macos-clang-arm64",
@@ -47,15 +36,16 @@
         "PATH": "${config:PATH}"
     },
     "cSpell.words": [
-        "OPENDAP",
-        "DISTCHECK",
         "bescmd",
         "besstandalone",
         "BINARYDATA",
         "CMAC",
+        "DISTCHECK",
+        "Dmrpp",
         "libdap",
         "ncml",
         "NDAP",
+        "OPENDAP",
         "xfail"
     ]
 }

--- a/.vscode/jhrg/settings.json
+++ b/.vscode/jhrg/settings.json
@@ -7,7 +7,9 @@
     "C_Cpp.default.configurationProvider": "ms-vscode.makefile-tools",
     "C_Cpp.default.compileCommands": "${workspaceFolder}/compile_commands.json",
     "C_Cpp.default.includePath": [
-        "${workspaceFolder}",
+        "${config:prefix}/include/**",
+        "${config:prefix}/deps/include/**",
+        "${workspaceFolder}/**",
         "${workspaceFolder}/cmdln",
         "${workspaceFolder}/dap",
         "${workspaceFolder}/dapreader",

--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -119,7 +119,9 @@ namespace dmrpp
     double DmrppRequestHandler::d_object_cache_purge_level = 0.2;
 
     bool DmrppRequestHandler::d_use_compute_threads = true;
-    unsigned long DmrppRequestHandler::d_max_compute_threads = 8;
+    unsigned long DmrppRequestHandler::d_max_compute_threads = 8UL;
+    unsigned long DmrppRequestHandler::d_default_max_compute_threads = 4UL;
+
 
     // Default minimum value is 2MB: 2 * (1024*1024)
     unsigned long long DmrppRequestHandler::d_contiguous_concurrent_threshold = DMRPP_DEFAULT_CONTIGUOUS_CONCURRENT_THRESHOLD;
@@ -159,7 +161,7 @@ namespace dmrpp
 
         // Using TheBESKeys calls instead of custom functions kln 4/1/26
         d_use_compute_threads = TheBESKeys::read_bool_key(DMRPP_USE_COMPUTE_THREADS_KEY, d_use_compute_threads);
-        d_max_compute_threads = std::max(4UL, TheBESKeys::read_ulong_key(DMRPP_MAX_COMPUTE_THREADS_KEY, d_max_compute_threads));
+        d_max_compute_threads = std::max(d_default_max_compute_threads, TheBESKeys::read_ulong_key(DMRPP_MAX_COMPUTE_THREADS_KEY, d_max_compute_threads));
         msg << prolog << "Concurrent Compute Threads: ";
         if (DmrppRequestHandler::d_use_compute_threads)
         {

--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -110,16 +110,16 @@ namespace dmrpp
     // that make and delete many of these objects. jhrg 11/22/24
     CurlHandlePool *DmrppRequestHandler::curl_handle_pool{nullptr};
 
-    // These now only affect the DDS and DAS ObjMemCaches; the DMR++
+    // These now only effect the DDS and DAS ObjMemCaches; the DMR++
     // is cached in the NGAP module. Once issues with the DMR++ object's
     // copy constructor are solved, the ObjMemCache can be used again.
     // jhrg 9/26/23
     bool DmrppRequestHandler::d_use_object_cache = true;
-    unsigned int DmrppRequestHandler::d_object_cache_entries = 100;
+    int DmrppRequestHandler::d_object_cache_entries = 100;
     double DmrppRequestHandler::d_object_cache_purge_level = 0.2;
 
     bool DmrppRequestHandler::d_use_compute_threads = true;
-    unsigned int DmrppRequestHandler::d_max_compute_threads = 8;
+    unsigned long DmrppRequestHandler::d_max_compute_threads = 8;
 
     // Default minimum value is 2MB: 2 * (1024*1024)
     unsigned long long DmrppRequestHandler::d_contiguous_concurrent_threshold = DMRPP_DEFAULT_CONTIGUOUS_CONCURRENT_THRESHOLD;
@@ -159,7 +159,7 @@ namespace dmrpp
 
         // Using TheBESKeys calls instead of custom functions kln 4/1/26
         d_use_compute_threads = TheBESKeys::read_bool_key(DMRPP_USE_COMPUTE_THREADS_KEY, d_use_compute_threads);
-        d_max_compute_threads = TheBESKeys::read_bool_key(DMRPP_MAX_COMPUTE_THREADS_KEY, d_max_compute_threads);
+        d_max_compute_threads = TheBESKeys::read_ulong_key(DMRPP_MAX_COMPUTE_THREADS_KEY, d_max_compute_threads);
         msg << prolog << "Concurrent Compute Threads: ";
         if (DmrppRequestHandler::d_use_compute_threads)
         {

--- a/modules/dmrpp_module/DmrppRequestHandler.cc
+++ b/modules/dmrpp_module/DmrppRequestHandler.cc
@@ -159,7 +159,7 @@ namespace dmrpp
 
         // Using TheBESKeys calls instead of custom functions kln 4/1/26
         d_use_compute_threads = TheBESKeys::read_bool_key(DMRPP_USE_COMPUTE_THREADS_KEY, d_use_compute_threads);
-        d_max_compute_threads = TheBESKeys::read_ulong_key(DMRPP_MAX_COMPUTE_THREADS_KEY, d_max_compute_threads);
+        d_max_compute_threads = std::max(4UL, TheBESKeys::read_ulong_key(DMRPP_MAX_COMPUTE_THREADS_KEY, d_max_compute_threads));
         msg << prolog << "Concurrent Compute Threads: ";
         if (DmrppRequestHandler::d_use_compute_threads)
         {

--- a/modules/dmrpp_module/DmrppRequestHandler.h
+++ b/modules/dmrpp_module/DmrppRequestHandler.h
@@ -65,9 +65,9 @@ private:
     static void get_dmrpp_from_container_or_cache(BESContainer *container, libdap::DMR *dmr);
     template <class T> static void get_dds_from_dmr_or_cache(BESContainer *container, T *bdds);
 
-    // Allocate a new DMZ for each request? This should work, but may result in more
+    // Allocate a new DMZ for each request? That should work, but may result in more
     // cycling of data in and out of memory. The shared_ptr<> will be passed into
-    // instances of BaseType and used from withing the specialized read methods.
+    // instances of BaseType and used from within the specialized read methods.
     // jhrg 11/3/21
     static std::shared_ptr<DMZ> dmz;
 
@@ -79,6 +79,7 @@ public:
 
     static bool d_use_compute_threads;
     static unsigned long d_max_compute_threads;
+    static unsigned long d_default_max_compute_threads;
 
     static unsigned long long d_contiguous_concurrent_threshold;
 

--- a/modules/dmrpp_module/DmrppRequestHandler.h
+++ b/modules/dmrpp_module/DmrppRequestHandler.h
@@ -58,7 +58,7 @@ private:
     static std::unique_ptr<ObjMemCache> dds_cache;
 
     static bool d_use_object_cache;
-    static unsigned int d_object_cache_entries;
+    static int d_object_cache_entries;
     static double d_object_cache_purge_level;
 
 
@@ -78,7 +78,7 @@ public:
     static CurlHandlePool *curl_handle_pool;
 
     static bool d_use_compute_threads;
-    static unsigned int d_max_compute_threads;
+    static unsigned long d_max_compute_threads;
 
     static unsigned long long d_contiguous_concurrent_threshold;
 


### PR DESCRIPTION
## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2130

Also relates to (solves?) #1332 

<!-- Description of task -->
In DmrppRequestHandler.cc, read_bool_key() is used to read the number of threads. When the feature is turned on, this leads to a race condition.

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] Tests added/updated
- [x] Dead code removed
- [x] No TODOs added
