### PR TITLE
Hyrax 2193

### DIFF
--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -307,13 +307,15 @@ uint64_t crsaibv_process_variable(
         }
         else {
             // width_ll() returns the number of bytes needed to hold the data
-cerr<<"var name: "<<var->name() <<endl;
-cerr<<"vsize number of elements: "<<var->length_ll() <<endl;
-if(var->type()==dods_array_c && var->var()->type() == dods_str_c) {
-auto temp_array = dynamic_cast<Array *>(var);
-cerr<<"string size: "<<(temp_array->get_str()).size() <<endl;
-}
             uint64_t vsize = var->width_ll(true);
+            // If the data type is string, in C++, sizeof(string) is always 24. So the total size for a string array is
+            // always 24 x number of elements of this array, which may cause false positive for the server to issue
+            // an error that the maximum response size is exceeded. To avoid this case, we choose to use the minimal possible string size
+            // for a C string 2: 1 character and 1 terminator. This is also the case for a real NASA file.
+            if (var->type()==dods_array_c && var->var()->type() == dods_str_c)
+                vsize = 2*var->length_ll(); 
+            else
+                vsize = var->width_ll(true);
             response_size += vsize;
 
             BESDEBUG(MODULE_VERBOSE, prolog << "  " << get_dap_decl(var) << "(" << vsize << " bytes)" << endl);

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -307,6 +307,12 @@ uint64_t crsaibv_process_variable(
         }
         else {
             // width_ll() returns the number of bytes needed to hold the data
+cerr<<"var name: "<<var->name() <<endl;
+cerr<<"vsize number of elements: "<<var->length_ll() <<endl;
+if(var->type()==dods_array_c && var->var()->type() == dods_str_c) {
+auto temp_array = dynamic_cast<Array *>(var);
+cerr<<"string size: "<<(temp_array->get_str()).size() <<endl;
+}
             uint64_t vsize = var->width_ll(true);
             response_size += vsize;
 

--- a/dap/DapUtils.cc
+++ b/dap/DapUtils.cc
@@ -307,7 +307,7 @@ uint64_t crsaibv_process_variable(
         }
         else {
             // width_ll() returns the number of bytes needed to hold the data
-            uint64_t vsize = var->width_ll(true);
+            uint64_t vsize = 0;
             // If the data type is string, in C++, sizeof(string) is always 24. So the total size for a string array is
             // always 24 x number of elements of this array, which may cause false positive for the server to issue
             // an error that the maximum response size is exceeded. To avoid this case, we choose to use the minimal possible string size

--- a/dap/unit-tests/DapUtilsTest.cc
+++ b/dap/unit-tests/DapUtilsTest.cc
@@ -417,7 +417,7 @@ public:
 
         stringstream msg;
         uint64_t response_size = 0;
-        uint64_t expected_response_size = 1016;
+        uint64_t expected_response_size = 752;
         uint64_t max_var_size = 200;
         std::vector<std::string> too_big;
 
@@ -433,7 +433,7 @@ public:
             for(auto entry:too_big){
                 DBG(cerr << prolog << "  " << entry <<  endl);
             }
-            CPPUNIT_ASSERT( too_big.size() == 2 );
+            CPPUNIT_ASSERT( too_big.size() == 1 );
         }
         else {
             CPPUNIT_FAIL("ERROR: No variables were deemed too big!");


### PR DESCRIPTION
## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2193

<!-- Description of task -->
When calculating the request var size of a string array, the string size is always 24. This may cause false alarm and it happens to a real file in service. This pull request will relax the calculation by always assuming the string size is 2, which is the real file case. Since string data is easy to be compressed and decompressed, the service time for a bigger string is relatively small, so we think this should be OK even for bigger string size array.

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] Tests added/updated
- [x] Dead code removed
- [x] No TODOs added
