### PR TITLE
Jhrg/warnings removal

### DIFF
--- a/.vscode/jhrg/tasks.json
+++ b/.vscode/jhrg/tasks.json
@@ -38,7 +38,7 @@
         {
             "label": "autotools: build",
             "type": "shell",
-            "command": "make -j",
+            "command": "make -j${config:nproc}",
             "problemMatcher": [
                 "$gcc"
             ],
@@ -50,7 +50,7 @@
         {
             "label": "autotools: check",
             "type": "shell",
-            "command": "make -j check",
+            "command": "make -j${config:nproc} check",
             "problemMatcher": [
                 "$gcc"
             ],
@@ -82,7 +82,7 @@
         {
             "label": "autotools: compile_commands",
             "type": "shell",
-            "command": "make clean && bear -- make -j -k && bear --append -- make -j -k check",
+            "command": "make clean && bear -- make -j${config:nproc} -k && bear --append -- make -j${config:nproc} -k check",
             "problemMatcher": [
                 "$gcc"
             ],
@@ -124,7 +124,7 @@
             },
             "label": "autotools: build dmrpp module",
             "type": "shell",
-            "command": "make -j",
+            "command": "make -j${config:nproc}",
             "problemMatcher": [
                 "$gcc"
             ],

--- a/dap/BESDASResponse.h
+++ b/dap/BESDASResponse.h
@@ -51,8 +51,8 @@ public:
     }
     virtual ~BESDASResponse();
 
-    virtual void set_container(const std::string &cn);
-    virtual void clear_container();
+    void set_container(const std::string &cn) override;
+    void clear_container() override;
 
     void dump(std::ostream &strm) const override;
 
@@ -67,4 +67,3 @@ public:
 };
 
 #endif // I_BESDASResponse
-

--- a/dap/BESDASResponseHandler.h
+++ b/dap/BESDASResponseHandler.h
@@ -52,8 +52,8 @@ public:
     BESDASResponseHandler(const std::string &name);
     virtual ~BESDASResponseHandler();
 
-    virtual void execute(BESDataHandlerInterface &dhi);
-    virtual void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi);
+    void execute(BESDataHandlerInterface &dhi) override;
+    void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi) override;
 
     void dump(std::ostream &strm) const override;
 
@@ -61,4 +61,3 @@ public:
 };
 
 #endif // I_BESDASResponseHandler_h
-

--- a/dap/BESDDSResponse.h
+++ b/dap/BESDDSResponse.h
@@ -59,8 +59,8 @@ public:
 
     virtual ~BESDDSResponse();
 
-    virtual void set_container(const std::string &cn);
-    virtual void clear_container();
+    void set_container(const std::string &cn) override;
+    void clear_container() override;
 
     void dump(std::ostream &strm) const override;
 
@@ -96,4 +96,3 @@ public:
 };
 
 #endif // I_BESDDSResponse
-

--- a/dap/BESDDSResponseHandler.h
+++ b/dap/BESDDSResponseHandler.h
@@ -56,8 +56,8 @@ public:
     BESDDSResponseHandler(const std::string &name);
     virtual ~BESDDSResponseHandler(void);
 
-    virtual void execute(BESDataHandlerInterface &dhi);
-    virtual void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi);
+    void execute(BESDataHandlerInterface &dhi) override;
+    void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi) override;
 
     void dump(std::ostream &strm) const override;
 
@@ -65,4 +65,3 @@ public:
 };
 
 #endif // I_BESDDSResponseHandler_h
-

--- a/dap/BESDDXResponseHandler.h
+++ b/dap/BESDDXResponseHandler.h
@@ -55,8 +55,8 @@ public:
     BESDDXResponseHandler(const std::string &name);
     virtual ~BESDDXResponseHandler(void);
 
-    virtual void execute(BESDataHandlerInterface &dhi);
-    virtual void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi);
+    void execute(BESDataHandlerInterface &dhi) override;
+    void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi) override;
 
     void dump(std::ostream &strm) const override;
 
@@ -64,4 +64,3 @@ public:
 };
 
 #endif // I_BESDDXResponseHandler_h
-

--- a/dap/BESDMRResponse.h
+++ b/dap/BESDMRResponse.h
@@ -55,8 +55,8 @@ public:
 
 	virtual ~BESDMRResponse();
 
-	virtual void set_container(const std::string &cn);
-	virtual void clear_container();
+	void set_container(const std::string &cn) override;
+	void clear_container() override;
 
 	void dump(std::ostream &strm) const override;
 

--- a/dap/BESDMRResponseHandler.h
+++ b/dap/BESDMRResponseHandler.h
@@ -52,8 +52,8 @@ public:
 	BESDMRResponseHandler(const std::string &name);
 	virtual ~BESDMRResponseHandler();
 
-	virtual void execute(BESDataHandlerInterface &dhi);
-	virtual void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi);
+	void execute(BESDataHandlerInterface &dhi) override;
+	void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi) override;
 
 	void dump(std::ostream &strm) const override;
 

--- a/dap/BESDap4ResponseHandler.h
+++ b/dap/BESDap4ResponseHandler.h
@@ -57,8 +57,8 @@ public:
 	BESDap4ResponseHandler(const std::string &name);
 	virtual ~BESDap4ResponseHandler();
 
