### PR TITLE
Control authentication scope for  the curl::http_get_and_write_resource() function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -237,7 +237,7 @@ jobs:
       - autoreconf --force --install --verbose
       - ./configure $CONFIGURE_OPTIONS --disable-dependency-tracking --prefix=$prefix --with-dependencies=$prefix/deps --enable-developer --enable-coverage
       - build-wrapper-linux-x86-64 --out-dir bw-output make -j16
-      - sonar-scanner -Dproject.settings=sonar-bes-framework.properties -Dsonar.login=$SONAR_LOGIN
+      - sonar-scanner -Dproject.settings=sonar-bes-framework.properties -Dsonar.token=$SONAR_TOKEN
       - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-bes | grep "QUALITY GATE PASS"
 
     - stage: scan
@@ -247,7 +247,7 @@ jobs:
         - autoreconf --force --install --verbose
         - ./configure $CONFIGURE_OPTIONS --disable-dependency-tracking --prefix=$prefix --with-dependencies=$prefix/deps --enable-developer  --enable-coverage
         - build-wrapper-linux-x86-64 --out-dir bw-output make -j16
-        - sonar-scanner -Dproject.settings=sonar-bes-modules-1.properties -Dsonar.login=$SONAR_MODULES_LOGIN
+        - sonar-scanner -Dproject.settings=sonar-bes-modules-1.properties -Dsonar.token=$SONAR_TOKEN
         - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-bes-modules | grep "QUALITY GATE PASS"
 
     - stage: scan
@@ -257,7 +257,7 @@ jobs:
         - autoreconf --force --install --verbose
         - ./configure $CONFIGURE_OPTIONS --disable-dependency-tracking --prefix=$prefix --with-dependencies=$prefix/deps --enable-developer  --enable-coverage
         - build-wrapper-linux-x86-64 --out-dir bw-output make -j16
-        - sonar-scanner -Dproject.settings=sonar-bes-hdf-handlers.properties -Dsonar.login=$SONAR_SUBMODULES_LOGIN
+        - sonar-scanner -Dproject.settings=sonar-bes-hdf-handlers.properties -Dsonar.token=$SONAR_TOKEN
         # We call the hdf4/5 handlers scan opendap-bes-submodules for historical reasons. jhrg 1/13/22
         - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-bes-submodules | grep "QUALITY GATE PASS"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,12 +62,6 @@ env:
     - TESTSUITEFLAGS=-j7
     # Change this when libdap version numbers change
     - LIBDAP_RPM_VERSION=3.21.1-0
-    # SONAR_LOGIN, made using "travis encrypt --org -r OPENDAP/bes SONAR_LOGIN=335df..."
-    #- secure: "TmoFcgeIyAEjFyrlqB6rhdUhDqPJfxVZmT5fewgVHj0xm767VZ6DU21mM6ZHgNGyk99TzX0Gx/dwSqbsUj18hSSAvEa7fJQSKJ5IBJvTeMKhXn1DPPG9VpuZ4ti5afRDiNr6EJKbVxwBTkz+3798S8LajPuXGupYupir8IJQCt8="
-    # SONAR_MODULES_LOGIN, using "travis encrypt --org -r OPENDAP/bes SONAR_MODULES_LOGIN=42ba..."
-    #- secure: "V3fMZgzMRRB0xFQMTvXf2fFPHIdwvg2y6bNFKqSGI5HP2sZEtc7XqSC4hjboR9RjnyZY/H1L/EuYQCS45gmJMsmtzo4g1Cn0oTfuPRJzDSi00jRlB1wUl5p1pU0Fdv2ffrGF4m6/SRfYFT0KkR/Tp8hdIoYx5/8R4MajysABMT4="
-    # SONAR_SUBMODULES_LOGIN, using "travis encrypt --org -r OPENDAP/bes SONAR_SUBMODULES_LOGIN=Q4aWrvS..."
-    #- secure: "Q4aWrvSlKUY7413FNI6tHlWJdhVtjJxrtSBApJRe5fGTn/HEmod5n3O4o0elFhuYh0O57aYsYclD7t0lriKMPvPdY/s8CFAaIPSANhNRkD44MWYWCPyivl83BBUlhWgkqgWFcCEaTqCpF/8A0HlOF1TsE1KKyQSns7snqgWTfSA="    # AWS_ACCESS_KEY_ID
     # AWS_ACCESS_KEY_ID
     # user == travis-bes
     - secure: "ZfL1IPX5zab1HWkJTlNPHroyUOp2lhAlcCH6UXDEL/yXpKoRCNkSo/CILM20DsjBckGys/7chom6uIoOilLu9Tp/6nPwkYlOe5DjgDt/qqKutclk9QBfrwU7WHRUOiEOESZl3Knd6B+GzuBZe8nrJzJhZWT54VFiOlEAGeIiFwo="

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,11 @@ env:
     # Change this when libdap version numbers change
     - LIBDAP_RPM_VERSION=3.21.1-0
     # SONAR_LOGIN, made using "travis encrypt --org -r OPENDAP/bes SONAR_LOGIN=335df..."
