### PR TITLE
Removed sed operations on unused PEM files in bes/Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -208,10 +208,6 @@ RUN sed -i.dist \
     -e 's:=.*/lib/bes:=/usr/lib/bes:' \
     -e 's:=.*/share/bes:=/usr/share/bes:' \
     -e 's:=.*/share/hyrax:=/usr/share/hyrax:' \
-    -e 's:=/full/path/to/serverside/certificate/file.pem:=/etc/pki/bes/cacerts/file.pem:' \
-    -e 's:=/full/path/to/serverside/key/file.pem:=/etc/pki/bes/public/file.pem:' \
-    -e 's:=/full/path/to/clientside/certificate/file.pem:=/etc/pki/bes/cacerts/file.pem:' \
-    -e 's:=/full/path/to/clientside/key/file.pem:=/etc/pki/bes/public/file.pem:' \
     -e 's:=user_name:='"$BES_USER"':' \
     -e 's:=group_name:='"$BES_USER"':' \
     /etc/bes/bes.conf \


### PR DESCRIPTION
## Description

<!-- Update PR title to `HYRAX-2081: Remove unused PEM file references in Dockerfile`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2081

<!-- Description of task -->
Updated Dockerfile; removing sed operations on unused PEM files.

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [ ] Ticket exists and is linked in title
- [ ] Tests added/updated
- [ ] Dead code removed
- [ ] No TODOs added