-	virtual void execute(BESDataHandlerInterface &dhi);
-	virtual void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi);
+	void execute(BESDataHandlerInterface &dhi) override;
+	void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi) override;
 
 	/**
 	 * @brief Is the BES.Use.Dmrpp key set in the bes.conf?

--- a/dap/BESDataDDSResponse.h
+++ b/dap/BESDataDDSResponse.h
@@ -61,10 +61,10 @@ public:
 
     virtual ~BESDataDDSResponse();
 
-    virtual void set_container(const std::string &cn);
-    virtual void clear_container();
+    void set_container(const std::string &cn) override;
+    void clear_container() override;
 
-    virtual void dump(std::ostream & strm) const;
+    void dump(std::ostream & strm) const override;
 
     /**
      * Set the response object's DDS. The caller should probably
@@ -90,4 +90,3 @@ public:
 };
 
 #endif // I_BESDataDDSResponse
-

--- a/dap/BESDataResponseHandler.h
+++ b/dap/BESDataResponseHandler.h
@@ -62,8 +62,8 @@ public:
     BESDataResponseHandler(const std::string &name);
     virtual ~BESDataResponseHandler(void);
 
-    virtual void execute(BESDataHandlerInterface &dhi);
-    virtual void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi);
+    void execute(BESDataHandlerInterface &dhi) override;
+    void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi) override;
 
     void dump(std::ostream &strm) const override;
 
@@ -71,4 +71,3 @@ public:
 };
 
 #endif
-

--- a/dap/BESStoredDapResultCache.cc
+++ b/dap/BESStoredDapResultCache.cc
@@ -35,6 +35,7 @@
 #include <string>
 #include <fstream>
 #include <sstream>
+#include <vector>
 
 #include <libdap/DDS.h>
 #include <libdap/DMR.h>
@@ -419,14 +420,14 @@ bool BESStoredDapResultCache::read_dap4_data_from_cache(const string &cache_file
             }
 
             // get chunk
-            char chunk[chunk_size];
-            cis.read(chunk, chunk_size);
+            std::vector<char> chunk(chunk_size);
+            cis.read(chunk.data(), chunk_size);
             BESDEBUG("cache", "BESStoredDapResultCache::read_dap4_data_from_cache() - Read first chunk." << endl);
 
             // parse char * with given size
             D4ParserSax2 parser;
             // '-2' to discard the CRLF pair
-            parser.intern(chunk, chunk_size - 2, dmr, debug);
+            parser.intern(chunk.data(), chunk_size - 2, dmr, debug);
             BESDEBUG("cache", "BESStoredDapResultCache::read_dap4_data_from_cache() - Parsed first chunk." << endl);
 
             D4StreamUnMarshaller um(cis, cis.twiddle_bytes());

--- a/dap/GlobalMetadataStore.h
+++ b/dap/GlobalMetadataStore.h
@@ -129,15 +129,15 @@ protected:
      * SYMMETRIC_ADD_RESPONSES controls if this feature is on or not; currently it
      * is turned off.
      */
