### PR TITLE
Fixing "get as dmrpp test "with new baseline and filters

### DIFF
--- a/cmdln/tests/dmrpp/dmrpp-return-as-test.bescmd.baseline
+++ b/cmdln/tests/dmrpp/dmrpp-return-as-test.bescmd.baseline
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="1.0" name="daymet_v4_daily_na_tmax_2010.nc" dmrpp:href="https://data.ornldaac.earthdata.nasa.gov/protected/daymet/Daymet_Daily_V4R1/data/daymet_v4_daily_na_tmax_2010.nc" dmrpp:s3="s3://ornl-cumulus-prod-protected/daymet/Daymet_Daily_V4R1/data/daymet_v4_daily_na_tmax_2010.nc" dmrpp:s3credentials="https://data.ornldaac.earthdata.nasa.gov/s3credentials" dmrpp:trust="true" dmrpp:version="3.21.1-367">
+<Dataset xmlns="http://xml.opendap.org/ns/DAP/4.0#" xmlns:dmrpp="http://xml.opendap.org/dap/dmrpp/1.0.0#" dapVersion="4.0" dmrVersion="removed" name="daymet_v4_daily_na_tmax_2010.nc" dmrpp:href="https://data.ornldaac.earthdata.nasa.gov/protected/daymet/Daymet_Daily_V4R1/data/daymet_v4_daily_na_tmax_2010.nc" dmrpp:s3="s3://ornl-cumulus-prod-protected/daymet/Daymet_Daily_V4R1/data/daymet_v4_daily_na_tmax_2010.nc" dmrpp:s3credentials="https://data.ornldaac.earthdata.nasa.gov/s3credentials" dmrpp:trust="true" dmrpp:version="removed_version">
     <Dimension name="y" size="8075"/>
     <Dimension name="x" size="7814"/>
     <Dimension name="time" size="365"/>
@@ -189,7 +189,7 @@
             <Value>standard</Value>
         </Attribute>
         <Attribute name="units" type="String">
-            <Value>days since 1950-01-01 00:00:00</Value>
+            <Value>days since removed date-time</Value>
         </Attribute>
         <Attribute name="bounds" type="String">
             <Value>time_bnds</Value>
@@ -27672,6 +27672,11 @@
             <dmrpp:chunk offset="11631259710" nBytes="10" chunkPositionInArray="[364]"/>
         </dmrpp:chunks>
     </Int16>
+    <Attribute name="DODS_EXTRA" type="Container">
+        <Attribute name="Unlimited_Dimension" type="String">
+            <Value>time</Value>
+        </Attribute>
+    </Attribute>
     <Attribute name="start_year" type="Int16">
         <Value>2010</Value>
     </Attribute>
@@ -27695,19 +27700,19 @@
     </Attribute>
     <Attribute name="build_dmrpp_metadata" type="Container">
         <Attribute name="created" type="String">
-            <Value>2025-09-15T19:37:22Z</Value>
+            <Value>removed date-time</Value>
         </Attribute>
         <Attribute name="build_dmrpp" type="String">
-            <Value>3.21.1-367</Value>
+            <Value>removed_version</Value>
         </Attribute>
         <Attribute name="bes" type="String">
-            <Value>3.21.1-367</Value>
+            <Value>removed_version</Value>
         </Attribute>
         <Attribute name="libdap" type="String">
-            <Value>libdap-3.21.1-99</Value>
+            <Value>removed_version</Value>
         </Attribute>
         <Attribute name="invocation" type="String">
-            <Value>build_dmrpp -f /tmp/tmp0tv4iczy/daymet_v4_daily_na_tmax_2010.nc -r daymet_v4_daily_na_tmax_2010.nc.dmr -u OPeNDAP_DMRpp_DATA_ACCESS_URL -M</Value>
+            <Value>build_dmrpp -f /tmp/removed-temp-dir-name/daymet_v4_daily_na_tmax_2010.nc -r daymet_v4_daily_na_tmax_2010.nc.dmr -u OPeNDAP_DMRpp_DATA_ACCESS_URL -M</Value>
         </Attribute>
     </Attribute>
 </Dataset>

