### PR TITLE
HYRAX-2144, use get_parent to traverse the ancestor group to avoid th…

### DIFF
--- a/modules/hdf5_handler/h5dmr.cc
+++ b/modules/hdf5_handler/h5dmr.cc
@@ -676,7 +676,16 @@ void add_unlimited_dimension_info(libdap::D4Group *d4_grp) {
                         break;
                     
                     }
-                    temp_grp = dynamic_cast<D4Group*>(temp_grp->get_ancestor());
+                    // Previously we use libdap's get_ancestor() and it causes infinite loops for the cases 
+                    // when a variable has mulitple unlimited dimensions and some dimensions are defined under
+                    // ancestor groups. See https://github.com/OPENDAP/bes/issues/1338 for the detailed info.
+                    // However, even applied James' fix, the code still doesn't behave as expected. So we 
+                    // use another way to traverse each ancestor group. KY 2026-05-01
+                    
+                    if(temp_grp->get_parent())
+                        temp_grp = static_cast<D4Group*>(temp_grp->get_parent());
+                    else
+                        temp_grp = nullptr;
                 }
                 unlimited_dimpaths.insert(dim_path);
             }


### PR DESCRIPTION
…e infinite loop and unexpected behavior.

## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2144

<!-- Description of task -->
Use libdap's get_ancestor() method to traverse DAP4 groups may give you unexpected output and it causes infinite loops for one NASA testing file.  We use the get_parents() to traverse with the expected results. 

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] Dead code removed