-    struct StreamDAP : public std::unary_function<libdap::DapObj*, void> {
-        libdap::DDS *d_dds;
-        libdap::DMR *d_dmr;
+    struct StreamDAP {
+        libdap::DDS *d_dds = nullptr;
+        libdap::DMR *d_dmr = nullptr;
 
-        StreamDAP() : d_dds(0), d_dmr(0) {
+        StreamDAP() {
             throw BESInternalFatalError("Unknown DAP object type.", __FILE__, __LINE__);
         }
-        StreamDAP(libdap::DDS *dds) : d_dds(dds), d_dmr(0) { }
-        StreamDAP(libdap::DMR *dmr) : d_dds(0), d_dmr(dmr) { }
+        StreamDAP(libdap::DDS *dds) : d_dds(dds) { }
+        StreamDAP(libdap::DMR *dmr) : d_dmr(dmr) { }
 
         virtual void operator()(std::ostream &os) = 0;
     };
@@ -190,7 +190,7 @@ public:
      * in this code, then only a GlobalMetadataStore, and not the subclass,
      * will be used to unlock the item.
      */
-    struct MDSReadLock : public std::unary_function<std::string, bool> {
+    struct MDSReadLock {
         std::string name;
         bool locked;
         GlobalMetadataStore *mds;

--- a/dap/ShowPathInfoResponseHandler.h
+++ b/dap/ShowPathInfoResponseHandler.h
@@ -58,8 +58,8 @@ public:
     ShowPathInfoResponseHandler(const std::string &name);
     virtual ~ShowPathInfoResponseHandler(void);
 
-    virtual void execute(BESDataHandlerInterface &dhi);
-    virtual void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi);
+    void execute(BESDataHandlerInterface &dhi) override;
+    void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi) override;
 
     void dump(std::ostream &strm) const override;
 
@@ -67,4 +67,3 @@ public:
 };
 
 #endif // I_ShowPathInfoResponseHandler_h
-

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -252,8 +252,6 @@ public:
     {
         uint64_t max_response_size_bytes;
         uint64_t max_var_size_bytes;
-        bool is_dap2 = false;
-
         dap_utils::get_max_sizes_bytes(max_response_size_bytes, max_var_size_bytes, true);
         DBG( cerr << prolog << "max_response_size_bytes: " << max_response_size_bytes << "\n");
         DBG( cerr << prolog << "     max_var_size_bytes: " << max_var_size_bytes << "\n");
@@ -680,4 +678,3 @@ int main(int argc, char *argv[]) {
     string bes_debug="cerr,bes,dap_utils,dap_utils_verbose,context";
     return bes_run_tests<dap_utils::DapUtilsTest>(argc, argv, bes_debug) ? 0 : 1;
 }
-

--- a/dap/unit-tests/GlobalMetadataStoreTest.cc
+++ b/dap/unit-tests/GlobalMetadataStoreTest.cc
@@ -405,7 +405,7 @@ public:
 
     void removeDMRVersion(string& str)
     {
-        std::regex dmr_version_regex("dmrVersion=\"[0-9]+\.[0-9]+\"");
+        std::regex dmr_version_regex("dmrVersion=\"[0-9]+\\.[0-9]+\"");
         str = std::regex_replace(str, dmr_version_regex, "dmrVersion=\"removed\"");
     }
 
@@ -2046,7 +2046,7 @@ public:
          CPPUNIT_ASSERT(access(baseline_name.c_str(), R_OK) == 0);
 
          // Strip out dmr version
-         std::regex dmr_version_regex("dmrVersion=\"[0-9]+\.[0-9]+\"");
+         std::regex dmr_version_regex("dmrVersion=\"[0-9]+\\.[0-9]+\"");
          auto stripped_input = std::regex_replace(oss.str(), dmr_version_regex, "dmrVersion=\"removed\"");
 
          string insert_xml_base_baseline = read_test_baseline(baseline_name);

--- a/dap/unit-tests/ObjMemCacheTest.cc
+++ b/dap/unit-tests/ObjMemCacheTest.cc
@@ -55,7 +55,7 @@ public:
 
     ~DDSMemCacheTest() override = default;
 
-    void setUp()
+    void setUp() override
     {
         DBG2(cerr << "setUp() - BEGIN" << endl);
 
@@ -80,7 +80,7 @@ public:
         DBG2(cerr << "setUp() - END" << endl);
     }
 
-    void tearDown()
+    void tearDown() override
     {
         delete dds_cache;
         delete dds;

--- a/dispatch/FileCache.h
+++ b/dispatch/FileCache.h
@@ -507,7 +507,8 @@ public:
         // Here we might use st_blocks and st_blksize if that will speed up the transfer.
         // This is likely to matter only for large files (where large means...?). jhrg 11/02/23
 
-        if (write(fd, data.c_str(), data.size()) != data.size()) {
+        const ssize_t bytes_written = write(fd, data.c_str(), data.size());
+        if (bytes_written < 0 || static_cast<std::string::size_type>(bytes_written) != data.size()) {
             ERROR("Error writing to data to cache file: " + key + " " + get_errno());
             return false;
         }

--- a/http/awsv4.cc
+++ b/http/awsv4.cc
@@ -41,6 +41,7 @@
 #include <iostream>
 #include <sstream>
 
+#include <openssl/evp.h>
 #include <openssl/sha.h>
 #include <openssl/hmac.h>
 
@@ -78,13 +79,24 @@ std::string join(const std::vector<std::string> &ss, const std::string &delim) {
 std::string sha256_base16(const std::string &str) {
 
     unsigned char hashOut[SHA256_DIGEST_LENGTH];
-    SHA256_CTX sha256;
-    SHA256_Init(&sha256);
-    SHA256_Update(&sha256, (const unsigned char *) str.c_str(), str.size());
-    SHA256_Final(hashOut, &sha256);
+    unsigned int hash_length = 0;
+
+    EVP_MD_CTX *sha256 = EVP_MD_CTX_new();
+    if (!sha256) {
+        throw BESInternalError(prolog + "Failed to allocate an EVP_MD_CTX for SHA-256.", __FILE__, __LINE__);
+    }
+
+    if (EVP_DigestInit_ex(sha256, EVP_sha256(), nullptr) != 1
+        || EVP_DigestUpdate(sha256, str.data(), str.size()) != 1
+        || EVP_DigestFinal_ex(sha256, hashOut, &hash_length) != 1) {
+        EVP_MD_CTX_free(sha256);
+        throw BESInternalError(prolog + "Failed to compute a SHA-256 digest.", __FILE__, __LINE__);
+    }
+
+    EVP_MD_CTX_free(sha256);
 
     char outputBuffer[SHA256_DIGEST_STRING_LENGTH + 1];
-    for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
+    for (unsigned int i = 0; i < hash_length; i++) {
         snprintf(outputBuffer + (i * 2), 3, "%02x", hashOut[i]);
     }
     outputBuffer[SHA256_DIGEST_STRING_LENGTH] = 0;

--- a/modules/asciival/BESAsciiModule.h
+++ b/modules/asciival/BESAsciiModule.h
@@ -42,11 +42,10 @@ public:
 	virtual ~BESAsciiModule()
 	{
 	}
-	virtual void initialize(const std::string &modname);
-	virtual void terminate(const std::string &modname);
+	void initialize(const std::string &modname) override;
+	void terminate(const std::string &modname) override;
 
 	void dump(std::ostream &strm) const override;
 };
 
 #endif // A_BESAsciiModule_H
-

--- a/modules/asciival/get_ascii_dap4.cc
+++ b/modules/asciival/get_ascii_dap4.cc
@@ -421,8 +421,9 @@ static void print_values_as_ascii(D4Opaque *v, bool print_name, ostream &strm, C
 
 static void print_values_as_ascii(D4Group *group, bool print_name, ostream &strm, Crc32 &checksum)
 {
-    for (D4Group::groupsIter g = group->grp_begin(), e = group->grp_end(); g != e; ++g)
-    	print_values_as_ascii(*g, print_name, strm, checksum);
+    for (D4Group::groupsIter g = group->grp_begin(), e = group->grp_end(); g != e; ++g) {
+        print_values_as_ascii(*g, print_name, strm, checksum);
+    }
 
     // Specialize how the top-level variables in any Group are sent; include
     // a checksum for them. A subset operation might make an interior set of

--- a/modules/cmr_module/CmrContainer.h
+++ b/modules/cmr_module/CmrContainer.h
@@ -60,6 +60,8 @@ private:
     }
 
 protected:
+    using BESContainer::_duplicate;
+
     void _duplicate(CmrContainer &copy_to);
 
 public:

--- a/modules/cmr_module/CmrContainerStorage.h
+++ b/modules/cmr_module/CmrContainerStorage.h
@@ -51,7 +51,7 @@ public:
     CmrContainerStorage(const std::string &n);
     virtual ~CmrContainerStorage();
 
-    virtual void add_container(const std::string &s_name, const std::string &r_name, const std::string &type);
+    void add_container(const std::string &s_name, const std::string &r_name, const std::string &type) override;
 
     void dump(std::ostream &strm) const override;
 };

--- a/modules/cmr_module/CmrModule.h
+++ b/modules/cmr_module/CmrModule.h
@@ -45,8 +45,8 @@ public:
 	virtual ~CmrModule()
 	{
 	}
-	virtual void initialize(const std::string &modname);
-	virtual void terminate(const std::string &modname);
+	void initialize(const std::string &modname) override;
+	void terminate(const std::string &modname) override;
 
 	void dump(std::ostream &strm) const override;
 };

--- a/modules/csv_handler/CSVModule.h
+++ b/modules/csv_handler/CSVModule.h
@@ -45,8 +45,8 @@ public:
 	virtual ~CSVModule()
 	{
 	}
-	virtual void initialize(const std::string &modname);
-	virtual void terminate(const std::string &modname);
+	void initialize(const std::string &modname) override;
+	void terminate(const std::string &modname) override;
 
 	void dump(std::ostream &strm) const override;
 };

--- a/modules/csv_handler/CSVRequestHandler.h
+++ b/modules/csv_handler/CSVRequestHandler.h
@@ -57,7 +57,7 @@ public:
     // This handler supports the "not including attributes" in 
     // the data access feature. Attributes are generated only
     // if necessary. KY 10/30/19
-	void add_attributes(BESDataHandlerInterface &dhi);
+	void add_attributes(BESDataHandlerInterface &dhi) override;
 };
 
 #endif // CSVRequestHandler.h

--- a/modules/fileout_netcdf/FONcAttributes.cc
+++ b/modules/fileout_netcdf/FONcAttributes.cc
@@ -461,6 +461,11 @@ void FONcAttributes::add_attributes_worker(int ncid, int varid, const string &va
                 FONcUtils::handle_error(stax, err, __FILE__, __LINE__);
             }
                 break;
+            default: {
+                string err = (string) "File out netcdf, unsupported attribute type for classic model: " + new_name;
+                FONcUtils::handle_error(stax, err, __FILE__, __LINE__);
+            }
+                break;
         }
     }
 }
