### PR TITLE
Modifications to the besstandalone Makefile.am

### DIFF
--- a/standalone/Makefile.am
+++ b/standalone/Makefile.am
@@ -4,6 +4,8 @@
 AUTOMAKE_OPTIONS = foreign subdir-objects
 
 AM_CPPFLAGS = -I$(top_srcdir)/xmlcommand -I$(top_srcdir)/cmdln -I$(top_srcdir)/dispatch $(XML2_CFLAGS)
+AM_CXXFLAGS = $(AM_CXX_FLAGS) 
+AM_LDFLAGS = -L$(top_builddir)/dispatch/.libs -L$(top_builddir)/xmlcommand/.libs $(AM_LD_FLAGS) 
 
 if BES_DEVELOPER
 AM_CPPFLAGS += -DBES_DEVELOPER
@@ -15,7 +17,7 @@ endif
 # will override the values set by configure. In many cases, that's what you want, but
 # here we want besstandalone to link up with the shared dependencies. jhrg 1/8/26
 
-AM_CXXFLAGS=
+AM_CXXFLAGS = $(AM_CXX_FLAGS) 
 include $(top_srcdir)/coverage.mk
 
 EXTRA_DIST = response-split.py
@@ -34,5 +36,6 @@ besstandalone_SOURCES = besstandalone.cc StandAloneApp.cc StandAloneClient.cc \
 
 # This depends on building in bes/cmdln first. It's not a good way to write
 # the Makefile.am, but I cannot get distcheck to work otherwise. jhrg 9/8/23
-besstandalone_LDADD = $(top_builddir)/cmdln/CmdTranslation.o $(top_builddir)/dispatch/libbes_dispatch.la \
-    $(top_builddir)/xmlcommand/libbes_xml_command.la $(READLINE_LIBS) $(XML2_LIBS)
+
+besstandalone_LDADD = $(top_builddir)/cmdln/CmdTranslation.o -lbes_dispatch -lbes_xml_command \
+    $(READLINE_LIBS) $(XML2_LIBS)


### PR DESCRIPTION
These changes support better debugging because they link to local or installed libraries.

## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2174

<!-- Description of task -->
We need to improve how besstandalone is linked so that it's easier to use with a debugger. Currently, it is linking only with installed versions of the BES libraries. This is an attempt to make it link with local or installed versions.

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [ ] Tests added/updated
- [ ] Dead code removed
- [ ] No TODOs added