-    - secure: "TmoFcgeIyAEjFyrlqB6rhdUhDqPJfxVZmT5fewgVHj0xm767VZ6DU21mM6ZHgNGyk99TzX0Gx/dwSqbsUj18hSSAvEa7fJQSKJ5IBJvTeMKhXn1DPPG9VpuZ4ti5afRDiNr6EJKbVxwBTkz+3798S8LajPuXGupYupir8IJQCt8="
+    #- secure: "TmoFcgeIyAEjFyrlqB6rhdUhDqPJfxVZmT5fewgVHj0xm767VZ6DU21mM6ZHgNGyk99TzX0Gx/dwSqbsUj18hSSAvEa7fJQSKJ5IBJvTeMKhXn1DPPG9VpuZ4ti5afRDiNr6EJKbVxwBTkz+3798S8LajPuXGupYupir8IJQCt8="
     # SONAR_MODULES_LOGIN, using "travis encrypt --org -r OPENDAP/bes SONAR_MODULES_LOGIN=42ba..."
-    - secure: "V3fMZgzMRRB0xFQMTvXf2fFPHIdwvg2y6bNFKqSGI5HP2sZEtc7XqSC4hjboR9RjnyZY/H1L/EuYQCS45gmJMsmtzo4g1Cn0oTfuPRJzDSi00jRlB1wUl5p1pU0Fdv2ffrGF4m6/SRfYFT0KkR/Tp8hdIoYx5/8R4MajysABMT4="
+    #- secure: "V3fMZgzMRRB0xFQMTvXf2fFPHIdwvg2y6bNFKqSGI5HP2sZEtc7XqSC4hjboR9RjnyZY/H1L/EuYQCS45gmJMsmtzo4g1Cn0oTfuPRJzDSi00jRlB1wUl5p1pU0Fdv2ffrGF4m6/SRfYFT0KkR/Tp8hdIoYx5/8R4MajysABMT4="
     # SONAR_SUBMODULES_LOGIN, using "travis encrypt --org -r OPENDAP/bes SONAR_SUBMODULES_LOGIN=Q4aWrvS..."