@@ -1622,4 +1627,3 @@ switch (attrType) {
 }
 
 #endif
-

--- a/modules/fileout_netcdf/data/build_test_data/simpleT00.cc
+++ b/modules/fileout_netcdf/data/build_test_data/simpleT00.cc
@@ -33,15 +33,11 @@ using namespace libdap;
 int main(int argc, char **argv)
 {
     bool debug = false;
-    bool dods_response = false; // write either a .dods or a netcdf file
     if (argc > 1) {
         for (int i = 0; i < argc; i++) {
             string arg = argv[i];
             if (arg == "debug") {
                 debug = true;
-            }
-            else if (arg == "dods") {
-                dods_response = true;
             }
         }
     }
@@ -106,4 +102,3 @@ int main(int argc, char **argv)
 
     return 0;
 }
-

--- a/modules/freeform_handler/FFModule.h
+++ b/modules/freeform_handler/FFModule.h
@@ -42,11 +42,10 @@ public:
 	virtual ~FFModule()
 	{
 	}
-	virtual void initialize(const std::string &modname);
-	virtual void terminate(const std::string &modname);
+	void initialize(const std::string &modname) override;
+	void terminate(const std::string &modname) override;
 
 	void dump(std::ostream &strm) const override;
 };
 
 #endif // A_FFModule_H
-

