### PR TITLE
Rename the macros incorrectly associated  with CMR to EDL

### DIFF
--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -1478,9 +1478,9 @@ curl_slist *add_edl_auth_headers(curl_slist *request_headers) {
         request_headers = append_http_header(request_headers, "Authorization", s);
     }
 
-    s = BESContextManager::TheManager()->get_context(CMR_CLIENT_ID_CONTEXT_KEY, found);
+    s = BESContextManager::TheManager()->get_context(EDL_CLIENT_APPLICATION_ID_CONTEXT_KEY, found);
     if (found && !s.empty()) {
-        request_headers = append_http_header(request_headers, CMR_CLIENT_ID_KEY, s);
+        request_headers = append_http_header(request_headers, EDL_CLIENT_APPLICATION_ID_REQUEST_HEADER_KEY, s);
     }
 
     // TODO Remove this. See HYRAX-1036. jhrg 11/13/25

--- a/http/HttpNames.h
+++ b/http/HttpNames.h
@@ -76,8 +76,8 @@
 #define EDL_UID_KEY "uid"
 
 // jhrg 11/13/25
-#define CMR_CLIENT_ID_CONTEXT_KEY "edl_client_application_id"
-#define CMR_CLIENT_ID_KEY "Client-Id"
+#define EDL_CLIENT_APPLICATION_ID_CONTEXT_KEY "edl_client_application_id"
+#define EDL_CLIENT_APPLICATION_ID_REQUEST_HEADER_KEY "Client-Id"
 
 #define REMOTE_RESOURCE_TMP_DIR_KEY "Http.RemoteResource.TmpDir"    // default is /tmp/bes_rr_tmp
 #define REMOTE_RESOURCE_DELETE_TMP_FILE "Http.RemoteResource.TmpFile.Delete"    // default is true

--- a/http/unit-tests/CurlUtilsTest.cc
+++ b/http/unit-tests/CurlUtilsTest.cc
@@ -87,7 +87,7 @@ public:
         // happen even if exceptions are thrown by the add_edl...() test.
         BESContextManager::TheManager()->unset_context(EDL_UID_KEY);
         BESContextManager::TheManager()->unset_context(EDL_AUTH_TOKEN_KEY);
-        BESContextManager::TheManager()->unset_context(CMR_CLIENT_ID_CONTEXT_KEY);
+        BESContextManager::TheManager()->unset_context(EDL_CLIENT_APPLICATION_ID_CONTEXT_KEY);
         // TODO Remove this and all instances of EDL_ECHO_TOKEN_KEY in this test suite.
         //  See HYRAX-1036. jhrg 11/13/25
         BESContextManager::TheManager()->unset_context(EDL_ECHO_TOKEN_KEY);
@@ -311,7 +311,7 @@ public:
 #if 0
         BESContextManager::TheManager()->set_context(EDL_ECHO_TOKEN_KEY, tokens[2]);
 #endif
-        BESContextManager::TheManager()->set_context(CMR_CLIENT_ID_CONTEXT_KEY, tokens[2]);
+        BESContextManager::TheManager()->set_context(EDL_CLIENT_APPLICATION_ID_CONTEXT_KEY, tokens[2]);
 
         try {
             hdrs = curl::add_edl_auth_headers(hdrs);

--- a/modules/dmrpp_module/ngap_container/unit-tests/NgapApiTest.cc
+++ b/modules/dmrpp_module/ngap_container/unit-tests/NgapApiTest.cc
@@ -201,7 +201,7 @@ public:
 
         // Set the context for the client id. jhrg 10/8/25
         const std::string test_client_id = "hyrax-test-client";
-        BESContextManager::TheManager()->set_context(CMR_CLIENT_ID_CONTEXT_KEY, test_client_id);
+        BESContextManager::TheManager()->set_context(EDL_CLIENT_APPLICATION_ID_CONTEXT_KEY, test_client_id);
 
         string resty_path(
             "/collections/C1443727145-LAADS/MOD08_D3.v6.1/granules/MOD08_D3.A2020308.061.2020309092644.hdf.nc");


### PR DESCRIPTION
- Rename the macro  `CMR_CLIENT_ID_CONTEXT_KEY` to `EDL_CLIENT_APPLICATION_ID_CONTEXT_KEY`
- Rename the macro `CMR_CLIENT_ID_KEY` to `EDL_CLIENT_APPLICATION_ID_REQUEST_HEADER_KEY` 

The values of these macros are EDL things, not CMR things, even though CMR might want/use/need them.

## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-####

<!-- Description of task -->
TODO

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [ ] Ticket exists and is linked in title
- [ ] Tests added/updated
- [ ] Dead code removed
- [ ] No TODOs added
