### PR TITLE
HYRAX-2222, for non-super chunk cases, release the buffer used by a c…

### DIFF
--- a/modules/dmrpp_module/Chunk.h
+++ b/modules/dmrpp_module/Chunk.h
@@ -372,7 +372,14 @@ public:
     {
         _duplicate(h4bs);
     }
-
+    virtual void release_chunk_buffer()
+    {
+        if (d_read_buffer_is_mine)
+            delete[] d_read_buffer;
+        d_read_buffer = nullptr;
+        d_read_buffer_is_mine = false;
+    }
+    
     virtual ~Chunk()
     {
         if(d_read_buffer_is_mine)

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -2220,10 +2220,13 @@ bool DmrppArray::read() {
     if ((var_type == dods_str_c || var_type == dods_url_c) && is_flsa()) 
         return read_string_array();
 
+    // Sonar cloud marks the following log vulnerable to injection attacks. So comment out for the time being.
+#if 0
     if (BESDebug::IsSet(MODULE)) {
         string msg = array_to_str(*this, "Reading Data From DmrppArray");
         BESDEBUG(MODULE, prolog << msg << endl);
     }
+#endif
     // Single chunk and 'contiguous' are the same for this code.
     if (get_chunk_count() == 1) {
         BESDEBUG(MODULE, prolog << "Reading data from a single contiguous chunk." << endl);

--- a/modules/dmrpp_module/DmrppArray.cc
+++ b/modules/dmrpp_module/DmrppArray.cc
@@ -2342,6 +2342,8 @@ bool DmrppArray::read() {
         }
     }
 
+    if (get_chunk_count() ==1 || get_using_linked_block() || is_multi_linked_blocks_chunk())
+        release_chunk_read_buffer();
     return true;
 }
 

--- a/modules/dmrpp_module/DmrppCommon.cc
+++ b/modules/dmrpp_module/DmrppCommon.cc
@@ -50,7 +50,6 @@
 
 #include "DmrppRequestHandler.h"
 #include "DmrppCommon.h"
-#include "Chunk.h"
 #include "byteswap_compat.h"
 #include "Base64.h"
 

--- a/modules/dmrpp_module/DmrppCommon.h
+++ b/modules/dmrpp_module/DmrppCommon.h
@@ -170,7 +170,7 @@ public:
 
     virtual ~DmrppCommon()= default;
 
-    virtual void release_chunk_read_buffer() {
+    virtual void release_chunk_read_buffer() const{
         for (auto &chunk: d_chunks)
             chunk->release_chunk_buffer();
     }

--- a/modules/dmrpp_module/DmrppCommon.h
+++ b/modules/dmrpp_module/DmrppCommon.h
@@ -35,6 +35,7 @@
 #include <pugixml.hpp>
 
 #include <libdap/Type.h>
+#include "Chunk.h"
 
 namespace libdap {
 class DMR;
@@ -168,6 +169,11 @@ public:
     DmrppCommon(const DmrppCommon &) = default;
 
     virtual ~DmrppCommon()= default;
+
+    virtual void release_chunk_read_buffer() {
+        for (auto &chunk: d_chunks)
+            chunk->release_chunk_buffer();
+    }
 
     /// @brief Return the names of all the filters in the order they were applied
     virtual std::string get_filters() const {


### PR DESCRIPTION
…hunk after reading data of a dmrpp array.

## Description

<!-- Update PR title to `HYRAX-####: short description`>
<!-- If no ticket exists for this issue yet, consider creating one -->
**Reference ticket:** HYRAX-2020

Release memory after reading the array variable data when the data storage is contiguous or only contains one chunk.
Otherwise, the memory of these variables will only be released right before the dmr object is destroyed. 

<!-- Description of task -->


## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] Ticket exists and is linked in title
- [x] No TODOs added