--- a/modules/freeform_handler/FFND/proclist.c
+++ b/modules/freeform_handler/FFND/proclist.c
@@ -1341,7 +1341,7 @@ int btype_to_btype(void *src_value, FF_TYPES_t src_type, void *dest_value, FF_TY
 			break;
 			
 			case FFV_INT32:
-				if (big_var < FFV_INT32_MIN || big_var > FFV_INT32_MAX)
+				if (big_var < (big_var_type)FFV_INT32_MIN || big_var > (big_var_type)FFV_INT32_MAX)
 				{
 					error = ERR_OUT_OF_RANGE;
 
@@ -1352,7 +1352,7 @@ int btype_to_btype(void *src_value, FF_TYPES_t src_type, void *dest_value, FF_TY
 			break;
 			
 			case FFV_UINT32:
-				if (big_var < FFV_UINT32_MIN || big_var > FFV_UINT32_MAX)
+				if (big_var < (big_var_type)FFV_UINT32_MIN || big_var > (big_var_type)FFV_UINT32_MAX)
 				{
 					error = ERR_OUT_OF_RANGE;
 
@@ -1856,4 +1856,3 @@ int initialize_middle_data
 
 	return(error_return);
 }
-

--- a/modules/functions/DapFunctions.h
+++ b/modules/functions/DapFunctions.h
@@ -37,8 +37,8 @@ public:
     virtual ~DapFunctions()
     {
     }
-    virtual void initialize(const std::string &modname);
-    virtual void terminate(const std::string &modname);
+    void initialize(const std::string &modname) override;
+    void terminate(const std::string &modname) override;
 
     void dump(std::ostream &strm) const override;
 };

--- a/modules/gateway_module/GatewayContainer.h
+++ b/modules/gateway_module/GatewayContainer.h
@@ -58,6 +58,8 @@ private:
     }
 
 protected:
+    using BESContainer::_duplicate;
+
     void _duplicate(GatewayContainer &copy_to);
 
 public:
@@ -67,11 +69,11 @@ public:
 
     virtual ~GatewayContainer();
 
-    virtual BESContainer * ptr_duplicate();
+    BESContainer * ptr_duplicate() override;
 
-    virtual std::string access();
+    std::string access() override;
 
-    virtual bool release();
+    bool release() override;
 
     void dump(std::ostream &strm) const override;
 };

--- a/modules/gateway_module/GatewayContainerStorage.h
+++ b/modules/gateway_module/GatewayContainerStorage.h
@@ -51,7 +51,7 @@ public:
     GatewayContainerStorage(const std::string &n);
     virtual ~GatewayContainerStorage();
 
-    virtual void add_container(const std::string &s_name, const std::string &r_name, const std::string &type);
+    void add_container(const std::string &s_name, const std::string &r_name, const std::string &type) override;
 
     void dump(std::ostream &strm) const override;
 };

--- a/modules/gateway_module/GatewayModule.h
+++ b/modules/gateway_module/GatewayModule.h
@@ -44,8 +44,8 @@ public:
     {
     }
 
-    virtual void initialize(const std::string &modname);
-    virtual void terminate(const std::string &modname);
+    void initialize(const std::string &modname) override;
+    void terminate(const std::string &modname) override;
 
     void dump(std::ostream &strm) const override;
 };

--- a/modules/gateway_module/GatewayPathInfoCommand.h
+++ b/modules/gateway_module/GatewayPathInfoCommand.h
@@ -16,9 +16,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return true;
     }

--- a/modules/gateway_module/GatewayPathInfoResponseHandler.h
+++ b/modules/gateway_module/GatewayPathInfoResponseHandler.h
@@ -56,8 +56,8 @@ public:
     GatewayPathInfoResponseHandler(const std::string &name);
     virtual ~GatewayPathInfoResponseHandler(void);
 
-    virtual void execute(BESDataHandlerInterface &dhi);
-    virtual void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi);
+    void execute(BESDataHandlerInterface &dhi) override;
+    void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi) override;
 
     void dump(std::ostream &strm) const override;
 
@@ -65,4 +65,3 @@ public:
 };
 
 #endif // I_GatewayPathInfoResponseHandler_h
-

--- a/modules/gdal_module/GDALModule.h
+++ b/modules/gdal_module/GDALModule.h
@@ -37,11 +37,10 @@ public:
     virtual ~GDALModule()
     {
     }
-    virtual void initialize(const std::string &modname);
-    virtual void terminate(const std::string &modname);
+    void initialize(const std::string &modname) override;
+    void terminate(const std::string &modname) override;
 
     void dump(std::ostream &strm) const override;
 };
 
 #endif // A_GDALModule_H
-

--- a/modules/gdal_module/GDALRequestHandler.cc
+++ b/modules/gdal_module/GDALRequestHandler.cc
@@ -256,8 +256,9 @@ bool GDALRequestHandler::gdal_build_dmr_using_dds(BESDataHandlerInterface &dhi)
 
     GDALDatasetH hDS = GDALOpen(filename.c_str(), GA_ReadOnly);
 