-    - secure: "Q4aWrvSlKUY7413FNI6tHlWJdhVtjJxrtSBApJRe5fGTn/HEmod5n3O4o0elFhuYh0O57aYsYclD7t0lriKMPvPdY/s8CFAaIPSANhNRkD44MWYWCPyivl83BBUlhWgkqgWFcCEaTqCpF/8A0HlOF1TsE1KKyQSns7snqgWTfSA="    # AWS_ACCESS_KEY_ID
+    #- secure: "Q4aWrvSlKUY7413FNI6tHlWJdhVtjJxrtSBApJRe5fGTn/HEmod5n3O4o0elFhuYh0O57aYsYclD7t0lriKMPvPdY/s8CFAaIPSANhNRkD44MWYWCPyivl83BBUlhWgkqgWFcCEaTqCpF/8A0HlOF1TsE1KKyQSns7snqgWTfSA="    # AWS_ACCESS_KEY_ID
     # AWS_ACCESS_KEY_ID
     # user == travis-bes
     - secure: "ZfL1IPX5zab1HWkJTlNPHroyUOp2lhAlcCH6UXDEL/yXpKoRCNkSo/CILM20DsjBckGys/7chom6uIoOilLu9Tp/6nPwkYlOe5DjgDt/qqKutclk9QBfrwU7WHRUOiEOESZl3Knd6B+GzuBZe8nrJzJhZWT54VFiOlEAGeIiFwo="

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -1133,13 +1133,14 @@ static void super_easy_perform(CURL *c_handle, int fd) {
  * method returns that the body of the response can be retrieved by reading
  * from this file descriptor.
  * @param http_response_headers Value/result parameter for the HTTP Response Headers.
+ * @param authenticate When true attempt to add edl authentication and/or s3 signing headers to the request
  * @param http_request_headers A pointer to a vector of HTTP request headers. Default is
  * null. These headers will be appended to the list of default headers.
  * @exception Error Thrown if libcurl encounters a problem; the libcurl
  * error message is stuffed into the Error object.
  */
 void http_get_and_write_resource(const std::shared_ptr<http::url> &target_url, int fd,
-                                 vector <string> *http_response_headers) {
+                                 vector <string> *http_response_headers, const bool authenticate) {
 
     vector<char> error_buffer(CURL_ERROR_SIZE, (char) 0);
     CURLcode res;
@@ -1157,11 +1158,12 @@ void http_get_and_write_resource(const std::shared_ptr<http::url> &target_url, i
     }
 
     try {
-        // Add the EDL authorization headers if the Information is in the BES Context Manager
-        req_headers = add_edl_auth_headers(req_headers);
-        // Add AWS credentials if they're available.
-        req_headers = sign_url_for_s3_if_possible(target_url->str(), req_headers);
-
+        if (authenticate) {
+            // Add the EDL authorization headers if the Information is in the BES Context Manager
+            req_headers = add_edl_auth_headers(req_headers);
+            // Add AWS credentials if they're available.
+            req_headers = sign_url_for_s3_if_possible(target_url->str(), req_headers);
+        }
         // OK! Make the cURL handle
         ceh = init(target_url->str(), req_headers, http_response_headers);
 

--- a/http/CurlUtils.cc
+++ b/http/CurlUtils.cc
@@ -1133,7 +1133,8 @@ static void super_easy_perform(CURL *c_handle, int fd) {
  * method returns that the body of the response can be retrieved by reading
  * from this file descriptor.
  * @param http_response_headers Value/result parameter for the HTTP Response Headers.
- * @param authenticate When true attempt to add edl authentication and/or s3 signing headers to the request
+ * @param authenticate When this value is set to true an attempt will be made to add EDL
+ * authentication and/or S3 signing headers to the outgoing request headers
  * @param http_request_headers A pointer to a vector of HTTP request headers. Default is
  * null. These headers will be appended to the list of default headers.
  * @exception Error Thrown if libcurl encounters a problem; the libcurl

--- a/http/CurlUtils.h
+++ b/http/CurlUtils.h
@@ -50,7 +50,7 @@ namespace curl {
 ///@name Get data from a URL
 ///@{
 void http_get_and_write_resource(const std::shared_ptr<http::url> &target_url, int fd,
-                                 std::vector<std::string> *http_response_headers);
+                                 std::vector<std::string> *http_response_headers, bool authenticate = false);
 
 void http_get(const std::string &target_url, std::vector<char> &buf);
 

--- a/http/RemoteResource.cc
+++ b/http/RemoteResource.cc
@@ -194,8 +194,9 @@ void RemoteResource::set_filename_for_file_url() {
  * When this method returns the RemoteResource object is fully initialized
  * URL contents are available in the temporary file. For file:// URLs this
  * method is a no-op.
+ * @param authenticate
  */
-void RemoteResource::retrieve_resource() {
+void RemoteResource::retrieve_resource(const bool authenticate) {
     if (d_initialized) {
         return;
     }
@@ -208,7 +209,7 @@ void RemoteResource::retrieve_resource() {
     }
 
     // Get the contents of the URL and put them in the temp file
-    get_url(d_fd);
+    get_url(d_fd, authenticate);
 
     string new_name = d_filename + "_" + d_uid + "#" + d_basename;
     if (rename(d_filename.c_str(), new_name.c_str()) != 0) {
@@ -232,15 +233,16 @@ void RemoteResource::retrieve_resource() {
  * @note Private
  *
  * @param fd An open file descriptor the is associated with the target file.
+ * @param authenticate
  */
-void RemoteResource::get_url(int fd) {
+void RemoteResource::get_url(int fd, bool authenticate) {
 
     BESDEBUG(MODULE, prolog << "BEGIN" << endl);
     BES_STOPWATCH_START(MODULE, prolog + "Timing retrieval. Target url: " + d_url->str());
 
     try {
         // Throws an HttpError if there is a curl error.
-        curl::http_get_and_write_resource(d_url, fd, &d_response_headers);
+        curl::http_get_and_write_resource(d_url, fd, &d_response_headers, authenticate);
         BESDEBUG(MODULE, prolog << "Resource " << d_url->str() << " saved to temporary file " << d_filename << endl);
     }
     catch (http::HttpError &http_error) {

--- a/http/RemoteResource.cc
+++ b/http/RemoteResource.cc
@@ -194,7 +194,8 @@ void RemoteResource::set_filename_for_file_url() {
  * When this method returns the RemoteResource object is fully initialized
  * URL contents are available in the temporary file. For file:// URLs this
  * method is a no-op.
- * @param authenticate
+ * @param authenticate When this value is set to true an attempt will be made to add EDL
+ * authentication and/or S3 signing headers to the outgoing request headers
  */
 void RemoteResource::retrieve_resource(const bool authenticate) {
     if (d_initialized) {
@@ -233,9 +234,10 @@ void RemoteResource::retrieve_resource(const bool authenticate) {
  * @note Private
  *
  * @param fd An open file descriptor the is associated with the target file.
- * @param authenticate
+ * @param authenticate When this value is set to true an attempt will be made to add EDL
+ * authentication and/or S3 signing headers to the outgoing request headers
  */
-void RemoteResource::get_url(int fd, bool authenticate) {
+void RemoteResource::get_url(int fd, const bool authenticate) {
 
     BESDEBUG(MODULE, prolog << "BEGIN" << endl);
     BES_STOPWATCH_START(MODULE, prolog + "Timing retrieval. Target url: " + d_url->str());

--- a/http/RemoteResource.h
+++ b/http/RemoteResource.h
@@ -84,7 +84,7 @@ private:
     std::vector<std::string> d_response_headers; // Response headers
 
     /// write the url content to a file, set the type, and rewind the file descriptor
-    void get_url(int fd);
+    void get_url(int fd, bool authenticate = false);
 
     /// Protect the mkstemp() call
     static std::mutex d_mkstemp_mutex;
@@ -102,7 +102,7 @@ public:
 
     virtual ~RemoteResource();
 
-    void retrieve_resource();
+    void retrieve_resource(bool authenticate = false);
 
     /**
      * Returns the DAP type std::string of the RemoteHttpResource

--- a/modules/cmr_module/CmrApi.cc
+++ b/modules/cmr_module/CmrApi.cc
@@ -425,7 +425,7 @@ void CmrApi::get_years(const string &collection_name, vector<string> &years_resu
 
     BESDEBUG(MODULE, prolog << "CMR Query URL: "<< cmr_query_url.str() << endl);
 
-    const auto &cmr_doc = json.get_as_json(cmr_query_url.str());
+    const auto &cmr_doc = json.get_as_json(cmr_query_url.str(), true);
 
     const auto &year_group = get_year_group(cmr_doc);
     if(year_group[CMR_V2_HAS_CHILDREN_KEY].get<bool>()) {
@@ -459,7 +459,7 @@ CmrApi::get_months(const string &collection_name,
     cmr_query_url << http::url_encode("temporal_facet[0][year]") << "=" << r_year;
     BESDEBUG(MODULE, prolog << "CMR Query URL: "<< cmr_query_url.str() << endl);
 
-    const auto &cmr_doc = json.get_as_json(cmr_query_url.str());
+    const auto &cmr_doc = json.get_as_json(cmr_query_url.str(), true);
     BESDEBUG(MODULE, prolog << "Got JSON Document: "<< endl << cmr_doc.dump(2) << endl);
 
     const auto &year_group = get_year_group(cmr_doc);
@@ -532,7 +532,7 @@ void CmrApi::get_days(const string &collection_concept_id,
     BESDEBUG(MODULE, prolog << "CMR Query URL: " << cmr_query_url.str() << endl);
 
     JsonUtils json;
-    const auto &cmr_doc = json.get_as_json(cmr_query_url.str());
+    const auto &cmr_doc = json.get_as_json(cmr_query_url.str(), true);
 
     const auto &day_group = get_day_group(r_month, r_year, cmr_doc);
     const auto &days = get_children(day_group);
@@ -632,7 +632,7 @@ void CmrApi::granule_search(const std::string &collection_name,
 
     BESDEBUG(MODULE, prolog << "CMR Granule Search Request Url: " << cmr_query_url.str() << endl);
 
-    cmr_doc = json.get_as_json(cmr_query_url.str());
+    cmr_doc = json.get_as_json(cmr_query_url.str(), true);
     BESDEBUG(MODULE, prolog << "Got JSON Document: "<< endl << cmr_doc.dump(4) << endl);
 }
 
@@ -668,7 +668,7 @@ const {
 
     BESDEBUG(MODULE, prolog << "CMR Granule Search Request Url: " << cmr_query_url.str() << endl);
 
-    cmr_doc = json.get_as_json(cmr_query_url.str());
+    cmr_doc = json.get_as_json(cmr_query_url.str(), true);
     BESDEBUG(MODULE, prolog << "Got JSON Document: "<< endl << cmr_doc.dump(4) << endl);
 }
 
@@ -779,7 +779,7 @@ void CmrApi::get_providers(vector<unique_ptr<cmr::Provider> > &providers) const
     JsonUtils json;
     BES_STOPWATCH_START(MODULE, prolog + "Timing");
 
-    const auto &cmr_doc = json.get_as_json(d_cmr_providers_search_endpoint_url);
+    const auto &cmr_doc = json.get_as_json(d_cmr_providers_search_endpoint_url, true);
     unsigned int hits = cmr_doc["hits"];
     BESDEBUG(MODULE, prolog << "hits: " << hits << endl);
     if (hits == 0){
@@ -835,7 +835,7 @@ unsigned long int CmrApi::get_opendap_collections_count(const string &provider_i
     cmr_query_url << "?has_opendap_url=true&page_size=0";
     cmr_query_url << "&provider=" << provider_id;
     BESDEBUG(MODULE, prolog << "cmr_query_url: " << cmr_query_url.str() << endl);
-    const auto &cmr_doc = json.get_as_json(cmr_query_url.str());
+    const auto &cmr_doc = json.get_as_json(cmr_query_url.str(), true);
 
     const unsigned long int hits = json.qc_integer(CMR_HITS_KEY,cmr_doc);
     BESDEBUG(MODULE, prolog << CMR_HITS_KEY <<  ": " << hits << endl);
@@ -863,7 +863,7 @@ const {
     string cmr_query_url = cmr_query_url_base + "page_num=" + to_string(page_num);
     BESDEBUG(MODULE, prolog << "cmr_query_url: " << cmr_query_url << endl);
 
-    const auto &cmr_doc = json.get_as_json(cmr_query_url);
+    const auto &cmr_doc = json.get_as_json(cmr_query_url, true);
 
     unsigned int hits = cmr_doc["hits"];
     BESDEBUG(MODULE, prolog << "hits: " << hits << endl);

--- a/modules/cmr_module/CmrContainer.cc
+++ b/modules/cmr_module/CmrContainer.cc
@@ -145,7 +145,7 @@ string CmrContainer::access() {
         BESDEBUG( MODULE, prolog << "Building new RemoteResource." << endl );
         shared_ptr<http::url> target_url(new http::url(granule_url,true));
         d_remoteResource = new http::RemoteResource(target_url);
-        d_remoteResource->retrieve_resource();
+        d_remoteResource->retrieve_resource(true);
     }
     BESDEBUG( MODULE, prolog << "Retrieved RemoteResource." << endl );
 

--- a/modules/cmr_module/JsonUtils.cc
+++ b/modules/cmr_module/JsonUtils.cc
@@ -52,14 +52,15 @@ namespace cmr {
  * parser to populate the parameter 'd'
  *
  * @param url The URL of the JSON document to parse.
+ * @param authenticate
  * @return The json document parsed from the source URL response..
  *
  */
-json JsonUtils::get_as_json(const string &url) const
+json JsonUtils::get_as_json(const string &url, bool authenticate) const
 {
     BESDEBUG(MODULE,prolog << "Trying url: " << url << endl);
     http::RemoteResource remoteResource(make_shared<http::url>(url));
-    remoteResource.retrieve_resource();
+    remoteResource.retrieve_resource(authenticate);
     std::ifstream f(remoteResource.get_filename());
     json data = json::parse(f);
     return data;

--- a/modules/cmr_module/JsonUtils.h
+++ b/modules/cmr_module/JsonUtils.h
@@ -43,7 +43,7 @@ class JsonUtils {
 public:
     static std::string typeName(unsigned int t);
 
-    nlohmann::json get_as_json(const std::string &url) const;
+    nlohmann::json get_as_json(const std::string &url, bool authenticate = false) const;
 
 
     const nlohmann::json& qc_get_object(const std::string &key, const nlohmann::json& json_obj) const;

--- a/modules/s3_reader/S3Container.cc
+++ b/modules/s3_reader/S3Container.cc
@@ -175,7 +175,7 @@ string S3Container::access()
             d_dmrpp_rresource = std::make_shared<http::RemoteResource>(dmrpp_url);
 
             BES_STOPWATCH_START(MODULE, prolog + "Timing DMR++ retrieval. Target url: " + dmrpp_url->str());
-            d_dmrpp_rresource->retrieve_resource();
+            d_dmrpp_rresource->retrieve_resource(true);
 
             // Substitute the data_access_url and missing_data_access_url in the dmr++ file.
             map<string, string, std::less<>> content_filters;


### PR DESCRIPTION
## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-####

<!-- Description of task -->
This PR amends the function `curl::http_get_and_write_resource()` so that it can be asked to conditionally add authentication information to the outgoing request headers. Currently it always adds these headers, even when that's not useful.

 `curl::http_get_and_write_resource()` is used in exactly one place, `RemoteResource::get_url()`. Which, in turn, is only ever called by `RemoteResource::retrieve_resource`, which is widely used.

Here's is the how the change affects the dependent code:
- `CmrContainer.cc` - _Uses EDL to authenticate with CMR_
- `GatewayContainer.cc` - _No Auth_
- `HttpdCatalogContainer.cc` - _No Auth_
- `JsonUtils.cc` - _Exclusively used by the CmrApi to interrogate CMR. Uses EDL to authenticate with CMR_
- `S3Container.cc` - _Authenticates (I think with S3 signing headers)_

This PR addresses the authentication needs and stops authentication headers from being broadcast by Gateway and HttpdCatalog.

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [ ] Ticket exists and is linked in title
- [ ] Tests added/updated
- [ ] Dead code removed
- [ ] No TODOs added
