### PR TITLE
HYRAX-2178: Add EDL user id to relevant cache keys in SignedURLCache

### DIFF
--- a/aws/SignedUrlCache.cc
+++ b/aws/SignedUrlCache.cc
@@ -68,7 +68,7 @@ namespace bes {
 void SignedUrlCache::cache_presigned_s3_url(string const &unsigned_url,
                                             shared_ptr<http::EffectiveUrl> const signed_url) {
     std::string key = append_edl_username_to_key(unsigned_url);
-    INFO_LOG(prolog + "Caching presigned url with key - " + key);
+    BESDEBUG(MODULE, prolog + "Caching presigned url with key " + key);
     d_presigned_s3_urls_cache[key] = signed_url;
 }
 
@@ -80,7 +80,6 @@ void SignedUrlCache::cache_presigned_s3_url(string const &unsigned_url,
 shared_ptr<http::EffectiveUrl> SignedUrlCache::get_cached_presigned_s3_url(string const &url_key) {
     shared_ptr<http::EffectiveUrl> signed_url(nullptr);
     std::string signed_url_key = append_edl_username_to_key(url_key);
-    INFO_LOG(prolog + "URL ATTEMPTED - " + url_key + " - with key - " + signed_url_key);
     auto it = d_presigned_s3_urls_cache.find(signed_url_key);
     if (it != d_presigned_s3_urls_cache.end()) {
         signed_url = (*it).second;
@@ -125,7 +124,6 @@ std::string SignedUrlCache::append_edl_username_to_key(string const &key) {
     if (found && !uid.empty()) {
         return key + ":" + uid;
     }
-
     INFO_LOG(prolog + string("SERVICE CHAIN WARNING - EDL UID missing; using raw key " + key));
     return key;
 }
@@ -139,8 +137,7 @@ std::string SignedUrlCache::append_edl_username_to_key(string const &key) {
 void SignedUrlCache::cache_sts_credentials(string const &tea_endpoint_url,
                                            shared_ptr<S3AccessKeyTuple> const credentials) {
     auto tea_endpoint_url_key = append_edl_username_to_key(tea_endpoint_url);
-    INFO_LOG(prolog + "Caching STS credentials for TEA endpoint - " + tea_endpoint_url + " - with key - " +
-             tea_endpoint_url_key);
+    BESDEBUG(MODULE, prolog + "Caching STS credentials for TEA endpoint; key: " + tea_endpoint_url_key);
     d_tea_endpoint_sts_credentials_cache[tea_endpoint_url_key] = credentials;
 }
 
@@ -326,7 +323,8 @@ SignedUrlCache::get_sts_credentials_from_tea_endpoint(std::string const &tea_end
     try {
         BES_PROFILE_TIMING(string("Request s3 credentials from TEA - ") + tea_endpoint_url);
 
-        // Note: this http_get call internally adds edl auth headers, if available
+        // Note: this http_get call internally adds EDL auth headers, if available. The resultant credentials are
+        // specific to the current EDL user
         curl::http_get(tea_endpoint_url, s3credentials_json_string);
     } catch (http::HttpError &http_error) {
         string err_msg = prolog +
@@ -347,13 +345,7 @@ SignedUrlCache::get_sts_credentials_from_tea_endpoint(std::string const &tea_end
     auto credentials = extract_sts_credentials_from_json_response(s3credentials_json_string);
     if (credentials) {
         // Store credentials if any were retrieved
-        // auto tea_endpoint_url_key = append_edl_username_to_key(tea_endpoint_url);
-        // INFO_LOG(prolog + "Caching STS credentials for TEA endpoint - " + tea_endpoint_url + " - with key - " +
-        //          tea_endpoint_url_key);
-        // d_tea_endpoint_sts_credentials_cache[tea_endpoint_url_key] = credentials;
-
         cache_sts_credentials(tea_endpoint_url, credentials);
-
     } else {
         INFO_LOG(prolog + "SERVICE CHAIN WARNING - Error extracting STS credentials from TEA endpoint - " +
                  tea_endpoint_url);

--- a/aws/SignedUrlCache.cc
+++ b/aws/SignedUrlCache.cc
@@ -117,6 +117,11 @@ bool SignedUrlCache::is_timestamp_after_now(std::string const &timestamp_str) {
     return timestamp_secs > now_secs;
 }
 
+/**
+ * @brief Append the EDL username from the BESContext to key.
+ * @param key Key prefix.
+ * @note This method is not, itself, thread safe.
+ */
 std::string SignedUrlCache::append_edl_username_to_key(string const &key) {
     bool found = false;
     string uid = BESContextManager::TheManager()->get_context(EDL_UID_KEY, found);
@@ -148,9 +153,7 @@ void SignedUrlCache::cache_sts_credentials(string const &tea_endpoint_url,
  */
 shared_ptr<SignedUrlCache::S3AccessKeyTuple>
 SignedUrlCache::get_cached_sts_credentials(string const &tea_endpoint_url) {
-
     auto tea_endpoint_url_key = append_edl_username_to_key(tea_endpoint_url);
-
     shared_ptr<S3AccessKeyTuple> s3_access_key_tuple(nullptr);
     auto it = d_tea_endpoint_sts_credentials_cache.find(tea_endpoint_url_key);
     if (it != d_tea_endpoint_sts_credentials_cache.end()) {

--- a/aws/SignedUrlCache.cc
+++ b/aws/SignedUrlCache.cc
@@ -60,13 +60,28 @@ constexpr auto MODULE_DUMPER = "euc:dump";
 namespace bes {
 
 /**
+ * @brief Cache presigned URL with key unsigned_url:edl_userid.
+ * @param unsigned_url Url to be used as cache key prefix
+ * @param signed_url Presigned URL.
+ * @note This method is not, itself, thread safe.
+ */
+void SignedUrlCache::cache_presigned_s3_url(string const &unsigned_url,
+                                            shared_ptr<http::EffectiveUrl> const signed_url) {
+    std::string key = append_edl_username_to_key(unsigned_url);
+    INFO_LOG(prolog + "Caching presigned url with key - " + key);
+    d_presigned_s3_urls_cache[key] = signed_url;
+}
+
+/**
  * @brief Get the cached presigned URL.
  * @param url_key Key to a cached presigned URL.
  * @note This method is not, itself, thread safe.
  */
 shared_ptr<http::EffectiveUrl> SignedUrlCache::get_cached_presigned_s3_url(string const &url_key) {
     shared_ptr<http::EffectiveUrl> signed_url(nullptr);
-    auto it = d_presigned_s3_urls_cache.find(url_key);
+    std::string signed_url_key = append_edl_username_to_key(url_key);
+    INFO_LOG(prolog + "URL ATTEMPTED - " + url_key + " - with key - " + signed_url_key);
+    auto it = d_presigned_s3_urls_cache.find(signed_url_key);
     if (it != d_presigned_s3_urls_cache.end()) {
         signed_url = (*it).second;
     }
@@ -111,8 +126,7 @@ std::string SignedUrlCache::append_edl_username_to_key(string const &key) {
         return key + ":" + uid;
     }
 
-    INFO_LOG(prolog +
-             string("SERVICE CHAIN WARNING - EDL UID missing; using raw key " + key));
+    INFO_LOG(prolog + string("SERVICE CHAIN WARNING - EDL UID missing; using raw key " + key));
     return key;
 }
 
@@ -226,7 +240,7 @@ shared_ptr<http::EffectiveUrl> SignedUrlCache::get_presigned_s3_url(shared_ptr<h
                 // logged during failed signing.
                 return nullptr;
             }
-            d_presigned_s3_urls_cache[source_url_key] = signed_url;
+            cache_presigned_s3_url(source_url_key, signed_url);
 
             BESDEBUG(MODULE, prolog << "   Cached " << source_url_key << " with value " << signed_url->str() << endl);
         }

--- a/aws/SignedUrlCache.cc
+++ b/aws/SignedUrlCache.cc
@@ -31,6 +31,7 @@
 #include <string>
 
 #include "AWS_SDK.h"
+#include "BESContextManager.h"
 #include "BESDebug.h"
 #include "BESStopWatch.h"
 #include "BESUtil.h"
@@ -102,13 +103,29 @@ bool SignedUrlCache::is_timestamp_after_now(std::string const &timestamp_str) {
     return timestamp_secs > now_secs;
 }
 
+std::string SignedUrlCache::append_edl_username_to_key(string const &key) {
+    bool found = false;
+    string uid = BESContextManager::TheManager()->get_context(EDL_UID_KEY, found);
+    BESDEBUG(MODULE, prolog << "EDL_UID_KEY(" << EDL_UID_KEY << "): " << uid << endl);
+    if (found && !uid.empty()) {
+        return key + ":" + uid;
+    }
+
+    INFO_LOG(prolog +
+             string("SERVICE CHAIN WARNING - EDL UID missing; using raw key " + key));
+    return key;
+}
+
 /**
  * @brief Get the cached STS credentials for a given TEA endpoint URL.
  * @param tea_endpoint_url_key URL to a TEA endpoint.
  * @note This method is not, itself, thread safe.
  */
 shared_ptr<SignedUrlCache::S3AccessKeyTuple>
-SignedUrlCache::retrieve_cached_sts_credentials(string const &tea_endpoint_url_key) {
+SignedUrlCache::retrieve_cached_sts_credentials(string const &tea_endpoint_url) {
+
+    auto tea_endpoint_url_key = append_edl_username_to_key(tea_endpoint_url);
+
     shared_ptr<S3AccessKeyTuple> s3_access_key_tuple(nullptr);
     auto it = d_tea_endpoint_sts_credentials_cache.find(tea_endpoint_url_key);
     if (it != d_tea_endpoint_sts_credentials_cache.end()) {
@@ -302,8 +319,10 @@ SignedUrlCache::cache_sts_credentials_from_tea_endpoint(std::string const &tea_e
     auto credentials = extract_sts_credentials_from_json_response(s3credentials_json_string);
     if (credentials) {
         // Store credentials if any were retrieved
-        INFO_LOG(prolog + "Caching STS credentials for TEA endpoint - " + tea_endpoint_url);
-        d_tea_endpoint_sts_credentials_cache[tea_endpoint_url] = credentials;
+        auto tea_endpoint_url_key = append_edl_username_to_key(tea_endpoint_url);
+        INFO_LOG(prolog + "Caching STS credentials for TEA endpoint - " + tea_endpoint_url + " - with key - " +
+                 tea_endpoint_url_key);
+        d_tea_endpoint_sts_credentials_cache[tea_endpoint_url_key] = credentials;
     } else {
         INFO_LOG(prolog + "SERVICE CHAIN WARNING - Error extracting STS credentials from TEA endpoint - " +
                  tea_endpoint_url);

--- a/aws/SignedUrlCache.cc
+++ b/aws/SignedUrlCache.cc
@@ -115,7 +115,7 @@ SignedUrlCache::retrieve_cached_sts_credentials(string const &tea_endpoint_url_k
         // Is it expired? If so, erase it!
         auto timestamp_str = get<3>(*(it->second));
         if (!is_timestamp_after_now(timestamp_str)) {
-            // Expired!
+            INFO_LOG("Previously cached STS credentials have expired for TEA endpoint " + tea_endpoint_url_key);
             d_tea_endpoint_sts_credentials_cache.erase(it);
         } else {
             s3_access_key_tuple = it->second;

--- a/aws/SignedUrlCache.cc
+++ b/aws/SignedUrlCache.cc
@@ -131,12 +131,26 @@ std::string SignedUrlCache::append_edl_username_to_key(string const &key) {
 }
 
 /**
+ * @brief Cache STS credentials with key tea_endpoint_url:edl_userid.
+ * @param tea_endpoint_url Url to be used as cache key prefix
+ * @param credentials Credentials fetched from endpoint.
+ * @note This method is not, itself, thread safe.
+ */
+void SignedUrlCache::cache_sts_credentials(string const &tea_endpoint_url,
+                                           shared_ptr<S3AccessKeyTuple> const credentials) {
+    auto tea_endpoint_url_key = append_edl_username_to_key(tea_endpoint_url);
+    INFO_LOG(prolog + "Caching STS credentials for TEA endpoint - " + tea_endpoint_url + " - with key - " +
+             tea_endpoint_url_key);
+    d_tea_endpoint_sts_credentials_cache[tea_endpoint_url_key] = credentials;
+}
+
+/**
  * @brief Get the cached STS credentials for a given TEA endpoint URL.
  * @param tea_endpoint_url_key URL to a TEA endpoint.
  * @note This method is not, itself, thread safe.
  */
 shared_ptr<SignedUrlCache::S3AccessKeyTuple>
-SignedUrlCache::retrieve_cached_sts_credentials(string const &tea_endpoint_url) {
+SignedUrlCache::get_cached_sts_credentials(string const &tea_endpoint_url) {
 
     auto tea_endpoint_url_key = append_edl_username_to_key(tea_endpoint_url);
 
@@ -221,9 +235,9 @@ shared_ptr<http::EffectiveUrl> SignedUrlCache::get_presigned_s3_url(shared_ptr<h
             }
 
             // 2. ...get unexpired access credentials from cache or s3credentials endpoint...
-            auto s3_access_key_tuple = retrieve_cached_sts_credentials(tea_endpoint_url);
+            auto s3_access_key_tuple = get_cached_sts_credentials(tea_endpoint_url);
             if (!s3_access_key_tuple) {
-                s3_access_key_tuple = cache_sts_credentials_from_tea_endpoint(tea_endpoint_url);
+                s3_access_key_tuple = get_sts_credentials_from_tea_endpoint(tea_endpoint_url);
             }
             if (!s3_access_key_tuple) {
                 INFO_LOG(prolog +
@@ -306,7 +320,7 @@ SignedUrlCache::retrieve_cached_prerequisites_for_url_signing(const std::string 
  * @note If credential retrieval fails at any point, returns nullptr and does not cache results
  */
 shared_ptr<SignedUrlCache::S3AccessKeyTuple>
-SignedUrlCache::cache_sts_credentials_from_tea_endpoint(std::string const &tea_endpoint_url) {
+SignedUrlCache::get_sts_credentials_from_tea_endpoint(std::string const &tea_endpoint_url) {
     // 1. Get the credentials from TEA
     std::string s3credentials_json_string;
     try {
@@ -333,10 +347,13 @@ SignedUrlCache::cache_sts_credentials_from_tea_endpoint(std::string const &tea_e
     auto credentials = extract_sts_credentials_from_json_response(s3credentials_json_string);
     if (credentials) {
         // Store credentials if any were retrieved
-        auto tea_endpoint_url_key = append_edl_username_to_key(tea_endpoint_url);
-        INFO_LOG(prolog + "Caching STS credentials for TEA endpoint - " + tea_endpoint_url + " - with key - " +
-                 tea_endpoint_url_key);
-        d_tea_endpoint_sts_credentials_cache[tea_endpoint_url_key] = credentials;
+        // auto tea_endpoint_url_key = append_edl_username_to_key(tea_endpoint_url);
+        // INFO_LOG(prolog + "Caching STS credentials for TEA endpoint - " + tea_endpoint_url + " - with key - " +
+        //          tea_endpoint_url_key);
+        // d_tea_endpoint_sts_credentials_cache[tea_endpoint_url_key] = credentials;
+
+        cache_sts_credentials(tea_endpoint_url, credentials);
+
     } else {
         INFO_LOG(prolog + "SERVICE CHAIN WARNING - Error extracting STS credentials from TEA endpoint - " +
                  tea_endpoint_url);

--- a/aws/SignedUrlCache.h
+++ b/aws/SignedUrlCache.h
@@ -68,8 +68,11 @@ private:
 
     static std::shared_ptr<S3AccessKeyTuple>
     extract_sts_credentials_from_json_response(std::string const &s3credentials_json_string);
-    std::shared_ptr<S3AccessKeyTuple> cache_sts_credentials_from_tea_endpoint(std::string const &tea_endpoint_url);
-    std::shared_ptr<S3AccessKeyTuple> retrieve_cached_sts_credentials(std::string const &tea_endpoint_url_key);
+    std::shared_ptr<S3AccessKeyTuple> get_sts_credentials_from_tea_endpoint(std::string const &tea_endpoint_url);
+
+    void cache_sts_credentials(std::string const &tea_endpoint_url,
+                               std::shared_ptr<S3AccessKeyTuple> const credentials);
+    std::shared_ptr<S3AccessKeyTuple> get_cached_sts_credentials(std::string const &tea_endpoint_url_key);
 
     static bool is_timestamp_after_now(std::string const &timestamp);
     const bool is_cache_supported_within_current_aws_region();

--- a/aws/SignedUrlCache.h
+++ b/aws/SignedUrlCache.h
@@ -63,7 +63,10 @@ private:
     std::map<std::string, std::string> d_href_to_tea_endpoint_cache;
     std::map<std::string, std::string> d_href_to_s3_uri_cache;
 
+
     std::map<std::string, std::shared_ptr<S3AccessKeyTuple>> d_tea_endpoint_sts_credentials_cache;
+    static std::string append_edl_username_to_key(std::string const &key);
+
     static std::shared_ptr<S3AccessKeyTuple> extract_sts_credentials_from_json_response(std::string const &s3credentials_json_string);
     std::shared_ptr<S3AccessKeyTuple> cache_sts_credentials_from_tea_endpoint(std::string const &tea_endpoint_url);
     std::shared_ptr<S3AccessKeyTuple> retrieve_cached_sts_credentials(std::string const &tea_endpoint_url_key);

--- a/aws/SignedUrlCache.h
+++ b/aws/SignedUrlCache.h
@@ -27,18 +27,18 @@
 #ifndef _bes_aws_SignedUrlCache_h_
 #define _bes_aws_SignedUrlCache_h_ 1
 
-#include <memory>
 #include <map>
-#include <unordered_map>
-#include <string>
+#include <memory>
 #include <mutex>
+#include <string>
+#include <unordered_map>
 
 #include "BESObj.h"
 
 namespace http {
-    class EffectiveUrl;
-    class url;
-}
+class EffectiveUrl;
+class url;
+} // namespace http
 
 namespace bes {
 
@@ -63,11 +63,11 @@ private:
     std::map<std::string, std::string> d_href_to_tea_endpoint_cache;
     std::map<std::string, std::string> d_href_to_s3_uri_cache;
 
-
     std::map<std::string, std::shared_ptr<S3AccessKeyTuple>> d_tea_endpoint_sts_credentials_cache;
     static std::string append_edl_username_to_key(std::string const &key);
 
-    static std::shared_ptr<S3AccessKeyTuple> extract_sts_credentials_from_json_response(std::string const &s3credentials_json_string);
+    static std::shared_ptr<S3AccessKeyTuple>
+    extract_sts_credentials_from_json_response(std::string const &s3credentials_json_string);
     std::shared_ptr<S3AccessKeyTuple> cache_sts_credentials_from_tea_endpoint(std::string const &tea_endpoint_url);
     std::shared_ptr<S3AccessKeyTuple> retrieve_cached_sts_credentials(std::string const &tea_endpoint_url_key);
 
@@ -85,8 +85,10 @@ private:
     static uint64_t num_seconds_until_expiration(
         const std::string &credentials_expiration_datetime,
         const std::chrono::system_clock::time_point current_time = std::chrono::system_clock::now());
-    std::shared_ptr<http::EffectiveUrl> sign_s3_uri_with_sts_credentials(std::string const &s3_uri,
-                                                                         std::shared_ptr<S3AccessKeyTuple> const s3_access_key_tuple);
+    std::shared_ptr<http::EffectiveUrl>
+    sign_s3_uri_with_sts_credentials(std::string const &s3_uri,
+                                     std::shared_ptr<S3AccessKeyTuple> const s3_access_key_tuple);
+    void cache_presigned_s3_url(std::string const &unsigned_url, std::shared_ptr<http::EffectiveUrl> const signed_url);
     std::shared_ptr<http::EffectiveUrl> get_cached_presigned_s3_url(std::string const &url_key);
 
     bool is_enabled();
@@ -113,7 +115,8 @@ public:
 
     void cache_prerequisites_for_url_signing(const std::string &key_href_url, const std::string &s3_uri,
                                              const std::string &tea_endpoint_url);
-    std::pair<std::string, std::string> retrieve_cached_prerequisites_for_url_signing(const std::string &key_href_url) const;
+    std::pair<std::string, std::string>
+    retrieve_cached_prerequisites_for_url_signing(const std::string &key_href_url) const;
 
     std::shared_ptr<http::EffectiveUrl> get_presigned_s3_url(std::shared_ptr<http::url> source_url);
 

--- a/aws/unit-tests/SignedUrlCacheTest.cc
+++ b/aws/unit-tests/SignedUrlCacheTest.cc
@@ -196,8 +196,7 @@ public:
 
         auto value =
             make_shared<SignedUrlCache::S3AccessKeyTuple>("a man", "a plan", "a canal", "3035-07-16 02:20:33+00:00");
-        theCache->d_tea_endpoint_sts_credentials_cache.insert(
-            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>("palindrome", value));
+        theCache->cache_sts_credentials("palindrome", value);
 
         theCache->d_href_to_tea_endpoint_cache.insert(pair<string, string>("foo", "whee"));
         theCache->d_href_to_s3_uri_cache.insert(pair<string, string>("yee", "haw"));
@@ -212,7 +211,7 @@ public:
             "\n        www.once.com:test_user --> http://www.upon.com" +
             "\n    href-to-s3credentials list:" + "\n        foo --> whee" +
             "\n    href-to-s3url list:" + "\n        yee --> haw" +
-            "\n    s3 credentials list:" + "\n        palindrome --> Expires: 3035-07-16 02:20:33+00:00\n";
+            "\n    s3 credentials list:" + "\n        palindrome:test_user --> Expires: 3035-07-16 02:20:33+00:00\n";
         CPPUNIT_ASSERT_MESSAGE("The dump should contain:\n" + expected_str + "\n\nbut did not; INSTEAD was\n" + result,
                                result.find(expected_str) != std::string::npos);
     }
@@ -231,29 +230,24 @@ public:
 
     void retrieve_cached_s3credentials_test() {
         std::string credentials_endpoint_url = "i_am_an_s3credentials_endpoint";
-        std::string cache_key = credentials_endpoint_url + ":test_user";
-        auto result_not_in_cache =
-            SignedUrlCache::TheCache()->retrieve_cached_sts_credentials(credentials_endpoint_url);
+        auto result_not_in_cache = SignedUrlCache::TheCache()->get_cached_sts_credentials(credentials_endpoint_url);
         CPPUNIT_ASSERT_MESSAGE("Cache miss should return null", result_not_in_cache == nullptr);
 
         auto value =
             make_shared<SignedUrlCache::S3AccessKeyTuple>("a man", "a plan", "a canal", "2135-07-16 02:20:33+00:00");
-        SignedUrlCache::TheCache()->d_tea_endpoint_sts_credentials_cache.insert(
-            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>(cache_key, value));
-        auto result_in_cache = SignedUrlCache::TheCache()->retrieve_cached_sts_credentials(credentials_endpoint_url);
+        SignedUrlCache::TheCache()->cache_sts_credentials(credentials_endpoint_url, value);
+        auto result_in_cache = SignedUrlCache::TheCache()->get_cached_sts_credentials(credentials_endpoint_url);
         CPPUNIT_ASSERT_MESSAGE("Cache hit should successfully retrieve result", result_in_cache == value);
     }
 
     void retrieve_cached_s3credentials_expired_credentials_test() {
         std::string credentials_endpoint_url = "i_am_an_s3credentials_endpoint";
-        std::string cache_key = credentials_endpoint_url + ":test_user";
         std::string expiration_time("1980-07-16 18:40:58+00:00");
         auto value = make_shared<SignedUrlCache::S3AccessKeyTuple>("https://www.foo", "https://www.bar",
                                                                    "https://www.bat", expiration_time);
-        SignedUrlCache::TheCache()->d_tea_endpoint_sts_credentials_cache.insert(
-            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>(cache_key, value));
+        SignedUrlCache::TheCache()->cache_sts_credentials(credentials_endpoint_url, value);
 
-        auto result = SignedUrlCache::TheCache()->retrieve_cached_sts_credentials(credentials_endpoint_url);
+        auto result = SignedUrlCache::TheCache()->get_cached_sts_credentials(credentials_endpoint_url);
         CPPUNIT_ASSERT_MESSAGE("Cached expired result should not be retrieved", result == nullptr);
         CPPUNIT_ASSERT_MESSAGE("Expired result should have been removed from cache",
                                SignedUrlCache::TheCache()->d_tea_endpoint_sts_credentials_cache.empty());
@@ -378,12 +372,12 @@ public:
                                key_no_uid == "foo_url");
     }
 
-    void cache_sts_credentials_from_tea_endpoint_test() {
+    void get_sts_credentials_from_tea_endpoint_test() {
         SignedUrlCache *theCache = SignedUrlCache::TheCache();
 
         CPPUNIT_ASSERT_MESSAGE("Credentials cache is empty", theCache->d_tea_endpoint_sts_credentials_cache.empty());
 
-        auto result_bad = theCache->cache_sts_credentials_from_tea_endpoint("http://badurl");
+        auto result_bad = theCache->get_sts_credentials_from_tea_endpoint("http://badurl");
         CPPUNIT_ASSERT_MESSAGE("After attempting fetch from invalid url, credentials cache is still empty",
                                theCache->d_tea_endpoint_sts_credentials_cache.empty());
         CPPUNIT_ASSERT_MESSAGE("Fetch from invalid url returns nullptr", result_bad == nullptr);
@@ -443,9 +437,7 @@ public:
         theCache->d_href_to_tea_endpoint_cache.insert(pair<string, string>(test_url->str(), "fake-tea-endpoint-name"));
         auto fake_sts_creds =
             make_shared<SignedUrlCache::S3AccessKeyTuple>("a man", "a plan", "a canal", "2126-07-16 18:40:58+04:00");
-        theCache->d_tea_endpoint_sts_credentials_cache.insert(
-            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>("fake-tea-endpoint-name:test_user",
-                                                                       fake_sts_creds));
+        theCache->cache_sts_credentials("fake-tea-endpoint-name", fake_sts_creds);
         CPPUNIT_ASSERT_MESSAGE("Signed URL cache should be empty before any valid responses",
                                theCache->d_presigned_s3_urls_cache.size() == 0);
 
@@ -470,8 +462,7 @@ public:
             "bar?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a%20man%2F20260514%2Fus-east-1%2Fs3%2Faws4_request&"
             "X-Amz-Date=20260514T221009Z&X-Amz-Expires=31846277424&X-Amz-Security-Token=a%20canal&X-Amz-SignedHeaders="
             "host&X-Amz-Signature=99d4cae916dc174f8f36e1e5ddb881f19ff32f84e24e4021deefc8d783c1e40f";
-        theCache->d_presigned_s3_urls_cache[new_key->str() + ":test_user"] =
-            make_shared<http::EffectiveUrl>(cached_presigned_url);
+        theCache->cache_presigned_s3_url(new_key->str(), make_shared<http::EffectiveUrl>(cached_presigned_url));
         CPPUNIT_ASSERT_MESSAGE("When signed url has been precached, return cached value",
                                theCache->get_presigned_s3_url(new_key)->str() == cached_presigned_url);
         std::string expired_cached_url =
@@ -479,8 +470,7 @@ public:
             "bar?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a%20man%2F20260514%2Fus-east-1%2Fs3%2Faws4_request&"
             "X-Amz-Date=20200621T161744Z&X-Amz-Expires=86400&X-Amz-Security-Token=a%20canal&X-Amz-SignedHeaders="
             "host&X-Amz-Signature=99d4cae916dc174f8f36e1e5ddb881f19ff32f84e24e4021deefc8d783c1e40f";
-        theCache->d_presigned_s3_urls_cache[new_key->str() + ":test_user"] =
-            make_shared<http::EffectiveUrl>(expired_cached_url);
+        theCache->cache_presigned_s3_url(new_key->str(), make_shared<http::EffectiveUrl>(expired_cached_url));
         auto regenerated_url = theCache->get_presigned_s3_url(new_key);
         CPPUNIT_ASSERT_MESSAGE("When cached url has expired, regenerate it on request " + regenerated_url->str(),
                                regenerated_url->str() != expired_cached_url);
@@ -579,7 +569,7 @@ public:
     CPPUNIT_TEST(cache_signed_url_components_test);
     CPPUNIT_TEST(retrieve_cached_signed_url_components_test);
     CPPUNIT_TEST(append_edl_username_to_key_test);
-    CPPUNIT_TEST(cache_sts_credentials_from_tea_endpoint_test);
+    CPPUNIT_TEST(get_sts_credentials_from_tea_endpoint_test);
 
     // ...and, specifically, the signing itself:
     CPPUNIT_TEST(sign_s3_uri_with_sts_credentials_test);

--- a/aws/unit-tests/SignedUrlCacheTest.cc
+++ b/aws/unit-tests/SignedUrlCacheTest.cc
@@ -480,8 +480,7 @@ public:
         theCache->d_href_to_s3_uri_cache.insert(pair<string, string>(bad_request_key->str(), "s3://foo/bar"));
         theCache->d_href_to_tea_endpoint_cache.insert(
             pair<string, string>(bad_request_key->str(), "fake-tea-endpoint-name-2"));
-        theCache->d_tea_endpoint_sts_credentials_cache.insert(
-            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>("fake-tea-endpoint-name-2", fake_sts_creds));
+        theCache->cache_sts_credentials("fake-tea-endpoint-name-2", fake_sts_creds);
         CPPUNIT_ASSERT_MESSAGE(
             "When credentials available for input that is not a url, return nullptr output without throwing error",
             !theCache->get_presigned_s3_url(bad_request_key));

--- a/aws/unit-tests/SignedUrlCacheTest.cc
+++ b/aws/unit-tests/SignedUrlCacheTest.cc
@@ -69,6 +69,7 @@ public:
         string bes_conf = BESUtil::assemblePath(TEST_BUILD_DIR, "bes.conf");
         DBG(cerr << prolog << "Using BES configuration: " << bes_conf << endl);
         TheBESKeys::ConfigFile = bes_conf;
+        BESContextManager::TheManager()->set_context(EDL_UID_KEY, "test_user");
 
         // Reset to same starting point every time
         // (It's a singleton so resetting it is important for testing determinism)
@@ -229,27 +230,30 @@ public:
     }
 
     void retrieve_cached_s3credentials_test() {
-        std::string key("i_am_a_key");
-        auto result_not_in_cache = SignedUrlCache::TheCache()->retrieve_cached_sts_credentials(key);
+        std::string credentials_endpoint_url = "i_am_an_s3credentials_endpoint";
+        std::string cache_key = credentials_endpoint_url + ":test_user";
+        auto result_not_in_cache =
+            SignedUrlCache::TheCache()->retrieve_cached_sts_credentials(credentials_endpoint_url);
         CPPUNIT_ASSERT_MESSAGE("Cache miss should return null", result_not_in_cache == nullptr);
 
         auto value =
             make_shared<SignedUrlCache::S3AccessKeyTuple>("a man", "a plan", "a canal", "2135-07-16 02:20:33+00:00");
         SignedUrlCache::TheCache()->d_tea_endpoint_sts_credentials_cache.insert(
-            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>(key, value));
-        auto result_in_cache = SignedUrlCache::TheCache()->retrieve_cached_sts_credentials(key);
+            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>(cache_key, value));
+        auto result_in_cache = SignedUrlCache::TheCache()->retrieve_cached_sts_credentials(credentials_endpoint_url);
         CPPUNIT_ASSERT_MESSAGE("Cache hit should successfully retrieve result", result_in_cache == value);
     }
 
     void retrieve_cached_s3credentials_expired_credentials_test() {
-        std::string key("i_am_a_key");
+        std::string credentials_endpoint_url = "i_am_an_s3credentials_endpoint";
+        std::string cache_key = credentials_endpoint_url + ":test_user";
         std::string expiration_time("1980-07-16 18:40:58+00:00");
         auto value = make_shared<SignedUrlCache::S3AccessKeyTuple>("https://www.foo", "https://www.bar",
                                                                    "https://www.bat", expiration_time);
         SignedUrlCache::TheCache()->d_tea_endpoint_sts_credentials_cache.insert(
-            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>(key, value));
+            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>(cache_key, value));
 
-        auto result = SignedUrlCache::TheCache()->retrieve_cached_sts_credentials(key);
+        auto result = SignedUrlCache::TheCache()->retrieve_cached_sts_credentials(credentials_endpoint_url);
         CPPUNIT_ASSERT_MESSAGE("Cached expired result should not be retrieved", result == nullptr);
         CPPUNIT_ASSERT_MESSAGE("Expired result should have been removed from cache",
                                SignedUrlCache::TheCache()->d_tea_endpoint_sts_credentials_cache.empty());
@@ -361,6 +365,19 @@ public:
         CPPUNIT_ASSERT_MESSAGE("If both urls were not cached, no response is returned", retrieved2 == empty_pair);
     }
 
+    void append_edl_username_to_key_test() {
+        SignedUrlCache *theCache = SignedUrlCache::TheCache();
+
+        std::string expected = "foo_url:test_user";
+        auto key = theCache->append_edl_username_to_key("foo_url");
+        CPPUNIT_ASSERT_MESSAGE("EDL user is appended to key; expected " + expected + " got " + key, key == expected);
+
+        BESContextManager::TheManager()->unset_context(EDL_UID_KEY);
+        auto key_no_uid = theCache->append_edl_username_to_key("foo_url");
+        CPPUNIT_ASSERT_MESSAGE("When EDL user is empty, key should be identity; expected foo_url got " + key_no_uid,
+                               key_no_uid == "foo_url");
+    }
+
     void cache_sts_credentials_from_tea_endpoint_test() {
         SignedUrlCache *theCache = SignedUrlCache::TheCache();
 
@@ -427,7 +444,7 @@ public:
         auto fake_sts_creds =
             make_shared<SignedUrlCache::S3AccessKeyTuple>("a man", "a plan", "a canal", "2126-07-16 18:40:58+04:00");
         theCache->d_tea_endpoint_sts_credentials_cache.insert(
-            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>("fake-tea-endpoint-name", fake_sts_creds));
+            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>("fake-tea-endpoint-name:test_user", fake_sts_creds));
         CPPUNIT_ASSERT_MESSAGE("Signed URL cache should be empty before any valid responses",
                                theCache->d_presigned_s3_urls_cache.size() == 0);
 
@@ -559,6 +576,7 @@ public:
 
     CPPUNIT_TEST(cache_signed_url_components_test);
     CPPUNIT_TEST(retrieve_cached_signed_url_components_test);
+    CPPUNIT_TEST(append_edl_username_to_key_test);
     CPPUNIT_TEST(cache_sts_credentials_from_tea_endpoint_test);
 
     // ...and, specifically, the signing itself:

--- a/aws/unit-tests/SignedUrlCacheTest.cc
+++ b/aws/unit-tests/SignedUrlCacheTest.cc
@@ -99,14 +99,14 @@ public:
         auto input_url = make_shared<http::url>("http://started_here.com");
         auto output_url = make_shared<http::EffectiveUrl>("http://started_here.com?signed-now");
 
-        SignedUrlCache::TheCache()->d_presigned_s3_urls_cache.insert(
-            pair<string, shared_ptr<http::EffectiveUrl>>(input_url->str(), output_url));
+        SignedUrlCache::TheCache()->cache_presigned_s3_url(input_url->str(), output_url);
         auto result = SignedUrlCache::TheCache()->get_presigned_s3_url(input_url);
-        CPPUNIT_ASSERT_MESSAGE("Cached url should be retrievable", result->str() == output_url->str());
+        CPPUNIT_ASSERT_MESSAGE("Cached url should be retrievable",
+                               result != nullptr && result->str() == output_url->str());
 
         std::string non_http_key("foo");
-        SignedUrlCache::TheCache()->d_presigned_s3_urls_cache.insert(
-            pair<string, shared_ptr<http::EffectiveUrl>>(non_http_key, output_url));
+        SignedUrlCache::TheCache()->cache_presigned_s3_url(non_http_key, output_url);
+
         auto result2 = SignedUrlCache::TheCache()->get_presigned_s3_url(make_shared<http::url>(non_http_key));
         CPPUNIT_ASSERT_MESSAGE("Non-url key returns nullptr", result2 == nullptr);
     }
@@ -166,8 +166,8 @@ public:
         auto input_url = make_shared<http::url>("http://started_here.com");
         auto output_url = make_shared<http::EffectiveUrl>("http://started_here.com?signed-now");
 
-        SignedUrlCache::TheCache()->d_presigned_s3_urls_cache.insert(
-            pair<string, shared_ptr<http::EffectiveUrl>>(input_url->str(), output_url));
+        SignedUrlCache::TheCache()->cache_presigned_s3_url(input_url->str(), output_url);
+
         CPPUNIT_ASSERT_MESSAGE("Cache contains single item",
                                SignedUrlCache::TheCache()->d_presigned_s3_urls_cache.size() == 1);
 
@@ -182,17 +182,17 @@ public:
 
         auto result_when_enabled = SignedUrlCache::TheCache()->get_presigned_s3_url(input_url);
         CPPUNIT_ASSERT_MESSAGE("When cache is re-enabled, value is returned",
-                               result_when_enabled->str() == output_url->str());
+                               result_when_enabled != nullptr && result_when_enabled->str() == output_url->str());
     }
 
     void dump_test() {
         SignedUrlCache *theCache = SignedUrlCache::TheCache();
 
         // Add values to each type of subcache
-        theCache->d_presigned_s3_urls_cache.insert(pair<string, shared_ptr<http::EffectiveUrl>>(
-            "www.once.com", make_shared<http::EffectiveUrl>("http://www.upon.com")));
-        theCache->d_presigned_s3_urls_cache.insert(pair<string, shared_ptr<http::EffectiveUrl>>(
-            "www.a.com", make_shared<http::EffectiveUrl>("http://www.time.com")));
+        SignedUrlCache::TheCache()->cache_presigned_s3_url("www.once.com",
+                                                           make_shared<http::EffectiveUrl>("http://www.upon.com"));
+        SignedUrlCache::TheCache()->cache_presigned_s3_url("www.a.com",
+                                                           make_shared<http::EffectiveUrl>("http://www.time.com"));
 
         auto value =
             make_shared<SignedUrlCache::S3AccessKeyTuple>("a man", "a plan", "a canal", "3035-07-16 02:20:33+00:00");
@@ -208,8 +208,8 @@ public:
         // Remove start of string to skip address that varies
         auto result = strm.str().substr(49);
         std::string expected_str =
-            string("presigned url list:") + "\n        www.a.com --> http://www.time.com" +
-            "\n        www.once.com --> http://www.upon.com" +
+            string("presigned url list:") + "\n        www.a.com:test_user --> http://www.time.com" +
+            "\n        www.once.com:test_user --> http://www.upon.com" +
             "\n    href-to-s3credentials list:" + "\n        foo --> whee" +
             "\n    href-to-s3url list:" + "\n        yee --> haw" +
             "\n    s3 credentials list:" + "\n        palindrome --> Expires: 3035-07-16 02:20:33+00:00\n";
@@ -444,7 +444,8 @@ public:
         auto fake_sts_creds =
             make_shared<SignedUrlCache::S3AccessKeyTuple>("a man", "a plan", "a canal", "2126-07-16 18:40:58+04:00");
         theCache->d_tea_endpoint_sts_credentials_cache.insert(
-            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>("fake-tea-endpoint-name:test_user", fake_sts_creds));
+            pair<string, shared_ptr<SignedUrlCache::S3AccessKeyTuple>>("fake-tea-endpoint-name:test_user",
+                                                                       fake_sts_creds));
         CPPUNIT_ASSERT_MESSAGE("Signed URL cache should be empty before any valid responses",
                                theCache->d_presigned_s3_urls_cache.size() == 0);
 
@@ -469,7 +470,8 @@ public:
             "bar?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a%20man%2F20260514%2Fus-east-1%2Fs3%2Faws4_request&"
             "X-Amz-Date=20260514T221009Z&X-Amz-Expires=31846277424&X-Amz-Security-Token=a%20canal&X-Amz-SignedHeaders="
             "host&X-Amz-Signature=99d4cae916dc174f8f36e1e5ddb881f19ff32f84e24e4021deefc8d783c1e40f";
-        theCache->d_presigned_s3_urls_cache[new_key->str()] = make_shared<http::EffectiveUrl>(cached_presigned_url);
+        theCache->d_presigned_s3_urls_cache[new_key->str() + ":test_user"] =
+            make_shared<http::EffectiveUrl>(cached_presigned_url);
         CPPUNIT_ASSERT_MESSAGE("When signed url has been precached, return cached value",
                                theCache->get_presigned_s3_url(new_key)->str() == cached_presigned_url);
         std::string expired_cached_url =
@@ -477,8 +479,8 @@ public:
             "bar?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a%20man%2F20260514%2Fus-east-1%2Fs3%2Faws4_request&"
             "X-Amz-Date=20200621T161744Z&X-Amz-Expires=86400&X-Amz-Security-Token=a%20canal&X-Amz-SignedHeaders="
             "host&X-Amz-Signature=99d4cae916dc174f8f36e1e5ddb881f19ff32f84e24e4021deefc8d783c1e40f";
-        theCache->d_presigned_s3_urls_cache[new_key->str()] = make_shared<http::EffectiveUrl>(expired_cached_url);
-        // CPPUNIT_ASSERT_MESSAGE("Wat", theCache->get_presigned_s3_url(new_key));
+        theCache->d_presigned_s3_urls_cache[new_key->str() + ":test_user"] =
+            make_shared<http::EffectiveUrl>(expired_cached_url);
         auto regenerated_url = theCache->get_presigned_s3_url(new_key);
         CPPUNIT_ASSERT_MESSAGE("When cached url has expired, regenerate it on request " + regenerated_url->str(),
                                regenerated_url->str() != expired_cached_url);


### PR DESCRIPTION
## Description

**Reference ticket:** HYRAX-2178

## Tasks
- [x] Ticket exists and is linked in title
- [x] Tests added/updated
- [x] Dead code removed
- [x] No TODOs added