-    if (hDS == NULL)
+    if (hDS == NULL) {
         throw Error(string(CPLGetLastErrorMsg()));
+    }
 
 	try {
 		gdal_read_dataset_variables(&dds, hDS, filename,true);

--- a/modules/httpd_catalog_module/HttpdCatalog.h
+++ b/modules/httpd_catalog_module/HttpdCatalog.h
@@ -59,28 +59,28 @@ public:
     /**
      * @Deprecated
      */
-    virtual BESCatalogEntry * show_catalog(const std::string &container, BESCatalogEntry */*entry*/){
+    BESCatalogEntry * show_catalog(const std::string &container, BESCatalogEntry */*entry*/) override {
         throw BESInternalError("The HttpdCatalog::show_catalog() method is not supported. (container: '" + container + "')",__FILE__,__LINE__);
     }
 
     /**
      * This is a meaningless method for a remote catalog so it returns empty string
      */
-    virtual std::string get_root() const { return ""; }
+    std::string get_root() const override { return ""; }
 
     /**
      * Maybe someday...
      */
-    virtual void get_site_map(
+    void get_site_map(
         const std::string &/*prefix*/,
         const std::string &/*node_suffix*/,
         const std::string &/*leaf_suffix*/,
 		std::ostream &/*out*/,
-        const std::string &/*path = "/"*/) const {
+        const std::string &/*path = "/"*/) const override {
         BESDEBUG(MODULE, "The HttpdCatalog::get_site_map() method is not currently supported. SKIPPING. file: " << __FILE__ << " line: "  << __LINE__ << std::endl);
     }
 
-    virtual bes::CatalogNode *get_node(const std::string &path) const;
+    bes::CatalogNode *get_node(const std::string &path) const override;
 
     virtual std::string path_to_access_url(const std::string &path) const;
 
@@ -90,4 +90,3 @@ public:
 } // namespace httpd_catalog
 
 #endif // _HttpdCatalog_h_
-

--- a/modules/httpd_catalog_module/HttpdCatalogContainer.h
+++ b/modules/httpd_catalog_module/HttpdCatalogContainer.h
@@ -56,6 +56,8 @@ private:
     }
 
 protected:
+    using BESContainer::_duplicate;
+
     void _duplicate(HttpdCatalogContainer &copy_to);
 
 public:

--- a/modules/httpd_catalog_module/HttpdCatalogContainerStorage.h
+++ b/modules/httpd_catalog_module/HttpdCatalogContainerStorage.h
@@ -50,7 +50,7 @@ public:
     HttpdCatalogContainerStorage(const std::string &n);
     virtual ~HttpdCatalogContainerStorage();
 
-    virtual void add_container(const std::string &s_name, const std::string &r_name, const std::string &type);
+    void add_container(const std::string &s_name, const std::string &r_name, const std::string &type) override;
 
     void dump(std::ostream &strm) const override;
 };

--- a/modules/httpd_catalog_module/HttpdCatalogModule.h
+++ b/modules/httpd_catalog_module/HttpdCatalogModule.h
@@ -40,8 +40,8 @@ public:
 	{
 	}
 
-	virtual void initialize(const std::string &modname);
-	virtual void terminate(const std::string &modname);
+	void initialize(const std::string &modname) override;
+	void terminate(const std::string &modname) override;
 
 	void dump(std::ostream &strm) const override;
 };

--- a/modules/netcdf_handler/NCStructure.cc
+++ b/modules/netcdf_handler/NCStructure.cc
@@ -85,7 +85,7 @@ NCStructure::operator=(const NCStructure &rhs)
 /** When flattening a Structure, make sure to add an attribute to the
     new variables that indicate they are the product of translation. */
 
-class AddAttribute: public unary_function<BaseType *, void> {
+class AddAttribute {
 
 public:
     AddAttribute() {}
@@ -270,5 +270,4 @@ bool NCStructure::read()
 
     return true;
 }
-
 

--- a/modules/s3_reader/S3Container.h
+++ b/modules/s3_reader/S3Container.h
@@ -46,6 +46,7 @@ namespace s3 {
  */
 
 class S3Container: public BESContainer {
+    using BESContainer::_duplicate;
 
     std::shared_ptr<http::RemoteResource> d_dmrpp_rresource = nullptr;
 

--- a/modules/ugrid_functions/UgridFunctions.h
+++ b/modules/ugrid_functions/UgridFunctions.h
@@ -37,8 +37,8 @@ public:
     virtual ~UgridFunctions()
     {
     }
-    virtual void initialize(const std::string &modname);
-    virtual void terminate(const std::string &modname);
+    void initialize(const std::string &modname) override;
+    void terminate(const std::string &modname) override;
 
     void dump(std::ostream &strm) const override;
 };

--- a/modules/xml_data_handler/XDArray.cc
+++ b/modules/xml_data_handler/XDArray.cc
@@ -128,7 +128,7 @@ void XDArray::print_xml_data(XMLWriter *writer, bool /*show_type*/) throw(Intern
     }
 }
 
-class PrintArrayDimXML : public unary_function<Array::dimension&, void>
+class PrintArrayDimXML
 {
     XMLWriter *d_writer;
     bool d_constrained;

--- a/xmlcommand/BESXMLCatalogCommand.h
+++ b/xmlcommand/BESXMLCatalogCommand.h
@@ -46,9 +46,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return true;
     }
@@ -59,4 +59,3 @@ public:
 };
 
 #endif // A_BESXMLCatalogCommand_h
-

--- a/xmlcommand/BESXMLDapCommandModule.h
+++ b/xmlcommand/BESXMLDapCommandModule.h
@@ -43,10 +43,9 @@ public:
     virtual ~BESXMLDapCommandModule()
     {
     }