--- a/cmdln/tests/testsuite.at
+++ b/cmdln/tests/testsuite.at
@@ -120,10 +120,16 @@ AT_KEYWORDS([dmrpp])
     AS_IF([test -n "$baselines" -a x$baselines = xyes],
           [
             AT_CHECK([bescmdln -i $input], [], [stdout])
+            REMOVE_DATE_TIME([stdout])
+            REMOVE_VERSIONS([stdout])
+            REMOVE_TEMP_DIR_NAME([stdout])
             AT_CHECK([mv stdout $baseline.tmp])
           ],
           [
             AT_CHECK([bescmdln -i $input], [], [stdout])
+            REMOVE_DATE_TIME([stdout])
+            REMOVE_VERSIONS([stdout])
+            REMOVE_TEMP_DIR_NAME([stdout])
             AS_IF(diff -b -B $baseline stdout,
                   [AT_CHECK([diff -b -B $baseline stdout])],
                   [

--- a/modules/common/handler_tests_macros.m4
+++ b/modules/common/handler_tests_macros.m4
@@ -748,6 +748,11 @@ m4_define([REMOVE_DATE_TIME], [dnl
     mv $1.sed $1
 ])
 
+m4_define([REMOVE_TEMP_DIR_NAME], [dnl
+    sed -i -e 's@\/tmp\/tmp.\{8\}\/@\/tmp\/removed-temp-dir-name\/@g' $1
+])
+
+
 dnl Given a filename, remove any version string of the form <Value>3.20.9</Value>
 dnl or <Value>libdap-3.20.8</Value> in that file and put "removed_version" in its
 dnl place. This hack keeps the baselines more or less true to form without the


### PR DESCRIPTION
## Description

Update baseline file used for the bes/cmdln/tests/dmrpp/dmrpp-return-as-test.bescmd  (`./testsuite 61`)which uses the NGAP service to retrieve a dmr++ file from the NGAP cloud.

That dmr++ file, associated with the restified path:
```
collections/C2532426483-ORNL_CLOUD/granules/Daymet_Daily_V4R1.daymet_v4_daily_na_tmax_2010.nc
```
has been rewritten using a newer version of _build_dmrpp_. 

The previous version:
```xml
    <Attribute name="build_dmrpp_metadata" type="Container">
        <Attribute name="created" type="String">
            <Value>2025-09-15T19:37:22Z</Value>
        </Attribute>
        <Attribute name="build_dmrpp" type="String">
            <Value>3.21.1-367</Value>
        </Attribute>
        <Attribute name="bes" type="String">
            <Value>3.21.1-367</Value>
        </Attribute>
        <Attribute name="libdap" type="String">
            <Value>libdap-3.21.1-99</Value>
        </Attribute>
        <Attribute name="invocation" type="String">
            <Value>build_dmrpp -f /tmp/tmp0tv4iczy/daymet_v4_daily_na_tmax_2010.nc -r daymet_v4_daily_na_tmax_2010.nc.dmr -u OPeNDAP_DMRpp_DATA_ACCESS_URL -M</Value>
        </Attribute>
    </Attribute>
```
The new version:
```xml
    <Attribute name="build_dmrpp_metadata" type="Container">
        <Attribute name="created" type="String">
            <Value>2026-05-22T21:10:41Z</Value>
        </Attribute>
        <Attribute name="build_dmrpp" type="String">
            <Value>3.21.1-896</Value>
        </Attribute>
        <Attribute name="bes" type="String">
            <Value>3.21.1-896</Value>
        </Attribute>
        <Attribute name="libdap" type="String">
            <Value>libdap-3.21.1-336</Value>
        </Attribute>
        <Attribute name="invocation" type="String">
            <Value>build_dmrpp -f /tmp/tmpznmtnt8g/daymet_v4_daily_na_tmax_2010.nc -r daymet_v4_daily_na_tmax_2010.nc.dmr -u OPeNDAP_DMRpp_DATA_ACCESS_URL -M</Value>
        </Attribute>
    </Attribute>
```
I updated the m4 macro used by this test to normalize (remove) the various date, version, and temp directory names

So now the baseline has the normalized values for date, version, and temp dir names:
```xml
    <Attribute name="build_dmrpp_metadata" type="Container">
        <Attribute name="created" type="String">
            <Value>removed date-time</Value>
        </Attribute>
        <Attribute name="build_dmrpp" type="String">
            <Value>removed_version</Value>
        </Attribute>
        <Attribute name="bes" type="String">
            <Value>removed_version</Value>
        </Attribute>
        <Attribute name="libdap" type="String">
            <Value>removed_version</Value>
        </Attribute>
        <Attribute name="invocation" type="String">
            <Value>build_dmrpp -f /tmp/removed-temp-dir-name/daymet_v4_daily_na_tmax_2010.nc -r daymet_v4_daily_na_tmax_2010.nc.dmr -u OPeNDAP_DMRpp_DATA_ACCESS_URL -M</Value>
        </Attribute>
    </Attribute>
```

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-####

<!-- Description of task -->
TODO

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [ ] Ticket exists and is linked in title
- [ ] Tests added/updated
- [ ] Dead code removed
- [ ] No TODOs added
