### PR TITLE
Remove macos-15-intel from CICD

### DIFF
--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -54,7 +54,6 @@ jobs:
         runs-on:
           # See https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md for pre-installed software
           - macos-15
-          - macos-15-intel
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2119

<!-- Description of task -->
This is not a draft PR so that I can test the macos CICD tree.
Remove macos-15-intel from CICD: BES

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] Tests added/updated
- [x] Dead code removed
- [x] No TODOs added