-    virtual void initialize(const std::string &modname);
-    virtual void terminate(const std::string &modname);
+    void initialize(const std::string &modname) override;
+    void terminate(const std::string &modname) override;
     void dump(std::ostream &strm) const override;
 };
 
 #endif // A_BESXMLDapCommandModule_H
-

--- a/xmlcommand/BESXMLDeleteContainerCommand.h
+++ b/xmlcommand/BESXMLDeleteContainerCommand.h
@@ -43,9 +43,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return false;
     }
@@ -56,4 +56,3 @@ public:
 };
 
 #endif // A_BESXMLDeleteContainerCommand_h
-

--- a/xmlcommand/BESXMLDeleteContainersCommand.h
+++ b/xmlcommand/BESXMLDeleteContainersCommand.h
@@ -43,9 +43,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return false;
     }
@@ -56,4 +56,3 @@ public:
 };
 
 #endif // A_BESXMLDeleteContainersCommand_h
-

--- a/xmlcommand/BESXMLDeleteDefinitionCommand.h
+++ b/xmlcommand/BESXMLDeleteDefinitionCommand.h
@@ -43,9 +43,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return false;
     }
@@ -56,4 +56,3 @@ public:
 };
 
 #endif // A_BESXMLDeleteDefinitionCommand_h
-

--- a/xmlcommand/BESXMLDeleteDefinitionsCommand.h
+++ b/xmlcommand/BESXMLDeleteDefinitionsCommand.h
@@ -43,9 +43,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return false;
     }
@@ -56,4 +56,3 @@ public:
 };
 
 #endif // A_BESXMLDeleteDefinitionsCommand_h
-

--- a/xmlcommand/BESXMLGetCommand.h
+++ b/xmlcommand/BESXMLGetCommand.h
@@ -53,15 +53,15 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
-    virtual BESDataHandlerInterface &get_xmlcmd_dhi();
+    void parse_request(xmlNode *node) override;
+    BESDataHandlerInterface &get_xmlcmd_dhi() override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return true;
     }
 
-    virtual void prep_request();
+    void prep_request() override;
 
     void dump(std::ostream &strm) const override;
 
@@ -69,4 +69,3 @@ public:
 };
 
 #endif // A_BESXMLGetCommand_h
-

--- a/xmlcommand/BESXMLSetContainerCommand.h
+++ b/xmlcommand/BESXMLSetContainerCommand.h
@@ -58,9 +58,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return false;
     }
@@ -71,4 +71,3 @@ public:
 };
 
 #endif // A_BESXMLSetContainerCommand_h
-

--- a/xmlcommand/BESXMLSetContextCommand.h
+++ b/xmlcommand/BESXMLSetContextCommand.h
@@ -43,9 +43,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return false;
     }
@@ -56,4 +56,3 @@ public:
 };
 
 #endif // A_BESXMLSetContextCommand_h
-

--- a/xmlcommand/BESXMLShowCommand.h
+++ b/xmlcommand/BESXMLShowCommand.h
@@ -43,9 +43,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return true;
     }
@@ -56,4 +56,3 @@ public:
 };
 
 #endif // A_BESXMLShowCommand_h
-

--- a/xmlcommand/BESXMLShowErrorCommand.h
+++ b/xmlcommand/BESXMLShowErrorCommand.h
@@ -43,9 +43,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return false;
     }
@@ -56,4 +56,3 @@ public:
 };
 
 #endif // A_BESXMLShowErrorCommand_h
-

--- a/xmlcommand/NullResponseHandler.h
+++ b/xmlcommand/NullResponseHandler.h
@@ -56,7 +56,7 @@ public:
      * @param dhi structure that holds request and response information
      * @throws BESSyntaxUserError if no context name was given object
      */
-    virtual void execute(BESDataHandlerInterface &/*dhi*/) {
+    void execute(BESDataHandlerInterface &/*dhi*/) override {
         // This would be used in the transmit() method below to send a response back to the
         // BES's client, if this command returned data. Since it does not, this can be NULL
         // and the transmit() method can be a no-op. jhrg 2/8/18
@@ -71,9 +71,9 @@ public:
      * @param transmitter object that knows how to transmit specific basic types
      * @param dhi structure that holds the request and response information
      */
-    virtual void transmit(BESTransmitter */*transmitter*/, BESDataHandlerInterface &/*dhi*/) { }
+    void transmit(BESTransmitter */*transmitter*/, BESDataHandlerInterface &/*dhi*/) override { }
 
-    virtual void dump(std::ostream &strm) const {
+    void dump(std::ostream &strm) const override {
         strm << BESIndent::LMarg << "NullResponseHandler::dump - (" << (void *) this << ")" << std::endl;
         BESIndent::Indent();
         BESResponseHandler::dump(strm);
@@ -91,4 +91,3 @@ public:
 }   // namespace bes
 
 #endif // NullResponseHandler_h
-

--- a/xmlcommand/SetContextsResponseHandler.h
+++ b/xmlcommand/SetContextsResponseHandler.h
@@ -50,8 +50,8 @@ public:
     SetContextsResponseHandler(const std::string &name): BESResponseHandler(name) { }
     virtual ~SetContextsResponseHandler(void) { }
 
-    virtual void execute(BESDataHandlerInterface &dhi);
-    virtual void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi);
+    void execute(BESDataHandlerInterface &dhi) override;
+    void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi) override;
 
     void dump(std::ostream &strm) const override;
 
@@ -63,4 +63,3 @@ public:
 }   // namespace bes
 
 #endif // SetContextsResponseHandler_h
-

--- a/xmlcommand/ShowBesKeyCommand.h
+++ b/xmlcommand/ShowBesKeyCommand.h
@@ -44,9 +44,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return true;
     }

--- a/xmlcommand/ShowBesKeyResponseHandler.h
+++ b/xmlcommand/ShowBesKeyResponseHandler.h
@@ -49,8 +49,8 @@ public:
     ShowBesKeyResponseHandler(const std::string &name);
     virtual ~ShowBesKeyResponseHandler();
 
-    virtual void execute(BESDataHandlerInterface &dhi);
-    virtual void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi);
+    void execute(BESDataHandlerInterface &dhi) override;
+    void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi) override;
 
     void dump(std::ostream &strm) const override;
 
@@ -60,4 +60,3 @@ public:
 };
 
 #endif // I_ShowBesKeyResponseHandler_h
-

--- a/xmlcommand/ShowNodeCommand.h
+++ b/xmlcommand/ShowNodeCommand.h
@@ -38,9 +38,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return true;
     }
@@ -53,4 +53,3 @@ public:
 } // namespace bes
 
 #endif // A_ShowNodeCommand_h
-

--- a/xmlcommand/ShowPathInfoCommand.h
+++ b/xmlcommand/ShowPathInfoCommand.h
@@ -38,9 +38,9 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response()
+    bool has_response() override
     {
         return true;
     }

--- a/xmlcommand/SiteMapCommand.h
+++ b/xmlcommand/SiteMapCommand.h
@@ -62,10 +62,10 @@ public:
     {
     }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
     /// @brief This command does not return a response, unless its an error
-    virtual bool has_response()
+    bool has_response() override
     {
         return true;
     }
@@ -76,4 +76,3 @@ public:
 };
 
 #endif // A_SiteMapCommand_h
-

--- a/xmlcommand/SiteMapResponseHandler.h
+++ b/xmlcommand/SiteMapResponseHandler.h
@@ -60,8 +60,8 @@ public:
     SiteMapResponseHandler(const std::string &name);
     virtual ~SiteMapResponseHandler();
 
-    virtual void execute(BESDataHandlerInterface &dhi);
-    virtual void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi);
+    void execute(BESDataHandlerInterface &dhi) override;
+    void transmit(BESTransmitter *transmitter, BESDataHandlerInterface &dhi) override;
 
     void dump(std::ostream &strm) const override;
 
@@ -69,4 +69,3 @@ public:
 };
 
 #endif // I_SiteMapResponseHandler_h
-

--- a/xmlcommand/XMLSetContextsCommand.h
+++ b/xmlcommand/XMLSetContextsCommand.h
@@ -35,9 +35,9 @@ public:
     XMLSetContextsCommand(const BESDataHandlerInterface &base_dhi) : BESXMLCommand(base_dhi) { }
     virtual ~XMLSetContextsCommand() { }
 
-    virtual void parse_request(xmlNode *node);
+    void parse_request(xmlNode *node) override;
 
-    virtual bool has_response() {
+    bool has_response() override {
         return false;
     }
 
@@ -49,4 +49,3 @@ public:
 } // namespace bes
 
 #endif // XMLSetContextsCommand_h
-

--- a/xmlcommand/tests/TestModule.h
+++ b/xmlcommand/tests/TestModule.h
@@ -40,8 +40,8 @@ public:
 	TestModule() { }
 	virtual ~TestModule() { }
 
-	virtual void initialize(const std::string &modname);
-	virtual void terminate(const std::string &modname);
+	void initialize(const std::string &modname) override;
+	void terminate(const std::string &modname) override;
 
 	void dump(std::ostream &strm) const override;
 };

--- a/xmlcommand/unit-tests/XmlInterfaceTest.cc
+++ b/xmlcommand/unit-tests/XmlInterfaceTest.cc
@@ -48,7 +48,7 @@ using namespace std;
 class XmlInterfaceTest : public CppUnit::TestFixture {
 
 public:
-    string d_commands_dir = BESUtil::assemblePath(TEST_SRC_DIR, "cmd"); ;
+    string d_commands_dir = BESUtil::assemblePath(TEST_SRC_DIR, "cmd");
 
     // Called once before everything gets tested
     XmlInterfaceTest() = default;


### PR DESCRIPTION
## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2108

<!-- Description of task -->
As part of the 'fix NcML handler's woes' I decided it was time to cut away the warnings in the BES code. I have removed most _except_ the ones in nlohmann which has a much more recent release that we should look at and the HDF4/5 code, which is complex enough to warrant its own PR. There are many many warnings from ld and libtool that remain, as well. See the ticket's attached files.

Most of these changes are minor (missing overload keywords) but there are some code changes. Those are pretty obvious, so while this looks like a huge change, I hope it's not that hard a PR to review. If you need more help in locating key points, let me know.

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] Tests added/updated
- [x] Dead code removed
- [x] No TODOs added
